### PR TITLE
Fix PodMonitor port for main deployment

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v2.2.1] - 2022-01-20
+
+### Fixed
+- `PodMonitor` port does not have a `main-` prefix
+
 ## [v2.2.0] - 2022-01-20
 
 ### Changed

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 2.1.4](https://img.shields.io/badge/Version-2.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/pod-monitor.yaml
+++ b/charts/standard-application-stack/templates/pod-monitor.yaml
@@ -16,7 +16,7 @@ spec:
   podMetricsEndpoints:
     - interval: {{ default "30s" .Values.metrics.interval }}
       path: {{ default "/metrics" .Values.metrics.path }}
-      port: main-http
+      port: {{ default "http" .Values.metrics.port }}
       {{- if .Values.metrics.basicAuth }}
       {{- if .Values.metrics.basicAuth.enabled }}
       username:
@@ -58,7 +58,7 @@ spec:
   podMetricsEndpoints:
     - interval: {{ default "30s" $.Values.metrics.interval .interval }}
       path: {{ default "/metrics" $.Values.metrics.path .path }}
-      port: main-http
+      port: {{ default "http" $.Values.metrics.port .port }}
       {{- if .basicAuth }}
       {{- if .basicAuth.enabled }}
       username:


### PR DESCRIPTION
The `main-` prefix is added when you have a `Service` , was as `PodMonitor` should use the named port on the pod only.

Also made it an option to override via `metrics` settings.