### PR TITLE
Feat/support only cronjobs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 helm 3.7.0
-helm-docs 1.5.0
+helm-docs 1.7.0

--- a/charts/standard-application-stack/.tool-versions
+++ b/charts/standard-application-stack/.tool-versions
@@ -1,2 +1,0 @@
-helm 3.6.2
-helm-docs 1.7.0

--- a/charts/standard-application-stack/.tool-versions
+++ b/charts/standard-application-stack/.tool-versions
@@ -1,0 +1,2 @@
+helm 3.6.2
+helm-docs 1.7.0

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - Added `cronjobsOnly` flag to only show cronjobs and relevant resources (i.e. skip deployment / service etc)
+- Added `helm-docs` and `helm` to asdf `.tool-versions`
 
 ## [v3.3.0] - 2022-02-01
 

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.4.0] - 2022-02-03
+
+## Added
+- Added `cronjobsOnly` flag to only show cronjobs and relevant resources (i.e. skip deployment / service etc)
+
 ## [v3.3.0] - 2022-02-01
 
 ## Added
 - Added annotation to skip opa check for security context to deployment-aws-es-proxy.yaml,
   deployment-celery-exporter.yaml, deployment-mysqldexporter.yaml and deployment-postgresqlexporter.yaml
-
 
 ## [v3.2.2] - 2022-02-01
 

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - Added `cronjobsOnly` flag to only show cronjobs and relevant resources (i.e. skip deployment / service etc)
-- Added `helm-docs` and `helm` to asdf `.tool-versions`
 
 ## [v3.3.0] - 2022-02-01
 

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.3.0
+version: 3.4.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.2.1](https://img.shields.io/badge/Version-3.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -58,6 +58,8 @@ A generic chart to support most common application requirements
 | cronjobs.defaults.restartPolicy | string | `"Never"` | Configure CronJob pod restart Policy ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy |
 | cronjobs.defaults.suspend | bool | `false` | Tells controller to suspend future executions ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec |
 | cronjobs.jobs | list | `[]` | List of Cronjob configurations to be defined |
+| cronjobsOnly | bool | `false` | Only show cronjobs and relevent resources (i.e. if set to `true`, hide the main deployment resource) |
+| deploymentEnabled | bool | `true` | Enable the main deploment workload |
 | elasticsearch.enabled | bool | `false` |  |
 | env | list | `[]` | Optional environment variables injected into the container |
 | envFrom | list | `[]` | Optional environment variables injected into the container using envFrom (secrets/configmaps) |
@@ -113,8 +115,8 @@ A generic chart to support most common application requirements
 | k8snotify.team | string | `""` | Defines team (flow) notifications are to be directed at |
 | kibana.elasticsearchHosts | string | `""` |  |
 | kibana.enabled | bool | `false` |  |
-| kubelock | object | `{"enable":false}` | Configure the use of kubelock ref: https://github.com/mintel/kubelock |
-| kubelock.enable | bool | `false` | Set to true to enable kubelock |
+| kubelock | object | `{"enabled":false}` | Configure the use of kubelock ref: https://github.com/mintel/kubelock |
+| kubelock.enabled | bool | `false` | Set to true to enable kubelock |
 | liveness | object | `{"enabled":true,"startup":{"failureThreshold":60,"periodSeconds":5}}` | Configure extra options for liveness probe ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes |
 | liveness.enabled | bool | `true` | Enable liveness probe |
 | liveness.startup.failureThreshold | int | `60` | Failure threshold for startupProbe |

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.3.0](https://img.shields.io/badge/Version-3.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.4.0](https://img.shields.io/badge/Version-3.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -29,7 +29,7 @@ A generic chart to support most common application requirements
 | affinity.podAntiAffinity.zone | string | `"hard"` | Toggle whether zone affinity should be required (hard) or preferred (soft) |
 | args | list | `[]` | Optional arguments to the container |
 | celery | object | `{"args":["celery"],"enabled":false,"liveness":{"enabled":false},"metrics":{"enabled":true},"podDisruptionBudget":{"enabled":true,"minAvailable":"50%"},"readiness":{"enabled":false},"replicas":2,"resources":{"limits":{},"requests":{}}}` | Configure celery deployment Defaults to same image as main deployment but with the "celery" argument |
-| celery.args | list | `["celery"]` | Full image name override (registry/repository:tag)  image: "" -- Optional command to the celery container  command: [] -- Arguments to the celery container |
+| celery.args | list | `["celery"]` | Arguments to the celery container |
 | celery.enabled | bool | `false` | Set to true to enable a celery deployment |
 | celery.liveness | object | `{"enabled":false}` | Configure extra options for liveness probe ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes |
 | celery.liveness.enabled | bool | `false` | Enable liveness probe |
@@ -39,17 +39,19 @@ A generic chart to support most common application requirements
 | celery.readiness | object | `{"enabled":false}` | Configure extra options for readiness probe ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes |
 | celery.readiness.enabled | bool | `false` | Enable readiness probe |
 | celery.replicas | int | `2` | Desired number of replicas for celery deployment |
-| celery.resources | object | `{"limits":{},"requests":{}}` | Optional environment variables injected into the container  env: [] -- Container resource requests and limits ref: http://kubernetes.io/docs/user-guide/compute-resources |
+| celery.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits ref: http://kubernetes.io/docs/user-guide/compute-resources |
 | celery.resources.limits | object | `{}` | The resource limits for the container |
+| celery.resources.requests | object | `{}` | The requested resources for the container |
 | celeryBeat | object | `{"args":["celerybeat"],"enabled":false,"liveness":{"enabled":false},"readiness":{"enabled":false},"resources":{"limits":{},"requests":{}}}` | Configure celerybeat deployment Defaults to same image as main deployment but with the "celerybeat" argument |
-| celeryBeat.args | list | `["celerybeat"]` | Full image name override (registry/repository:tag)  image: "" -- Optional command to the celery container  command: [] |
+| celeryBeat.args | list | `["celerybeat"]` | Optional command to the celery container  command: [] |
 | celeryBeat.enabled | bool | `false` | Set to true to enable a celerybeat deployment |
 | celeryBeat.liveness | object | `{"enabled":false}` | Configure extra options for liveness probe ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes |
 | celeryBeat.liveness.enabled | bool | `false` | Enable liveness probe |
 | celeryBeat.readiness | object | `{"enabled":false}` | Configure extra options for readiness probe ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes |
 | celeryBeat.readiness.enabled | bool | `false` | Enable readiness probe |
-| celeryBeat.resources | object | `{"limits":{},"requests":{}}` | Optional environment variables injected into the container  env: [] -- Container resource requests and limits ref: http://kubernetes.io/docs/user-guide/compute-resources |
+| celeryBeat.resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits ref: http://kubernetes.io/docs/user-guide/compute-resources |
 | celeryBeat.resources.limits | object | `{}` | The resource limits for the container |
+| celeryBeat.resources.requests | object | `{}` | The requested resources for the container |
 | command | list | `["/app/docker-entrypoint.sh"]` | Optional command to the container |
 | configmaps | list | `[]` | A list of configuration maps for this application |
 | cronjobs | object | `{"defaults":{"concurrencyPolicy":"Forbid","restartPolicy":"Never","suspend":false},"jobs":[]}` | Define and Configure CronJob's Defaults to same image as main deployment but with defined arguments |
@@ -97,6 +99,7 @@ A generic chart to support most common application requirements
 | image.tag | string | `"auto-replaced"` | Container image tag |
 | imagePullSecrets | list | `[]` | Optional array of imagePullSecrets ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | ingress | object | `{"allowLivenessUrl":false,"allowReadinessUrl":false,"blackbox":{"enabled":true,"probePath":"/external-health-check"},"className":"haproxy","enabled":false,"extraAnnotations":{},"extraHosts":[],"specificRulesHostsYaml":{},"specificTlsHostsYaml":{},"tls":true}` | Configure the ingress resource that allows you to access the application from public-internet ref: http://kubernetes.io/docs/user-guide/ingress/ |
+| ingress.allowLivenessUrl | bool | `false` | Set to true to allow the liveness URL through the ingress |
 | ingress.allowReadinessUrl | bool | `false` | Set to true to allow the readiness URL through the ingress |
 | ingress.blackbox | object | `{"enabled":true,"probePath":"/external-health-check"}` | Configures annotations defining blackbox endpoints |
 | ingress.blackbox.enabled | bool | `true` | Set to true to tell blackboxes to hit endpoint |
@@ -119,6 +122,7 @@ A generic chart to support most common application requirements
 | kubelock.enabled | bool | `false` | Set to true to enable kubelock |
 | liveness | object | `{"enabled":true,"startup":{"failureThreshold":60,"periodSeconds":5}}` | Configure extra options for liveness probe ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes |
 | liveness.enabled | bool | `true` | Enable liveness probe |
+| liveness.startup | object | `{"failureThreshold":60,"periodSeconds":5}` | Configure startup probe ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes |
 | liveness.startup.failureThreshold | int | `60` | Failure threshold for startupProbe |
 | liveness.startup.periodSeconds | int | `5` | Perios seconds for startupProbe |
 | localstack.enableStartupScripts | bool | `true` |  |
@@ -145,7 +149,7 @@ A generic chart to support most common application requirements
 | mariadb.metrics.resources.requests.cpu | string | `"100m"` |  |
 | mariadb.metrics.resources.requests.memory | string | `"64Mi"` |  |
 | metrics | object | `{"additionalMonitors":[],"basicAuth":{"enabled":false,"passwordKey":"","secretName":"","usernameKey":""},"enabled":true}` | Prometheus Exporter / Metrics |
-| metrics.basicAuth | object | `{"enabled":false,"passwordKey":"","secretName":"","usernameKey":""}` | Interval at which metrics should be scraped ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint  interval: 30s -- URL path to the metrics endpoint  path: /metrics -- Name of the port to use for metrics endpoint  port: http -- Timeout after which the scrape is ended ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint  timeout: 10s -- Scheme (HTTP ot HTTPS)  scheme: HTTP |
+| metrics.basicAuth | object | `{"enabled":false,"passwordKey":"","secretName":"","usernameKey":""}` | Scheme (HTTP ot HTTPS)  scheme: HTTP |
 | metrics.enabled | bool | `true` | Enable Prometheus to access aplpication metrics endpoints |
 | minReadySeconds | int | `10` | Minimum number of seconds before deployments are ready |
 | nameOverride | string | `""` | String to fully override mintel_common.fullname template |
@@ -157,7 +161,7 @@ A generic chart to support most common application requirements
 | oauthProxy.image | string | `"quay.io/oauth2-proxy/oauth2-proxy:v7.1.3"` | Full image name override |
 | oauthProxy.ingressHost | string | `""` | Optional: hostname for proxy redirect url (defaults to service defaultHost) |
 | oauthProxy.issuerUrl | string | `"https://oauth.mintel.com"` | Optional: URL of the OIDC issuer |
-| oauthProxy.localSecretValues | list | `[]` | Container resource requests and limits ref: http://kubernetes.io/docs/user-guide/compute-resources  resources: -- The resource limits for the container    limits: {}    cpu: 200m    memory: 128Mi -- The requested resources for the container    requests: {}    cpu: 100m    memory: 64Mi |
+| oauthProxy.localSecretValues | list | `[]` | The requested resources for the container    requests: {}    cpu: 100m    memory: 64Mi |
 | oauthProxy.secretNameOverride | string | `""` | Optional: full name override for oauth secret |
 | oauthProxy.secretSuffix | string | `""` | Optional: oauth secret suffix, eg '-oauth' |
 | oauthProxy.skipAuthRegexes | list | `[]` | Optional: list of URL endpoints to bypass oauth-proxy for |
@@ -172,7 +176,7 @@ A generic chart to support most common application requirements
 | podAnnotations | object | `{}` | Additional annotations to apply to the pod |
 | podDisruptionBudget | object | `{"enabled":true,"minAvailable":"50%"}` | Pod Disruption Budget ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/ |
 | podSecurityContext | object | `{"runAsUser":1000}` | Pod Security context for the container ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
-| port | int | `8000` | Main container port for the application -- Set port to null to skip adding container Ports |
+| port | int | `8000` | Set port to null to skip adding container Ports |
 | postgresql.client.enabled | bool | `true` |  |
 | postgresql.client.resources.limits.cpu | string | `"300m"` |  |
 | postgresql.client.resources.limits.memory | string | `"128Mi"` |  |
@@ -194,6 +198,7 @@ A generic chart to support most common application requirements
 | replicas | int | `2` | Desired number of replicas for main deployment |
 | resources | object | `{"limits":{},"requests":{}}` | Container resource requests and limits ref: http://kubernetes.io/docs/user-guide/compute-resources |
 | resources.limits | object | `{}` | The resource limits for the container |
+| resources.requests | object | `{}` | The requested resources for the container |
 | securityContext | object | `{}` | Security context for the container ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | service | object | `{"annotations":{},"enabled":true,"labels":{},"type":"ClusterIP"}` | Kubernetes svc configutarion |
 | service.annotations | object | `{}` | Annotations to add to service |
@@ -226,4 +231,4 @@ A generic chart to support most common application requirements
 | volumes | string | `nil` | A list of volumes to be added to the pod |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.5.0](https://github.com/norwoodj/helm-docs/releases/v1.5.0)
+Autogenerated from chart metadata using [helm-docs v1.7.0](https://github.com/norwoodj/helm-docs/releases/v1.7.0)

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -58,7 +58,7 @@ A generic chart to support most common application requirements
 | cronjobs.defaults.restartPolicy | string | `"Never"` | Configure CronJob pod restart Policy ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy |
 | cronjobs.defaults.suspend | bool | `false` | Tells controller to suspend future executions ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec |
 | cronjobs.jobs | list | `[]` | List of Cronjob configurations to be defined |
-| cronjobsOnly | bool | `false` | Only show cronjobs and relevent resources (i.e. if set to `true`, hide the main deployment resource) |
+| cronjobsOnly | bool | `false` | Only show cronjobs and relevant resources (i.e. if set to `true`, hide the main deployment resource) |
 | deploymentEnabled | bool | `true` | Enable the main deploment workload |
 | elasticsearch.enabled | bool | `false` |  |
 | env | list | `[]` | Optional environment variables injected into the container |

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -61,7 +61,6 @@ A generic chart to support most common application requirements
 | cronjobs.defaults.suspend | bool | `false` | Tells controller to suspend future executions ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec |
 | cronjobs.jobs | list | `[]` | List of Cronjob configurations to be defined |
 | cronjobsOnly | bool | `false` | Only show cronjobs and relevant resources (i.e. if set to `true`, hide the main deployment resource) |
-| deploymentEnabled | bool | `true` | Enable the main deploment workload |
 | elasticsearch.enabled | bool | `false` |  |
 | env | list | `[]` | Optional environment variables injected into the container |
 | envFrom | list | `[]` | Optional environment variables injected into the container using envFrom (secrets/configmaps) |

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -1,3 +1,5 @@
+{{- if and .Values.deploymentEnabled (eq .Values.cronjobsOnly false)  }}
+---
 {{- if .Values.statefulset }}
 apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}
 kind: StatefulSet
@@ -348,3 +350,4 @@ spec:
             name: {{ include "mintel_common.fullname" . }}-filebeat
         {{- end }}
       {{- end }}
+{{- end }}

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.deploymentEnabled (eq .Values.cronjobsOnly false)  }}
+{{- if (eq .Values.cronjobsOnly false) }}
 ---
 {{- if .Values.statefulset }}
 apiVersion: {{ include "common.capabilities.statefulset.apiVersion" . }}

--- a/charts/standard-application-stack/templates/pdbs.yaml
+++ b/charts/standard-application-stack/templates/pdbs.yaml
@@ -1,4 +1,5 @@
 {{- if (and (gt (.Values.replicas | int) 1) .Values.podDisruptionBudget.enabled) }}
+{{- if eq .Values.cronjobsOnly false }}
 ---
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
@@ -38,5 +39,6 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{ include "mintel_common.selectorLabels" $data | nindent 6 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/standard-application-stack/templates/service-monitor.yaml
+++ b/charts/standard-application-stack/templates/service-monitor.yaml
@@ -1,4 +1,5 @@
 {{- if (and .Values.service .Values.service.enabled) }}
+{{- if (eq .Values.cronjobsOnly false) }}
 {{- if (ne .Values.global.clusterEnv "local") }}
 {{- if (and .Values.metrics .Values.metrics.enabled) }}
 ---
@@ -155,6 +156,7 @@ spec:
     matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 6 }}
   targetLabels: {{ include "mintel_common.targetLabelNames" . | nindent 4 }}
   podTargetLabels: {{ include "mintel_common.podTargetLabelNames" . | nindent 4 }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/standard-application-stack/templates/service.yaml
+++ b/charts/standard-application-stack/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.service.enabled }}
+{{- if and .Values.service.enabled (eq .Values.cronjobsOnly false) }}
 apiVersion: {{ include "common.capabilities.service.apiVersion" . }}
 kind: Service
 metadata:

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -26,6 +26,9 @@ global:
   # -- Global dictionary of TLS secrets
   ingressTLSSecrets: {}
 
+# -- Enable the main deploment workload
+deploymentEnabled: true
+
 # -- String to fully override mintel_common.fullname template
 nameOverride: ""
 
@@ -557,6 +560,9 @@ celeryBeat:
   readiness:
     # -- Enable readiness probe
     enabled: false
+
+# -- Only show cronjobs and relevent resources (i.e. if set to `true`, hide the main deployment resource)
+cronjobsOnly: false
 
 # -- Define and Configure CronJob's
 # Defaults to same image as main deployment but with defined arguments

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -26,9 +26,6 @@ global:
   # -- Global dictionary of TLS secrets
   ingressTLSSecrets: {}
 
-# -- Enable the main deploment workload
-deploymentEnabled: true
-
 # -- String to fully override mintel_common.fullname template
 nameOverride: ""
 

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -561,7 +561,7 @@ celeryBeat:
     # -- Enable readiness probe
     enabled: false
 
-# -- Only show cronjobs and relevent resources (i.e. if set to `true`, hide the main deployment resource)
+# -- Only show cronjobs and relevant resources (i.e. if set to `true`, hide the main deployment resource)
 cronjobsOnly: false
 
 # -- Define and Configure CronJob's


### PR DESCRIPTION
- Added cronjobsOnly flag to only show cronjobs and relevant resources (i.e. skip deployment / service etc)
- Bumped `helm-docs` version at root of repo (we don't really have a way to support changelogs for this...)

When `cronjobsOnly` is set to `true`, we:

- Disable the deployment main workload
- Disable service and service monitors
- Disable PDB

For now we still get a NetworkPolicy, since this could be useful for long running jobs (or any job really).