### PR TITLE
BUGFIX: Kubelock variable

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.2.2] - 2022-02-01
+
+### Fixed
+- Corrected enable to enabled under kubelock in values.yaml
+
 ## [v3.2.1] - 2022-01-31
 
 ## Added

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.1
+version: 3.2.2
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -462,7 +462,7 @@ oauthProxy:
 # ref: https://github.com/mintel/kubelock
 kubelock:
   # -- Set to true to enable kubelock
-  enable: false
+  enabled: false
 
 # -- Configure the use of k8snotify
 # ref: https://github.com/mintel/k8s-notify


### PR DESCRIPTION
- fix: Corrected enable to enabled under kubelock in values.yaml
- docs: Update version to 3.2.2 in CHANGELOG.md
- docs: Update Chart.yaml with new chart version 3.2.2