### PR TITLE
Allow opensearch `ExternalSecret` resource be enabled/disabled

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents all notable changes to the Mintel standard-application-stack Helm Chart.
 The release numbering uses [semantic versioning](http://semver.org).
 
+## v0.1.4-rc0
+
+* Allow opensearch `ExternalSecret` resource be enabled/disabled
+
 ## v0.1.3-rc2
 
 * Fixing logic for ingress annotations

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3-rc2
+version: 0.1.4-rc0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/templates/secrets.yaml
+++ b/charts/standard-application-stack/templates/secrets.yaml
@@ -150,6 +150,7 @@ data:
 {{- end }}
 
 {{- if (and .Values.opensearch .Values.opensearch.enabled) }}
+{{- if (.Values.opensearch.secrets.enabled) }}
 {{- if (ne .Values.global.clusterEnv "local") }}
 ---
 apiVersion: {{ include "common.capabilities.externalsecret.apiVersion" . }}
@@ -188,5 +189,6 @@ data:
   ES_HOSTS: {{ printf "opensearch-cluster-master-headless" | b64enc }}
   OPENSEARCH_HOST: {{ printf "opensearch-cluster-master-headless" | b64enc }}
   OPENSEARCH_DASHBOARD_HOST: {{ printf "%s-opensearch-dashboards" (include "mintel_common.fullname" .) | b64enc }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -538,6 +538,10 @@ opensearch:
         memory: 64Mi
     # -- Port for aws-es-proxy to listen on
     port: 9200
+  # -- Configure opensearch secrets
+  secrets:
+    # -- Set to true to populate application environment with opensearch secrets
+    enabled: true
 
 localstack:
   enabled: false


### PR DESCRIPTION
These cannot be used in AWS since the opensearch-py lib. doesn't deal with AWS sigv4 (hence we'll go via a proxy)