### PR TITLE
CPT-85: Add OPA Security context check

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.3.0] - 2022-02-01
+
+## Added
+- Added annotation to skip opa check for security context to deployment-aws-es-proxy.yaml,
+  deployment-celery-exporter.yaml, deployment-mysqldexporter.yaml and deployment-postgresqlexporter.yaml
+
+
 ## [v3.2.2] - 2022-02-01
 
 ### Fixed

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.2
+version: 3.3.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/templates/deployment-aws-es-proxy.yaml
+++ b/charts/standard-application-stack/templates/deployment-aws-es-proxy.yaml
@@ -11,6 +11,7 @@ metadata:
     secret.reloader.stakater.com/reload: {{ default (include "mintel_common.defaultOpensearchSecretName" .) .Values.opensearch.secretNameOverride }}
     app.mintel.com/opa-allow-single-replica: "true"
     app.mintel.com/opa-skip-readiness-probe-check.main: "true"
+    app.mintel.com/opa-skip-security-context-check: "true"
   labels: {{ include "mintel_common.labels" $data | nindent 4 }}
 spec:
   replicas: {{ default 2 .Values.opensearch.awsEsProxy.replicas }}

--- a/charts/standard-application-stack/templates/deployment-celery-exporter.yaml
+++ b/charts/standard-application-stack/templates/deployment-celery-exporter.yaml
@@ -11,6 +11,7 @@ metadata:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
     app.mintel.com/opa-skip-readiness-probe-check.main: "true"
     app.mintel.com/opa-allow-single-replica: "true"
+    app.mintel.com/opa-skip-security-context-check: "true"
   labels: {{ include "mintel_common.labels" $data | nindent 4 }}
 spec:
   replicas: 1

--- a/charts/standard-application-stack/templates/deployment-mysqldexporter.yaml
+++ b/charts/standard-application-stack/templates/deployment-mysqldexporter.yaml
@@ -19,6 +19,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        app.mintel.com/opa-skip-security-context-check: "true"
       labels: {{ include "mintel_common.labels" $data | nindent 8 }}
     spec:
       {{- include "mintel_common.imagePullSecrets" . | nindent 6 }}

--- a/charts/standard-application-stack/templates/deployment-postgresqlexporter.yaml
+++ b/charts/standard-application-stack/templates/deployment-postgresqlexporter.yaml
@@ -18,6 +18,8 @@ spec:
   strategy:
     type: RollingUpdate
   template:
+    annotations:
+      app.mintel.com/opa-skip-security-context-check: "true"
     metadata:
       labels: {{ include "mintel_common.labels" $data | nindent 8 }}
     spec:


### PR DESCRIPTION
- feat: Added annotation to skip (forthcoming) opa check for security context to deployment-aws-es-proxy.yaml,deployment-celery-exporter.yaml,deployment-mysqldexporter.yaml and deployment-postgresqlexporter.yaml
- docs: Update version to 3.3.0 in CHANGELOG.md
- docs: Update Chart.yaml with new chart version 3.3.0