### PR TITLE
Add extra configuration support to oauth2-proxy

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.8.0] - 2022-03-01
+
+### Added
+- Added support to set `env`, `scope` and `userIdClaim`  values for the oauth proxy sidecar
+
 ## [v3.7.0] - 2022-02-25
 
 ### Added

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.7.0
+version: 3.8.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.7.0](https://img.shields.io/badge/Version-3.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.8.0](https://img.shields.io/badge/Version-3.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -155,18 +155,20 @@ A generic chart to support most common application requirements
 | minReadySeconds | int | `10` | Minimum number of seconds before deployments are ready |
 | nameOverride | string | `""` | String to fully override mintel_common.fullname template |
 | networkPolicy | object | `{"additionalAllowFroms":[],"enabled":true}` | Define a default NetworkPolicy for allowing apps in the same 'app.kubernetes.io/part-of' group to communicate with eachother. ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/ |
-| oauthProxy | object | `{"allowedGroups":[],"emailDomain":"","enabled":false,"image":"quay.io/oauth2-proxy/oauth2-proxy:v7.1.3","ingressHost":"","issuerUrl":"https://oauth.mintel.com","localSecretValues":[],"secretNameOverride":"","secretSuffix":"","skipAuthRegexes":[],"type":"portal"}` | Configure oauth-proxy sidecar for main deployment |
+| oauthProxy | object | `{"allowedGroups":[],"emailDomain":"","enabled":false,"env":[],"image":"quay.io/oauth2-proxy/oauth2-proxy:v7.1.3","ingressHost":"","issuerUrl":"https://oauth.mintel.com","localSecretValues":[],"scope":"openid profile email","secretNameOverride":"","secretSuffix":"","skipAuthRegexes":[],"type":"portal","userIdClaim":"sub"}` | Configure oauth-proxy sidecar for main deployment |
 | oauthProxy.allowedGroups | list | `[]` | Optional: list of group ids to restrict access to |
 | oauthProxy.emailDomain | string | `""` | Optional: email domain to restrict access to |
 | oauthProxy.enabled | bool | `false` | Set to true to enable oauth-proxy sidecar |
+| oauthProxy.env | list | `[]` | Optional environment variables injected into the container |
 | oauthProxy.image | string | `"quay.io/oauth2-proxy/oauth2-proxy:v7.1.3"` | Full image name override |
 | oauthProxy.ingressHost | string | `""` | Optional: hostname for proxy redirect url (defaults to service defaultHost) |
 | oauthProxy.issuerUrl | string | `"https://oauth.mintel.com"` | Optional: URL of the OIDC issuer |
-| oauthProxy.localSecretValues | list | `[]` | The requested resources for the container    requests: {}    cpu: 100m    memory: 64Mi |
+| oauthProxy.scope | string | `"openid profile email"` | Optiona: OAuth scope specification |
 | oauthProxy.secretNameOverride | string | `""` | Optional: full name override for oauth secret |
 | oauthProxy.secretSuffix | string | `""` | Optional: oauth secret suffix, eg '-oauth' |
 | oauthProxy.skipAuthRegexes | list | `[]` | Optional: list of URL endpoints to bypass oauth-proxy for |
 | oauthProxy.type | string | `"portal"` | Identifies oauth-proxy as auth'ing with a mintel portal instance |
+| oauthProxy.userIdClaim | string | `"sub"` | Optiona: Claim contains the user ID |
 | opensearch | object | `{"awsEsProxy":{"enabled":false,"port":9200,"resources":{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"64Mi"}}},"enabled":false}` | Configures AWS Opensearch deployment/connections |
 | opensearch.awsEsProxy | object | `{"enabled":false,"port":9200,"resources":{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"64Mi"}}}` | Configures aws-es-proxy to enable external access to opensearch |
 | opensearch.awsEsProxy.enabled | bool | `false` | Set to true to add an aws-es-proxy deployment in front of opensearch |

--- a/charts/standard-application-stack/templates/_oauth-proxy.tpl
+++ b/charts/standard-application-stack/templates/_oauth-proxy.tpl
@@ -27,8 +27,13 @@
     {{- if (eq .proxiedService.oauthProxy.type "portal") }}
     - --insecure-oidc-allow-unverified-email=true
     - --cookie-secure=false
-    - --user-id-claim=sub
-    - --scope=openid profile email
+    - --user-id-claim={{ default "sub" .proxiedService.oauthProxy.userIdClaim }}
+    - --scope={{ default "openid profile email" .proxiedService.oauthProxy.scope }}
+    {{- end }}
+
+  env:
+    {{- with .proxiedService.oauthProxy.env }}
+    {{- toYaml . | nindent 12 }}
     {{- end }}
   envFrom:
     - secretRef:

--- a/charts/standard-application-stack/templates/_oauth-proxy.tpl
+++ b/charts/standard-application-stack/templates/_oauth-proxy.tpl
@@ -30,7 +30,6 @@
     - --user-id-claim={{ default "sub" .proxiedService.oauthProxy.userIdClaim }}
     - --scope={{ default "openid profile email" .proxiedService.oauthProxy.scope }}
     {{- end }}
-
   env:
     {{- with .proxiedService.oauthProxy.env }}
     {{- toYaml . | nindent 12 }}

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -433,7 +433,7 @@ oauthProxy:
   allowedGroups: []
   # -- Identifies oauth-proxy as auth'ing with a mintel portal instance
   type: portal
-  # -- Optiona: OAuth scope specification
+  # -- Optional: OAuth scope specification
   scope: "openid profile email"
   # -- Optional: oauth secret suffix, eg '-oauth'
   secretSuffix: ""
@@ -454,7 +454,7 @@ oauthProxy:
     #    memory: 64Mi
     #
     #
-  # -- Optiona: Claim contains the user ID
+  # -- Optional: Claim contains the user ID
   userIdClaim: "sub" 
   # -- Optional environment variables injected into the container
   env: []

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -455,7 +455,7 @@ oauthProxy:
     #
     #
   # -- Optional: Claim contains the user ID
-  userIdClaim: "sub" 
+  userIdClaim: "sub"
   # -- Optional environment variables injected into the container
   env: []
   #    - name: OAUTH_PROXY_SKIP_AUTH_PREFLIGHT

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -433,6 +433,8 @@ oauthProxy:
   allowedGroups: []
   # -- Identifies oauth-proxy as auth'ing with a mintel portal instance
   type: portal
+  # -- Optiona: OAuth scope specification
+  scope: "openid profile email"
   # -- Optional: oauth secret suffix, eg '-oauth'
   secretSuffix: ""
   # -- Optional: full name override for oauth secret
@@ -451,6 +453,13 @@ oauthProxy:
     #    cpu: 100m
     #    memory: 64Mi
     #
+    #
+  # -- Optiona: Claim contains the user ID
+  userIdClaim: "sub" 
+  # -- Optional environment variables injected into the container
+  env: []
+  #    - name: OAUTH_PROXY_SKIP_AUTH_PREFLIGHT
+  #      value: true
   localSecretValues: []
   #    - name: OAUTH_PROXY_CLIENT_ID
   #      value: test_value


### PR DESCRIPTION
Adds extra options to config the oauth2 proxy

`scope` and `user-id-claim` might be useful in the future, so added explicit options for now.

Added `env` to allow any other custom option passed in, although be wary that this can conflict with some of the explict args that we set, such as `scope` or `allowedgroups`.