### PR TITLE
Don't render the `tls:` key of the Ingress when there are no secrets

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.8.1] - 2022-03-01
+
+### Fixed
+- Don't render the `tls:` key of the Ingress when `ingress.specificTlsHostsYaml` and `global.ingressTLSSecrets` are both empty
+
 ## [v3.8.0] - 2022-03-01
 
 ### Added

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.8.0
+version: 3.8.1
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/templates/ingress.yaml
+++ b/charts/standard-application-stack/templates/ingress.yaml
@@ -130,7 +130,7 @@ spec:
     {{- with .Values.ingress.specificRulesHostsYaml }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- if .Values.ingress.tls }}
+  {{- if and .Values.ingress.tls ( or .Values.global.ingressTLSSecrets .Values.ingress.specificTlsHostsYaml ) }}
   tls:
     {{- range $key, $val := .Values.global.ingressTLSSecrets }}
     {{- $domainUsed := false -}}

--- a/charts/standard-application-stack/tests/ingress_test.yaml
+++ b/charts/standard-application-stack/tests/ingress_test.yaml
@@ -1,0 +1,29 @@
+suite: Test Ingress
+templates:
+  - ingress.yaml
+release:
+  namespace: test-namespace
+tests:
+  - it: Doesn't create tls if ingressTLSSecrets and specificTlsHostsYaml is empty
+    set:
+      global.clusterEnv: qa
+      global.ingressTLSSecrets: null
+      ingress.enabled: true
+      ingress.defaultHost: test-app.example.org
+      ingress.tls: true
+      ingress.specificTlsHostsYaml: null
+    asserts:
+      - isEmpty:
+          path: spec.tls
+
+  - it: Creates tls if ingressTLSSecrets is not empty
+    set:
+      global.clusterEnv: qa
+      global.ingressTLSSecrets.example_org: star-example-org
+      ingress.enabled: true
+      ingress.defaultHost: test-app.example.org
+      ingress.tls: true
+      ingress.specificTlsHostsYaml: null
+    asserts:
+      - isNotEmpty:
+          path: spec.tls


### PR DESCRIPTION
If neither `ingress.specificTlsHostsYaml` nor `global.ingressTLSSecrets` are specified, the `tls:` key of the Ingress should not be rendered.