### PR TITLE
WIP: Update opensearch `ES_HOSTS` to assume http scheme

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to the Mintel standard-application-stack Helm Chart.
 The release numbering uses [semantic versioning](http://semver.org).
 
+## v0.1.4-rc0
+
+* Update opensearch `ES_HOSTS` to assume http scheme is provided in non-local environments
+
 ## v0.1.3-rc2
 
 * Fixing logic for ingress annotations

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3-rc2
+version: 0.1.4-rc0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/templates/deployment-aws-es-proxy.yaml
+++ b/charts/standard-application-stack/templates/deployment-aws-es-proxy.yaml
@@ -37,7 +37,7 @@ spec:
             - -endpoint=http://$(OPENSEARCH_HOST):5601
             - -no-sign-reqs
             {{- else }}
-            - -endpoint=https://$(OPENSEARCH_HOST)
+            - -endpoint=$(OPENSEARCH_HOST)
             {{- end }}
           env:
             - name: KUBERNETES_POD_NAMESPACE


### PR DESCRIPTION
In non-local environments this is simpler to manage, since all the ES clients can deal with the scheme already provided.

Given that most clients support a list of endpoints, having to re-construct these variables in each scenario (schema+host) would get complicated.