### PR TITLE
Update default refreshInterval for external secrets

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.14.1] - 2022-04-22
+### Fixed
+- Fix perpetual ArgoCD diff caused by default ExternalSecret refreshInterval
+
 ## [v3.14.0] - 2022-04-22
 ### Added
 - Added support for pod `lifecycle` hooks

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.14.0
+version: 3.14.1
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/templates/secrets.yaml
+++ b/charts/standard-application-stack/templates/secrets.yaml
@@ -29,7 +29,7 @@ metadata:
 spec:
   dataFrom:
     - key: {{ coalesce .Values.externalSecret.pathOverride (printf "%s/%s/app" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
-  refreshInterval: {{ default "5m" .Values.externalSecret.secretRefreshIntervalOverride }}
+  refreshInterval: {{ default "5m0s" .Values.externalSecret.secretRefreshIntervalOverride }}
   secretStoreRef:
     name: {{ default "aws-secrets-manager-default" .Values.externalSecret.secretStoreRefOverride }}
     kind: SecretStore
@@ -69,7 +69,7 @@ metadata:
 spec:
   dataFrom:
     - key: {{ coalesce .path (printf "%s/%s/%s" $.Release.Namespace (include "mintel_common.fullname" $) .name) }}
-  refreshInterval: {{ default "5m" .refreshIntervalOverride }}
+  refreshInterval: {{ default "5m0s" .refreshIntervalOverride }}
   secretStoreRef:
     name: {{ default "aws-secrets-manager-default" .secretStoreRefOverride }}
     kind: SecretStore
@@ -109,7 +109,7 @@ spec:
       remoteRef:
         key: {{ $dataKey }}
         property: password
-  refreshInterval: {{ default "5m" .Values.mariadb.secretRefreshIntervalOverride }}
+  refreshInterval: {{ default "5m0s" .Values.mariadb.secretRefreshIntervalOverride }}
   secretStoreRef:
     name: {{ default "aws-secrets-manager-default" .Values.mariadb.secretStoreRefOverride }}
     kind: SecretStore
@@ -150,7 +150,7 @@ metadata:
 spec:
   dataFrom:
     - key: {{ coalesce .Values.redis.secretPathOverride (printf "%s/%s/redis" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
-  refreshInterval: {{ default "5m" .Values.redis.secretRefreshIntervalOverride }}
+  refreshInterval: {{ default "5m0s" .Values.redis.secretRefreshIntervalOverride }}
   secretStoreRef:
     name: {{ default "aws-secrets-manager-default" .Values.redis.secretStoreRefOverride }}
     kind: SecretStore
@@ -193,7 +193,7 @@ spec:
       remoteRef:
         key: {{ $dataKey }}
         property: ELASTICSEARCH_HOST
-  refreshInterval: {{ default "5m" .Values.elasticsearch.secretRefreshIntervalOverride }}
+  refreshInterval: {{ default "5m0s" .Values.elasticsearch.secretRefreshIntervalOverride }}
   secretStoreRef:
     name: {{ default "aws-secrets-manager-default" .Values.elasticsearch.secretStoreRefOverride }}
     kind: SecretStore
@@ -242,7 +242,7 @@ spec:
       remoteRef:
         key: {{ $dataKey }}
         property: OPENSEARCH_HOST
-  refreshInterval: {{ default "5m" .Values.opensearch.secretRefreshIntervalOverride }}
+  refreshInterval: {{ default "5m0s" .Values.opensearch.secretRefreshIntervalOverride }}
   secretStoreRef:
     name: {{ default "aws-secrets-manager-default" .Values.opensearch.secretStoreRefOverride }}
     kind: SecretStore
@@ -303,7 +303,7 @@ spec:
       remoteRef:
         key: {{ $dataKey }}
         property: port
-  refreshInterval: {{ default "5m" .Values.postgresql.secretRefreshIntervalOverride }}
+  refreshInterval: {{ default "5m0s" .Values.postgresql.secretRefreshIntervalOverride }}
   secretStoreRef:
     name: {{ default "aws-secrets-manager-default" .Values.postgresql.secretStoreRefOverride }}
     kind: SecretStore
@@ -351,7 +351,7 @@ metadata:
 spec:
   dataFrom:
     - key: {{ coalesce .Values.oauthProxy.secretPathOverride (printf "%s/%s/oauth" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
-  refreshInterval: {{ default "5m" .Values.oauthProxy.secretRefreshIntervalOverride }}
+  refreshInterval: {{ default "5m0s" .Values.oauthProxy.secretRefreshIntervalOverride }}
   secretStoreRef:
     name: {{ default "aws-secrets-manager-default" .Values.oauthProxy.secretStoreRefOverride }}
     kind: SecretStore


### PR DESCRIPTION
In the new version of external-secrets, the current default refreshInterval is causing a perpetual diff in ArgoCD.