### PR TITLE
Added option for cronjobs to inherit base podSecurityContext

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.5.0] - 2022-02-03
+
+## Added
+- Added `includeBasePodSecurityContext` flag for cronjobs
+
 ## [v3.4.0] - 2022-02-03
 
 ## Added

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.4.0
+version: 3.5.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.4.0](https://img.shields.io/badge/Version-3.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.5.0](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/cronjobs.yaml
+++ b/charts/standard-application-stack/templates/cronjobs.yaml
@@ -23,6 +23,11 @@ spec:
           labels: {{ include "mintel_common.labels" $data | nindent 12 }}
         spec:
           {{- include "mintel_common.imagePullSecrets" $ | nindent 10 }}
+          {{- if .includeBasePodSecurityContext }}
+          {{- with $.Values.podSecurityContext }}
+          securityContext: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
           {{- with .podSecurityContext }}
           securityContext: {{ toYaml . | nindent 12 }}
           {{- end }}


### PR DESCRIPTION
Defaults to false, but when set to true, it will pull in the `runAsUser: 1000`, which is defined as a default in values.yaml