### PR TITLE
Altering functionality around single replicas and service/ingress-les…

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.1.4] - 2022-01-19
+
+### Added
+- Added kubelock.enabled value (default: false)
+
+### Changed
+- Only set KUBELOCK env var's if kubelock enabled
+- Only create role/rolebinding if kubelock enabled
+- Set strategy type to Recreate for single replica deployments
+- Create pod-monitors instead of service-monitors if service not enabled
+
+### Fixed
+- Only populate `EXTRA_ALLOWED_HOSTS` if ingress enabled
+
+### Removed
+- Removed topologySpreadConstraints on single replica deployments
+
 ## [v2.1.3] - 2022-01-19
 
 ### Fixed

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.3
+version: 2.1.4
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 2.1.3](https://img.shields.io/badge/Version-2.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.1.4](https://img.shields.io/badge/Version-2.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -111,6 +111,8 @@ A generic chart to support most common application requirements
 | k8snotify.team | string | `""` | Defines team (flow) notifications are to be directed at |
 | kibana.elasticsearchHosts | string | `""` |  |
 | kibana.enabled | bool | `false` |  |
+| kubelock | object | `{"enable":false}` | Configure the use of kubelock ref: https://github.com/mintel/kubelock |
+| kubelock.enable | bool | `false` | Set to true to enable kubelock |
 | liveness | object | `{"enabled":true,"startup":{"failureThreshold":60,"periodSeconds":5}}` | Configure extra options for liveness probe ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes |
 | liveness.enabled | bool | `true` | Enable liveness probe |
 | liveness.startup.failureThreshold | int | `60` | Failure threshold for startupProbe |

--- a/charts/standard-application-stack/templates/deployment-celery.yaml
+++ b/charts/standard-application-stack/templates/deployment-celery.yaml
@@ -37,6 +37,7 @@ spec:
   replicas: {{ .Values.celery.replicas }}
   selector:
     matchLabels: {{ include "mintel_common.selectorLabels" $data | nindent 6 }}
+  {{- if (gt ( .Values.replicas | int) 1) }}
   strategy:
     {{- with .Values.strategy }}
     {{- if (and (eq .type "RollingUpdate") (or .maxSurge .maxUnavailable)) }}
@@ -52,6 +53,10 @@ spec:
     {{- else }}
     type: RollingUpdate
     {{- end }}
+  {{- else }}
+  strategy:
+    type: Recreate
+  {{- end }}
   template:
     metadata:
       labels: {{ include "mintel_common.labels" $data | nindent 8 }}

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -53,6 +53,7 @@ spec:
     type: RollingUpdate
   serviceName: {{ include "mintel_common.fullname" . }}
   {{- else }}
+  {{- if (gt (.Values.replicas | int) 1) }}
   strategy:
     {{- with .Values.strategy }}
     {{- if (and (eq .type "RollingUpdate") (or .maxSurge .maxUnavailable)) }}
@@ -68,6 +69,10 @@ spec:
     {{- else }}
     type: RollingUpdate
     {{- end }}
+  {{- else }}
+  strategy:
+    type: Recreate
+  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/charts/standard-application-stack/templates/pod-monitor-celery.yaml
+++ b/charts/standard-application-stack/templates/pod-monitor-celery.yaml
@@ -5,7 +5,7 @@
 {{- if (and .Values.filebeatSidecar.metrics .Values.filebeatSidecar.metrics.enabled) }}
 {{- $filebeatData := dict "Release" .Release "Chart" .Chart "Values" .Values "component" "celery-filebeat" }}
 ---
-apiVersion: {{ include "common.capabilities.servicemonitor.apiVersion" . }}
+apiVersion: {{ include "common.capabilities.podmonitor.apiVersion" . }}
 kind: PodMonitor
 metadata:
   name: {{ include "mintel_common.fullname" $filebeatData }}

--- a/charts/standard-application-stack/templates/pod-monitor.yaml
+++ b/charts/standard-application-stack/templates/pod-monitor.yaml
@@ -1,9 +1,9 @@
-{{- if (and .Values.service .Values.service.enabled) }}
+{{- if (eq .Values.service.enabled false) }}
 {{- if (ne .Values.global.clusterEnv "local") }}
 {{- if (and .Values.metrics .Values.metrics.enabled) }}
 ---
-apiVersion: {{ include "common.capabilities.servicemonitor.apiVersion" . }}
-kind: ServiceMonitor
+apiVersion: {{ include "common.capabilities.podmonitor.apiVersion" . }}
+kind: PodMonitor
 metadata:
   name: {{ include "mintel_common.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -13,7 +13,7 @@ metadata:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  endpoints:
+  podMetricsEndpoints:
     - interval: {{ default "30s" .Values.metrics.interval }}
       path: {{ default "/metrics" .Values.metrics.path }}
       port: main-http
@@ -39,14 +39,13 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 6 }}
-  targetLabels: {{ include "mintel_common.targetLabelNames" . | nindent 4 }}
   podTargetLabels: {{ include "mintel_common.podTargetLabelNames" . | nindent 4 }}
 
 {{- range .Values.metrics.additionalMonitors }}
 {{- $monitorData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "component" .name }}
 ---
-apiVersion: {{ include "common.capabilities.servicemonitor.apiVersion" $ }}
-kind: ServiceMonitor
+apiVersion: {{ include "common.capabilities.podmonitor.apiVersion" $ }}
+kind: PodMonitor
 metadata:
   name: {{ include "mintel_common.fullname" $monitorData }}
   namespace: {{ $.Release.Namespace }}
@@ -56,7 +55,7 @@ metadata:
     {{ include "mintel_common.commonAnnotations" $monitorData | nindent 4 }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  endpoints:
+  podMetricsEndpoints:
     - interval: {{ default "30s" $.Values.metrics.interval .interval }}
       path: {{ default "/metrics" $.Values.metrics.path .path }}
       port: main-http
@@ -82,7 +81,6 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels: {{ include "mintel_common.selectorLabels" $ | nindent 6 }}
-  targetLabels: {{ include "mintel_common.targetLabelNames" $ | nindent 4 }}
   podTargetLabels: {{ include "mintel_common.podTargetLabelNames" $ | nindent 4 }}
 {{- end }}
 {{- end }}
@@ -90,8 +88,8 @@ spec:
 {{- if (and .Values.oauthProxy .Values.oauthProxy.enabled) }}
 {{- $monitorData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "component" "oauth-metrics" }}
 ---
-apiVersion: {{ include "common.capabilities.servicemonitor.apiVersion" . }}
-kind: ServiceMonitor
+apiVersion: {{ include "common.capabilities.podmonitor.apiVersion" . }}
+kind: PodMonitor
 metadata:
   name: {{ include "mintel_common.fullname" $monitorData }}
   namespace: {{ .Release.Namespace }}
@@ -101,7 +99,7 @@ metadata:
     {{ include "mintel_common.commonAnnotations" $monitorData | nindent 4 }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  endpoints:
+  podMetricsEndpoints:
     - interval: {{ default "30s" .Values.metrics.interval }}
       path: /metrics
       port: auth-proxy-metrics
@@ -117,7 +115,6 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 6 }}
-  targetLabels: {{ include "mintel_common.targetLabelNames" . | nindent 4 }}
   podTargetLabels: {{ include "mintel_common.podTargetLabelNames" . | nindent 4 }}
 {{- end }}
 
@@ -125,8 +122,8 @@ spec:
 {{- if (and .Values.filebeatSidecar.metrics .Values.filebeatSidecar.metrics.enabled) }}
 {{- $filebeatData := dict "Release" .Release "Chart" .Chart "Values" .Values "component" "filebeat" }}
 ---
-apiVersion: {{ include "common.capabilities.servicemonitor.apiVersion" . }}
-kind: ServiceMonitor
+apiVersion: {{ include "common.capabilities.podmonitor.apiVersion" . }}
+kind: PodMonitor
 metadata:
   name: {{ include "mintel_common.fullname" $filebeatData }}
   namespace: {{ .Release.Namespace }}
@@ -135,7 +132,7 @@ metadata:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  endpoints:
+  podMetricsEndpoints:
     - interval: {{ default "30s" .Values.filebeatSidecar.metrics.interval }}
       path: {{ default "/metrics" .Values.filebeatSidecar.metrics.path }}
       port: beat-exporter-metrics
@@ -151,7 +148,6 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 6 }}
-  targetLabels: {{ include "mintel_common.targetLabelNames" . | nindent 4 }}
   podTargetLabels: {{ include "mintel_common.podTargetLabelNames" . | nindent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/standard-application-stack/templates/role-bindings.yaml
+++ b/charts/standard-application-stack/templates/role-bindings.yaml
@@ -1,4 +1,6 @@
 {{- if (and .Values.serviceAccount .Values.serviceAccount.create) }}
+
+{{- if (and .Values.kubelock .Values.kubelock.enabled) }}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: RoleBinding
 metadata:
@@ -14,4 +16,6 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "mintel_common.fullname" . }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
+
 {{- end }}

--- a/charts/standard-application-stack/templates/roles.yaml
+++ b/charts/standard-application-stack/templates/roles.yaml
@@ -1,4 +1,6 @@
 {{- if (and .Values.serviceAccount .Values.serviceAccount.create) }}
+
+{{- if (and .Values.kubelock .Values.kubelock.enabled) }}
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
 metadata:
@@ -25,4 +27,6 @@ rules:
   - list
   - create
   - update
+{{- end }}
+
 {{- end }}

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -430,6 +430,12 @@ oauthProxy:
   #    - name: OAUTH_PROXY_COOKIE_SECRET
   #      value: test_value
 
+# -- Configure the use of kubelock
+# ref: https://github.com/mintel/kubelock
+kubelock:
+  # -- Set to true to enable kubelock
+  enable: false
+
 # -- Configure the use of k8snotify
 # ref: https://github.com/mintel/k8s-notify
 k8snotify:


### PR DESCRIPTION
## [v2.1.4] - 2022-01-19

### Added
- Added kubelock.enabled value (default: false)

### Changed
- Only set KUBELOCK env var's if kubelock enabled
- Only create role/rolebinding if kubelock enabled
- Set strategy type to Recreate for single replica deployments
- Create pod-monitors instead of service-monitors if service not enabled

### Fixed
- Only populate `EXTRA_ALLOWED_HOSTS` if ingress enabled

### Removed
- Removed topologySpreadConstraints on single replica deployments
