### PR TITLE
add option for internal alb

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.15.0] - 2022-05-03
+### Added
+- `ingress.alb.scheme` value to allow for choice of `internet-facing` or `internal` alb
+
 ## [v3.14.5] - 2022-05-03
 ### Fixed
 - Fixed img.shields.io badge version (as a result of running `helm-docs`)

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.14.5
+version: 3.15.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.14.5](https://img.shields.io/badge/Version-3.14.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.15.0](https://img.shields.io/badge/Version-3.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -112,7 +112,7 @@ A generic chart to support most common application requirements
 | image.repository | string | `"test"` | Docker repository |
 | image.tag | string | `"auto-replaced"` | Container image tag |
 | imagePullSecrets | list | `[]` | Optional array of imagePullSecrets ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
-| ingress | object | `{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","deregistrationDelay":{"timeoutSeconds":5},"enabled":false,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"preStopDelay":{"delaySeconds":15,"enabled":true}},"allowLivenessUrl":false,"allowReadinessUrl":false,"blackbox":{"enabled":true,"probePath":"/external-health-check"},"enabled":false,"extraAnnotations":{},"extraHosts":[],"specificRulesHostsYaml":{},"specificTlsHostsYaml":{},"tls":true}` | Configure the ingress resource that allows you to access the application from public-internet ref: http://kubernetes.io/docs/user-guide/ingress/ |
+| ingress | object | `{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","deregistrationDelay":{"timeoutSeconds":5},"enabled":false,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"preStopDelay":{"delaySeconds":15,"enabled":true},"scheme":"internet-facing"},"allowLivenessUrl":false,"allowReadinessUrl":false,"blackbox":{"enabled":true,"probePath":"/external-health-check"},"enabled":false,"extraAnnotations":{},"extraHosts":[],"specificRulesHostsYaml":{},"specificTlsHostsYaml":{},"tls":true}` | Configure the ingress resource that allows you to access the application from public-internet ref: http://kubernetes.io/docs/user-guide/ingress/ |
 | ingress.alb.backendProtocol | string | `"HTTP"` | Application Version (HTTP / HTTPS) |
 | ingress.alb.backendProtocolVersion | string | `"HTTP1"` | Application Protocol Version (HTTP1 / HTTP2 / GRPC) |
 | ingress.alb.healthcheck.healthyThresholdCount | int | `2` | Success threshold |
@@ -122,6 +122,7 @@ A generic chart to support most common application requirements
 | ingress.alb.healthcheck.unhealthyThresholdCount | int | `2` | Failure threshold |
 | ingress.alb.preStopDelay.delaySeconds | int | `15` | The delay (sleep) to wait for. IMPORTANT: The terminationGracePeriodSeconds must be greater than this. |
 | ingress.alb.preStopDelay.enabled | bool | `true` | Enable an additional delay when the container is shutdown of delaySeconds. This allows ALB to fully de-register the pod (allows zero-downtime rollouts) |
+| ingress.alb.scheme | string | `"internet-facing"` | Public or private alb (internet-facing / internal) |
 | ingress.allowLivenessUrl | bool | `false` | Set to true to allow the liveness URL through the ingress |
 | ingress.allowReadinessUrl | bool | `false` | Set to true to allow the readiness URL through the ingress |
 | ingress.blackbox | object | `{"enabled":true,"probePath":"/external-health-check"}` | Configures annotations defining blackbox endpoints |

--- a/charts/standard-application-stack/templates/helpers/_ingress.yaml
+++ b/charts/standard-application-stack/templates/helpers/_ingress.yaml
@@ -3,7 +3,12 @@
 {{/* Output ingressClassName */}}
 {{- define "mintel_common.ingress.className" -}}
 {{- if (and .Values.ingress.alb .Values.ingress.alb.enabled) }}
+{{- if eq .Values.ingress.alb.scheme "internet-facing" }}
 {{- print "alb-public-apps-default" -}}
+{{- end }}
+{{- if eq .Values.ingress.alb.scheme "internal" }}
+{{- print "alb-internal-apps-default" -}}
+{{- end }}
 {{- else }}
 {{- print "haproxy" -}}
 {{- end }}

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -365,6 +365,8 @@ ingress:
   specificTlsHostsYaml: {}
   alb:
     enabled: false
+    # -- Public or private alb (internet-facing / internal)
+    scheme: internet-facing
     # -- Application Version (HTTP / HTTPS)
     backendProtocol: HTTP
     # -- Application Protocol Version (HTTP1 / HTTP2 / GRPC)


### PR DESCRIPTION
# Added
- `ingress.alb.scheme` value to allow for choice of `internet-facing` or `internal` alb

# Changed
- updated `_ingress.yaml` helper to allow for generating internal lb class name