### PR TITLE
Cpt 974 topology spread zone deprecation

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.14.4] - 2022-04-26
+### Changed
+- Change deprecated topologyKey from `failure-domain.beta.kubernetes.io/zone` to `topology.kubernetes.io/zone`
+
 ## [v3.14.3] - 2022-04-25
 ### Fixed
 - Fixed service account irsa ARN annotation when service account name is overriden

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.14.3
+version: 3.14.4
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -410,7 +410,7 @@ topologySpreadConstraints:
   - labelSelector:
       matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 8 }}
     maxSkew: {{ default 1 .Values.topologySpreadConstraints.zone.maxSkew }}
-    topologyKey: failure-domain.beta.kubernetes.io/zone
+    topologyKey: topology.kubernetes.io/zone
     whenUnsatisfiable: {{ default "DoNotSchedule" .Values.topologySpreadConstraints.zone.whenUnsatisfiable }}
   {{- end }}
   {{- if or (and (not (kindIs "bool" .Values.topologySpreadConstraints.node.enabled)) (eq .Values.global.clusterEnv "prod")) (and .Values.topologySpreadConstraints.node .Values.topologySpreadConstraints.node.enabled) }}

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -413,7 +413,7 @@ topologySpreadConstraints:
     topologyKey: topology.kubernetes.io/zone
     whenUnsatisfiable: {{ default "DoNotSchedule" .Values.topologySpreadConstraints.zone.whenUnsatisfiable }}
   {{- end }}
-  {{- if or (and (not (kindIs "bool" .Values.topologySpreadConstraints.node.enabled)) (eq .Values.global.clusterEnv "prod")) (and .Values.topologySpreadConstraints.node .Values.topologySpreadConstraints.node.enabled) }}
+  {{- if or (and (not (kindIs "bool" .Values.topologySpreadConstraints.node.enabled)) (or (eq .Values.global.clusterEnv "logs") (eq .Values.global.clusterEnv "prod"))) (and .Values.topologySpreadConstraints.node .Values.topologySpreadConstraints.node.enabled) }}
   - labelSelector:
       matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 8 }}
     maxSkew: {{ default 1 .Values.topologySpreadConstraints.node.maxSkew }}

--- a/charts/standard-application-stack/templates/deployment-celery.yaml
+++ b/charts/standard-application-stack/templates/deployment-celery.yaml
@@ -89,7 +89,7 @@ spec:
             {{- if (eq .Values.affinity.podAntiAffinity.zone "hard") }}
             - labelSelector:
                 matchLabels: {{ include "mintel_common.selectorLabels" $data | nindent 18 }}
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             {{- end }}
             {{- if (eq .Values.affinity.podAntiAffinity.node "hard") }}
             - labelSelector:
@@ -103,7 +103,7 @@ spec:
             - podAffinityTerm:
                 labelSelector:
                   matchLabels: {{ include "mintel_common.selectorLabels" $data | nindent 20 }}
-                topologyKey: failure-domain.beta.kubernetes.io/zone
+                topologyKey: topology.kubernetes.io/zone
               weight: {{ default 100 .Values.affinity.podAntiAffinity.weight }}
             {{- end }}
             {{- if (eq .Values.affinity.podAntiAffinity.node "soft") }}

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -121,7 +121,7 @@ spec:
             {{- if (eq .Values.affinity.podAntiAffinity.zone "hard") }}
             - labelSelector:
                 matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 18 }}
-              topologyKey: failure-domain.beta.kubernetes.io/zone
+              topologyKey: topology.kubernetes.io/zone
             {{- end }}
             {{- if (eq .Values.affinity.podAntiAffinity.node "hard") }}
             - labelSelector:
@@ -135,7 +135,7 @@ spec:
             - podAffinityTerm:
                 labelSelector:
                   matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 20 }}
-                topologyKey: failure-domain.beta.kubernetes.io/zone
+                topologyKey: topology.kubernetes.io/zone
               weight: {{ default 100 .Values.affinity.podAntiAffinity.weight }}
             {{- end }}
             {{- if (eq .Values.affinity.podAntiAffinity.node "soft") }}

--- a/charts/standard-application-stack/tests/ingress_test.yaml
+++ b/charts/standard-application-stack/tests/ingress_test.yaml
@@ -12,7 +12,7 @@ tests:
       - equal:
           path: spec.ingressClassName
           value: haproxy
- 
+
   - it: Check ALB className set if enabled
     set:
       global.clusterEnv: qa
@@ -40,12 +40,12 @@ tests:
       ingress.enabled: true
       ingress.alb.enabled: true
       ingress.alb.healthcheck.port: 9999
-      port: 8080 
+      port: 8080
     asserts:
       - equal:
           path: metadata.annotations.[alb.ingress.kubernetes.io/healthcheck-port]
           value: "9999"
- 
+
   - it: Check ALB gRPC default settings
     set:
       global.clusterEnv: qa
@@ -91,7 +91,7 @@ tests:
     asserts:
       - equal:
           path: metadata.annotations.[alb.ingress.kubernetes.io/backend-protocol-version]
-          value: HTTP2 
+          value: HTTP2
       - equal:
           path: metadata.annotations.[alb.ingress.kubernetes.io/success-codes]
           value: "200"

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -443,7 +443,7 @@ affinity:
   #              operator: In
   #              values:
   #              - portal-web
-  #          topologyKey: failure-domain.beta.kubernetes.io/zone
+  #          topologyKey: topology.kubernetes.io/zone
   #        weight: 100
 
 # -- Configure oauth-proxy sidecar for main deployment


### PR DESCRIPTION
Change deprecated topologyKey from 'failure-domain.beta.kubernetes.io/zone' to 'topology.kubernetes.io/zone' 