### PR TITLE
Added NetworkPolicy for apps with an internal alb

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v3.16.0] - 2022-05-03
+## [v3.15.1] - 2022-05-03
 ### Added
 - Added `allow-aws-alb-internal-to-APP-NAME` NetworkPolicy for apps with an internal alb
 

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.16.0] - 2022-05-03
+### Added
+- Added `allow-aws-alb-internal-to-APP-NAME` NetworkPolicy for apps with an internal alb
+
 ## [v3.15.0] - 2022-05-03
 ### Added
-- `ingress.alb.scheme` value to allow for choice of `internet-facing` or `internal` alb
+- Added `ingress.alb.scheme` value to allow for choice of `internet-facing` or `internal` alb
 
 ## [v3.14.5] - 2022-05-03
 ### Fixed

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.15.0
+version: 3.16.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.16.0
+version: 3.15.1
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.15.0](https://img.shields.io/badge/Version-3.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.16.0](https://img.shields.io/badge/Version-3.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.16.0](https://img.shields.io/badge/Version-3.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.15.1](https://img.shields.io/badge/Version-3.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/network-policy.yaml
+++ b/charts/standard-application-stack/templates/network-policy.yaml
@@ -44,7 +44,8 @@ spec:
 {{- end }}
 
 {{- if and .Values.ingress.enabled .Values.ingress.alb.enabled }}
-# We always generate this network policy if routing through the ALB
+{{- if eq .Values.ingress.alb.scheme "internet-facing" }}
+# We generate this network policy if routing through the public ALB
 # to allow the health-checks on the registered targets to pass
 ---
 kind: NetworkPolicy
@@ -69,4 +70,31 @@ spec:
       ports:
       - port: {{ default .Values.ingress.alb.healthcheck.port .Values.port }}
         protocol: TCP
+{{- end }}
+{{- if eq .Values.ingress.alb.scheme "internal" }}
+# On an internal alb, use the private-app subnet CIDR blocks
+---
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkpolicy.apiVersion" . }}
+metadata:
+  name: {{ printf "allow-aws-alb-internal-to-%s" .Values.global.name }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "mintel_common.labels" . | nindent 4 }}
+  annotations: {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: {{ .Values.global.partOf }}
+  ingress:
+    - from:
+      - ipBlock:
+          cidr: "${AWS_PRIVATE_APP_SUBNET_CIDR_BLOCKS_0}"
+      - ipBlock:
+          cidr: "${AWS_PRIVATE_APP_SUBNET_CIDR_BLOCKS_1}"
+      - ipBlock:
+          cidr: "${AWS_PRIVATE_APP_SUBNET_CIDR_BLOCKS_2}"
+      ports:
+      - port: {{ default .Values.ingress.alb.healthcheck.port .Values.port }}
+        protocol: TCP
+{{- end }}
 {{- end }}

--- a/charts/standard-application-stack/tests/networkpolicy_test.yaml
+++ b/charts/standard-application-stack/tests/networkpolicy_test.yaml
@@ -17,3 +17,17 @@ tests:
       - equal:
           path: metadata.name
           value: allow-aws-alb-to-example-app
+  - it: Check ALB NetworkPolicy created if internal alb selected
+    set:
+      global.clusterEnv: qa
+      ingress.enabled: true
+      # Disable default app networkpolicy
+      networkPolicy.enabled: false
+      ingress.alb.enabled: healthyThresholdCount
+      ingress.alb.scheme: internal
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: allow-aws-alb-internal-to-example-app


### PR DESCRIPTION
# Added
- Added `allow-aws-alb-internal-to-APP-NAME` NetworkPolicy for apps with an internal alb
   - this allows apps in the same private subnet as the internal alb to send and recieve traffic from the alb