### PR TITLE
Add gitsync sidecar support

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.7.0] - 2022-02-25
+
+### Added
+- Added `gitSyncSidecar` helper for syncing a git repository into a local directory
+
 ## [v3.6.1] - 2022-02-22
 
 ### Fixed

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.6.1
+version: 3.7.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -128,7 +128,7 @@ A generic chart to support most common application requirements
 | liveness.startup.periodSeconds | int | `5` | Perios seconds for startupProbe |
 | localstack.enableStartupScripts | bool | `true` |  |
 | localstack.enabled | bool | `false` |  |
-| localstack.extraEnvVars[0].name | string | `"AWS_DEFALT_REGION"` |  |
+| localstack.extraEnvVars[0].name | string | `"AWS_DEFAULT_REGION"` |  |
 | localstack.extraEnvVars[0].value | string | `"us-east-1"` |  |
 | localstack.extraEnvVars[1].name | string | `"AWS_ACCESS_KEY_ID"` |  |
 | localstack.extraEnvVars[1].value | string | `"test"` |  |

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -79,6 +79,15 @@ A generic chart to support most common application requirements
 | filebeatSidecar.resources.limits.memory | string | `"200Mi"` |  |
 | filebeatSidecar.resources.requests.cpu | string | `"100m"` |  |
 | filebeatSidecar.resources.requests.memory | string | `"100Mi"` |  |
+| gitSyncSidecar.enabled | bool | `false` |  |
+| gitSyncSidecar.extraArgs[0] | string | `"--repo=https://repo-to-sync"` |  |
+| gitSyncSidecar.extraArgs[1] | string | `"--branch=main"` |  |
+| gitSyncSidecar.extraArgs[2] | string | `"--dest=checkout-dir-under-dest"` |  |
+| gitSyncSidecar.extraArgs[3] | string | `"--dest=/git-sync"` |  |
+| gitSyncSidecar.resources.limits.cpu | string | `"200m"` |  |
+| gitSyncSidecar.resources.limits.memory | string | `"200Mi"` |  |
+| gitSyncSidecar.resources.requests.cpu | string | `"50m"` |  |
+| gitSyncSidecar.resources.requests.memory | string | `"50Mi"` |  |
 | global | object | `{"additionalLabels":{},"cloudProvider":{"accountId":""},"clusterDomain":"127.0.0.1.nip.io","clusterEnv":"local","clusterName":"","ingressTLSSecrets":{},"name":"example-app","owner":"","partOf":"","runtimeEnvironment":"kubernetes"}` | Global variables for us in all charts and sub charts |
 | global.additionalLabels | object | `{}` | Additional labels to apply to all resources |
 | global.cloudProvider | object | `{"accountId":""}` | Global variables relating to cloud provider |

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.6.1](https://img.shields.io/badge/Version-3.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.7.0](https://img.shields.io/badge/Version-3.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -79,15 +79,8 @@ A generic chart to support most common application requirements
 | filebeatSidecar.resources.limits.memory | string | `"200Mi"` |  |
 | filebeatSidecar.resources.requests.cpu | string | `"100m"` |  |
 | filebeatSidecar.resources.requests.memory | string | `"100Mi"` |  |
-| gitSyncSidecar.enabled | bool | `false` |  |
-| gitSyncSidecar.extraArgs[0] | string | `"--repo=https://repo-to-sync"` |  |
-| gitSyncSidecar.extraArgs[1] | string | `"--branch=main"` |  |
-| gitSyncSidecar.extraArgs[2] | string | `"--dest=checkout-dir-under-dest"` |  |
-| gitSyncSidecar.extraArgs[3] | string | `"--dest=/git-sync"` |  |
-| gitSyncSidecar.resources.limits.cpu | string | `"200m"` |  |
-| gitSyncSidecar.resources.limits.memory | string | `"200Mi"` |  |
-| gitSyncSidecar.resources.requests.cpu | string | `"50m"` |  |
-| gitSyncSidecar.resources.requests.memory | string | `"50Mi"` |  |
+| gitSyncSidecar | object | `{"branch":"main","enabled":false,"resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"50m","memory":"50Mi"}},"root":"/data/git-sync"}` | Helper to sync a local directory with Git ref: https://github.com/kubernetes/git-sync |
+| gitSyncSidecar.branch | string | `"main"` | The git branch to check out |
 | global | object | `{"additionalLabels":{},"cloudProvider":{"accountId":""},"clusterDomain":"127.0.0.1.nip.io","clusterEnv":"local","clusterName":"","ingressTLSSecrets":{},"name":"example-app","owner":"","partOf":"","runtimeEnvironment":"kubernetes"}` | Global variables for us in all charts and sub charts |
 | global.additionalLabels | object | `{}` | Additional labels to apply to all resources |
 | global.cloudProvider | object | `{"accountId":""}` | Global variables relating to cloud provider |
@@ -135,7 +128,7 @@ A generic chart to support most common application requirements
 | liveness.startup.periodSeconds | int | `5` | Perios seconds for startupProbe |
 | localstack.enableStartupScripts | bool | `true` |  |
 | localstack.enabled | bool | `false` |  |
-| localstack.extraEnvVars[0].name | string | `"AWS_DEFAULT_REGION"` |  |
+| localstack.extraEnvVars[0].name | string | `"AWS_DEFALT_REGION"` |  |
 | localstack.extraEnvVars[0].value | string | `"us-east-1"` |  |
 | localstack.extraEnvVars[1].name | string | `"AWS_ACCESS_KEY_ID"` |  |
 | localstack.extraEnvVars[1].value | string | `"test"` |  |

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -357,7 +357,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /
-              port: http-git-sync
+              port: git-sync-http
             periodSeconds: 30
             successThreshold: 1
             timeoutSeconds: 120

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -25,6 +25,9 @@ metadata:
     app.mintel.com/opa-skip-liveness-probe-check.beat-exporter: "true"
     {{- end }}
     {{- end }}
+    {{- if (and .Values.gitSyncSidecar .Values.gitSyncSidecar.enabled) }}
+    app.mintel.com/opa-skip-readiness-probe-check.git-sync: "true"
+    {{- end }}
     {{- include "mintel_common.k8snotify" . | nindent 4 }}
     {{- $secretListStr := (include "mintel_common.secretList" .) }}
     {{- with $secretListStr }}
@@ -334,12 +337,47 @@ spec:
         {{- $oauthProxyData := dict "Release" .Release "Chart" .Chart "Values" .Values "proxiedService" .Values }}
         {{- include "mintel_common.oauthProxySidecar" $oauthProxyData | nindent 8}}
         {{- end }}
-      {{- if (or (or .Values.volumes .Values.persistentVolumes) (and .Values.filebeatSidecar .Values.filebeatSidecar.enabled)) }}
+
+        {{- if (and .Values.gitSyncSidecar .Values.gitSyncSidecar.enabled) }}
+        - name: git-sync
+          image: k8s.gcr.io/git-sync/git-sync:v3.4.0
+          args:
+            - --depth=1
+            - --add-user
+            - --http-bind=0.0.0.0:7000
+            - --wait=5
+            - --max-sync-failures=-1
+            - --repo={{ .Values.gitSyncSidecar.repo }}
+            - --branch={{ .Values.gitSyncSidecar.branch }}
+            - --root={{ .Values.gitSyncSidecar.root }}
+            - --dest={{ .Values.gitSyncSidecar.dest }}
+          envFrom:
+            - secretRef:
+                name: {{ include "mintel_common.fullname" . }}-git-sync
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http-git-sync
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 120
+          ports:
+          - containerPort: 7000
+            name: git-sync-http
+          {{- with .Values.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: {{ .Values.gitSyncSidecar.root }}
+              name: {{ include "mintel_common.fullname" . }}-git-sync
+      {{- end }}
       volumes:
+        {{- if .Values.persistentVolumes }}
         {{- range .Values.persistentVolumes }}
         - name: {{ printf "%s-%s" (include "mintel_common.fullname" $ ) .name }}
           persistentVolumeClaim:
             claimName: {{ printf "%s-%s" (include "mintel_common.fullname" $ ) .name }}
+        {{- end }}
         {{- end }}
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
@@ -349,5 +387,8 @@ spec:
           configMap:
             name: {{ include "mintel_common.fullname" . }}-filebeat
         {{- end }}
-      {{- end }}
+        {{- if (and .Values.gitSyncSidecar .Values.gitSyncSidecar.enabled) }}
+        - name: {{ include "mintel_common.fullname" . }}-git-sync
+          emptyDir: {}
+        {{- end }}
 {{- end }}

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -779,7 +779,7 @@ localstack:
   mountDind:
     enabled: true
   extraEnvVars:
-    - name: AWS_DEFALT_REGION
+    - name: AWS_DEFAULT_REGION
       value: us-east-1
     - name: AWS_ACCESS_KEY_ID
       value: test

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -687,13 +687,23 @@ redis:
   tls:
     enabled: false
 
+# -- Helper to sync a local directory with Git
+# ref: https://github.com/kubernetes/git-sync
 gitSyncSidecar:
   enabled: false
-  extraArgs:
-    - --repo=https://repo-to-sync
-    - --branch=main
-    - --dest=checkout-dir-under-dest
-    - --dest=/git-sync
+
+  # -- The git repository to clone
+  # repo: <your-git-repo>
+
+  # -- The git branch to check out
+  branch: main
+
+  # -- The root directory for git-sync operations, under which --dest will be created
+  root: /data/git-sync
+
+  # -- The name of (a symlink to) a directory in which to check-out files under --root
+  #  dest: <your-dest>
+
   resources:
     limits:
       cpu: 200m
@@ -769,7 +779,7 @@ localstack:
   mountDind:
     enabled: true
   extraEnvVars:
-    - name: AWS_DEFAULT_REGION
+    - name: AWS_DEFALT_REGION
       value: us-east-1
     - name: AWS_ACCESS_KEY_ID
       value: test

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -687,6 +687,21 @@ redis:
   tls:
     enabled: false
 
+gitSyncSidecar:
+  enabled: false
+  extraArgs:
+    - --repo=https://repo-to-sync
+    - --branch=main
+    - --dest=checkout-dir-under-dest
+    - --dest=/git-sync
+  resources:
+    limits:
+      cpu: 200m
+      memory: 200Mi
+    requests:
+      cpu: 50m
+      memory: 50Mi
+
 filebeatSidecar:
   enabled: false
   resources:


### PR DESCRIPTION
Adds support for running GitSync as a sidecar.

Note, it's easier to be explicit about git-sync args here (hence the specific `repo` , `dest` options etc) rather than allow any args to be passed in.  Mostly because the `root` is a volume mount that we handled automatically (so we need to know the name of `root`).

---

Also simplified the logic around writing volumes. 

Does mean we can end up with:

```yaml
volumes:
   <nothing here>
```

but k8s ignores this.

