### PR TITLE
Refactor Ingress; drop support for Kubernetes < v1.21

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v1.2.2] - 2022-01-12
+## [v2.0.0] - 2022-01-12
+
+### Changed
+- Drop support for Kubernetes < v1.21
+- Leave Ingress class blank by default instead of setting it to `haproxy`
 
 ### Added
 - Use Ingress PathType where possible, defaulting to `Prefix`
@@ -15,9 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Render Ingress service name and port correctly for `networking.k8s.io/v1`
 - Use the `ingressClass` field instead of the `kubernetes.io/ingress.class` annotation where possible
-
-### Changed
-- Leave Ingress class blank by default instead of setting it to `haproxy`
 
 ## [v1.2.1] - 2022-01-11
 

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.2.2] - 2022-01-12
+
+### Added
+- Use Ingress PathType where possible, defaulting to `Prefix`
+
+### Fixed
+- Render Ingress service name and port correctly for `networking.k8s.io/v1`
+- Use the `ingressClass` field instead of the `kubernetes.io/ingress.class` annotation where possible
+
+### Changed
+- Leave Ingress class blank by default instead of setting it to `haproxy`
+
 ## [v1.2.1] - 2022-01-11
 
 ## Added

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.1
+version: 1.2.2
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.2
+version: 2.0.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -2,7 +2,9 @@
 
 ![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
-A generic chart to support most common application requirements
+A generic chart to support most common application requirements.
+
+A version of Kubernetes >= v1.21 is required.
 
 ## Requirements
 

--- a/charts/standard-application-stack/templates/_capabilities.tpl
+++ b/charts/standard-application-stack/templates/_capabilities.tpl
@@ -15,152 +15,77 @@ Return the target Kubernetes version
 {{- end -}}
 {{- end -}}
 
-{{/*
-Return the appropriate apiVersion for policy.
-*/}}
+{{/* Return the appropriate apiVersion for policy. */}}
 {{- define "common.capabilities.policy.apiVersion" -}}
-{{- if semverCompare "<1.21-0" (include "common.capabilities.kubeVersion" .) -}}
-{{- print "policy/v1beta1" -}}
-{{- else -}}
 {{- print "policy/v1" -}}
 {{- end -}}
-{{- end -}}
 
-{{/*
-Return the appropriate apiVersion for cronjob.
-*/}}
+{{/* Return the appropriate apiVersion for cronjob. */}}
 {{- define "common.capabilities.cronjob.apiVersion" -}}
-{{- if semverCompare "<1.21-0" (include "common.capabilities.kubeVersion" .) -}}
-{{- print "batch/v1beta1" -}}
-{{- else -}}
 {{- print "batch/v1" -}}
 {{- end -}}
-{{- end -}}
 
-{{/*
-Return the appropriate apiVersion for deployment.
-*/}}
+{{/* Return the appropriate apiVersion for deployment. */}}
 {{- define "common.capabilities.deployment.apiVersion" -}}
-{{- if semverCompare "<1.14-0" (include "common.capabilities.kubeVersion" .) -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
 {{- print "apps/v1" -}}
 {{- end -}}
-{{- end -}}
 
-{{/*
-Return the appropriate apiVersion for statefulset.
-*/}}
+{{/* Return the appropriate apiVersion for statefulset. */}}
 {{- define "common.capabilities.statefulset.apiVersion" -}}
-{{- if semverCompare "<1.14-0" (include "common.capabilities.kubeVersion" .) -}}
-{{- print "apps/v1beta1" -}}
-{{- else -}}
 {{- print "apps/v1" -}}
 {{- end -}}
-{{- end -}}
 
-{{/* Get Ingress API Version */}}
+{{/* Return the appropriate apiVersion for ingress */}}
 {{- define "common.capabilities.ingress.apiVersion" -}}
-  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" (include "common.capabilities.kubeVersion" .)) -}}
-      {{- print "networking.k8s.io/v1" -}}
-  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
-    {{- print "networking.k8s.io/v1beta1" -}}
-  {{- else -}}
-    {{- print "extensions/v1beta1" -}}
-  {{- end -}}
+{{- print "networking.k8s.io/v1" -}}
 {{- end -}}
 
-{{/* Check Ingress stability */}}
-{{- define "common.capabilities.ingress.isStable" -}}
-  {{- eq (include "common.capabilities.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
-{{- end -}}
-
-{{/* Check Ingress supports pathType */}}
-{{/* pathType was added to networking.k8s.io/v1beta1 in Kubernetes 1.18 */}}
-{{- define "common.capabilities.ingress.supportsPathType" -}}
-  {{- or (eq (include "common.capabilities.ingress.isStable" .) "true") (and (eq (include "common.capabilities.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" (include "common.capabilities.kubeVersion" .))) -}}
-{{- end -}}
-
-{{/* Check Ingress supports ingressClassName */}}
-{{/* ingressClassName was added to networking.k8s.io/v1beta1 in Kubernetes 1.18 */}}
-{{- define "common.capabilities.ingress.supportsIngressClassName" -}}
-  {{- or (eq (include "common.capabilities.ingress.isStable" .) "true") (and (eq (include "common.capabilities.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" (include "common.capabilities.kubeVersion" .))) -}}
-{{- end -}}
-
-{{/*
-Return the appropriate apiVersion for RBAC resources.
-*/}}
+{{/* Return the appropriate apiVersion for RBAC resources. */}}
 {{- define "common.capabilities.rbac.apiVersion" -}}
-{{- if semverCompare "<1.17-0" (include "common.capabilities.kubeVersion" .) -}}
-{{- print "rbac.authorization.k8s.io/v1beta1" -}}
-{{- else -}}
 {{- print "rbac.authorization.k8s.io/v1" -}}
 {{- end -}}
-{{- end -}}
 
-{{/*
-Return the appropriate apiVersion for CRDs.
-*/}}
+{{/* Return the appropriate apiVersion for CRDs. */}}
 {{- define "common.capabilities.crd.apiVersion" -}}
-{{- if semverCompare "<1.19-0" (include "common.capabilities.kubeVersion" .) -}}
-{{- print "apiextensions.k8s.io/v1beta1" -}}
-{{- else -}}
 {{- print "apiextensions.k8s.io/v1" -}}
 {{- end -}}
-{{- end -}}
 
-{{/*
-Return the appropriate apiVersion for Pod Monitors.
-*/}}
+{{/* Return the appropriate apiVersion for Pod Monitors. */}}
 {{- define "common.capabilities.podmonitor.apiVersion" -}}
 {{- print "monitoring.coreos.com/v1" -}}
 {{- end -}}
 
-{{/*
-Return the appropriate apiVersion for Service Monitors.
-*/}}
+{{/* Return the appropriate apiVersion for Service Monitors. */}}
 {{- define "common.capabilities.servicemonitor.apiVersion" -}}
 {{- print "monitoring.coreos.com/v1" -}}
 {{- end -}}
 
-{{/*
-Return the appropriate apiVersion for External Secrets.
-*/}}
+{{/* Return the appropriate apiVersion for External Secrets. */}}
 {{- define "common.capabilities.externalsecret.apiVersion" -}}
 {{- print "kubernetes-client.io/v1" -}}
 {{- end -}}
 
-{{/*
-Return the appropriate apiVersion for Secrets.
-*/}}
+{{/* Return the appropriate apiVersion for Secrets. */}}
 {{- define "common.capabilities.secret.apiVersion" -}}
 {{- print "v1" -}}
 {{- end -}}
 
-{{/*
-Return the appropriate apiVersion for Configmaps
-*/}}
+{{/* Return the appropriate apiVersion for Configmaps */}}
 {{- define "common.capabilities.configmap.apiVersion" -}}
 {{- print "v1" -}}
 {{- end -}}
 
-{{/*
-Return the appropriate apiVersion for Service Accounts.
-*/}}
+{{/* Return the appropriate apiVersion for Service Accounts. */}}
 {{- define "common.capabilities.serviceaccount.apiVersion" -}}
 {{- print "v1" -}}
 {{- end -}}
 
-{{/*
-Return the appropriate apiVersion for Services.
-*/}}
+{{/* Return the appropriate apiVersion for Services. */}}
 {{- define "common.capabilities.service.apiVersion" -}}
 {{- print "v1" -}}
 {{- end -}}
 
-{{/*
-Return the appropriate apiVersion for NetworkPolicy.
-*/}}
+{{/* Return the appropriate apiVersion for NetworkPolicy. */}}
 {{- define "common.capabilities.networkpolicy.apiVersion" -}}
 {{- print "networking.k8s.io/v1" -}}
 {{- end -}}

--- a/charts/standard-application-stack/templates/ingress.yaml
+++ b/charts/standard-application-stack/templates/ingress.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.ingress.enabled }}
-{{- $apiIsStable := eq (include "common.capabilities.ingress.isStable" .) "true" -}}
-{{- $ingressSupportsPathType := eq (include "common.capabilities.ingress.supportsPathType" .) "true" -}}
 {{- if (eq .Values.global.clusterEnv "local") }}
 ---
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
@@ -12,31 +10,19 @@ metadata:
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
     ingress.kubernetes.io/ssl-redirect: "false"
-    {{- if not (include "common.capabilities.ingress.supportsIngressClassName" .) }}
-    kubernetes.io/ingress.class: traefik
-    {{- end }}
 spec:
-  {{- if (include "common.capabilities.ingress.supportsIngressClassName" .) }}
   ingressClassName: traefik
-  {{- end }}
   rules:
     - host: {{ .Values.ingress.defaultHost }}
       http:
         paths:
           - path: /
-            {{- if $ingressSupportsPathType }}
             pathType: Prefix
-            {{- end }}
             backend:
-              {{- if $apiIsStable }}
               service:
                 name: {{ include "mintel_common.fullname" . }}
                 port:
                   number: {{ .Values.port }}
-              {{- else }}
-              serviceName: {{ include "mintel_common.fullname" . }}
-              servicePort: {{ .Values.port }}
-              {{- end }}
 {{- else }}
 ---
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
@@ -47,9 +33,6 @@ metadata:
   labels: {{ include "mintel_common.labels" . | nindent 4 }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
-    {{- if and .Values.ingress.className (not (include "common.capabilities.ingress.supportsIngressClassName" .)) }}
-    kubernetes.io/ingress.class: {{ .Values.ingress.className }}
-    {{- end }}
     {{- with .Values.ingress.serverTimeoutSeconds }}
     ingress.kubernetes.io/timeout-server: {{ . }}s
     {{- end }}
@@ -64,45 +47,29 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
-  {{- if and .Values.ingress.className (include "common.capabilities.ingress.supportsIngressClassName" .) }}
-  ingressClassName: .Values.ingress.className
-  {{- end }}
+  ingressClassName: {{ .Values.ingress.className }}
   rules:
     - host: {{ .Values.ingress.defaultHost }}
       http:
         paths:
           - path: /
-            {{- if $ingressSupportsPathType }}
             pathType: Prefix
-            {{- end }}
             backend:
-              {{- if $apiIsStable }}
               service:
                 name: {{ include "mintel_common.fullname" . }}
                 port:
                   number: {{ .Values.port }}
-              {{- else }}
-              serviceName: {{ include "mintel_common.fullname" . }}
-              servicePort: {{ .Values.port }}
-              {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name }}
       http:
         paths:
           - path: {{ default "/" .path }}
-            {{- if $ingressSupportsPathType }}
             pathType: {{ default "Prefix" .pathType }}
-            {{- end }}
             backend:
-              {{- if $apiIsStable }}
               service:
                 name: {{ default (include "mintel_common.fullname" $) .serviceName }}
                 port:
                   number: {{ default $.Values.port .servicePort }}
-              {{- else }}
-              serviceName: {{ default (include "mintel_common.fullname" $) .serviceName }}
-              servicePort: {{ default $.Values.port .servicePort }}
-              {{- end }}
     {{- end }}
     {{- with .Values.ingress.specificRulesHostsYaml }}
     {{- toYaml . | nindent 4 }}

--- a/charts/standard-application-stack/templates/ingress.yaml
+++ b/charts/standard-application-stack/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled }}
+{{- $apiIsStable := eq (include "common.capabilities.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "common.capabilities.ingress.supportsPathType" .) "true" -}}
 {{- if (eq .Values.global.clusterEnv "local") }}
 ---
-apiVersion: networking.k8s.io/v1
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ include "mintel_common.fullname" . }}
@@ -10,19 +12,31 @@ metadata:
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
     ingress.kubernetes.io/ssl-redirect: "false"
+    {{- if not (include "common.capabilities.ingress.supportsIngressClassName" .) }}
     kubernetes.io/ingress.class: traefik
+    {{- end }}
 spec:
+  {{- if (include "common.capabilities.ingress.supportsIngressClassName" .) }}
+  ingressClassName: traefik
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.defaultHost }}
       http:
         paths:
-          - backend:
+          - path: /
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if $apiIsStable }}
               service:
                 name: {{ include "mintel_common.fullname" . }}
                 port:
                   number: {{ .Values.port }}
-            path: /
-            pathType: Prefix
+              {{- else }}
+              serviceName: {{ include "mintel_common.fullname" . }}
+              servicePort: {{ .Values.port }}
+              {{- end }}
 {{- else }}
 ---
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
@@ -33,10 +47,8 @@ metadata:
   labels: {{ include "mintel_common.labels" . | nindent 4 }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
-    {{- if .Values.className }}
-    kubernetes.io/ingress.class: {{ .Values.ClassName }}
-    {{- else }}
-    kubernetes.io/ingress.class: haproxy
+    {{- if and .Values.ingress.className (not (include "common.capabilities.ingress.supportsIngressClassName" .)) }}
+    kubernetes.io/ingress.class: {{ .Values.ingress.className }}
     {{- end }}
     {{- with .Values.ingress.serverTimeoutSeconds }}
     ingress.kubernetes.io/timeout-server: {{ . }}s
@@ -52,22 +64,45 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
+  {{- if and .Values.ingress.className (include "common.capabilities.ingress.supportsIngressClassName" .) }}
+  ingressClassName: .Values.ingress.className
+  {{- end }}
   rules:
     - host: {{ .Values.ingress.defaultHost }}
       http:
         paths:
-          - backend:
+          - path: /
+            {{- if $ingressSupportsPathType }}
+            pathType: Prefix
+            {{- end }}
+            backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ include "mintel_common.fullname" . }}
+                port:
+                  number: {{ .Values.port }}
+              {{- else }}
               serviceName: {{ include "mintel_common.fullname" . }}
               servicePort: {{ .Values.port }}
-            path: /
+              {{- end }}
     {{- range .Values.ingress.extraHosts }}
     - host: {{ .name }}
       http:
         paths:
-          - backend:
+          - path: {{ default "/" .path }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ default "Prefix" .pathType }}
+            {{- end }}
+            backend:
+              {{- if $apiIsStable }}
+              service:
+                name: {{ default (include "mintel_common.fullname" $) .serviceName }}
+                port:
+                  number: {{ default $.Values.port .servicePort }}
+              {{- else }}
               serviceName: {{ default (include "mintel_common.fullname" $) .serviceName }}
               servicePort: {{ default $.Values.port .servicePort }}
-            path: {{ default "/" .path }}
+              {{- end }}
     {{- end }}
     {{- with .Values.ingress.specificRulesHostsYaml }}
     {{- toYaml . | nindent 4 }}

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -270,6 +270,7 @@ ingress:
   #  extraHosts:
   #    - name: ""
   #      path: ""
+  #      pathType: "Prefix"
   #      serviceName: ""
   #      servicePort: ""
   # -- Optional, defines number of seconds to set server-timeout to


### PR DESCRIPTION
The Ingress currently doesn't render for `networking.k8s.io/v1` correctly. This should fix it.

- Drop support for Kubernetes < v1.21, per @nabadger 

- Render service and port correctly for Ingress v1.

- Makes use of the `ingressClass` field instead of the `kubernetes.io/ingress.class` annotation where possible.

- Stop setting the ingress class to haproxy by default. We only have one ingress class (haproxy) and the controller is set to handle ingresses with no class set via the `--watch-ingress-without-class` flag. (What we really need to do is create an IngressClass resource for haproxy with the `ingressclass.kubernetes.io/is-default-class` annotation set. That's the canonical way to have a default ingress class.)