### PR TITLE
Change the default ALB healthcheck path to /readiness

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.16.0] - 2022-05-10
+### Changed
+- Change the default ALB healthcheck path from `/external-health-check` to `/readiness`
+
 ## [v3.15.1] - 2022-05-03
 ### Added
 - Added `allow-aws-alb-internal-to-APP-NAME` NetworkPolicy for apps with an internal alb

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.15.1
+version: 3.16.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.15.1](https://img.shields.io/badge/Version-3.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.16.0](https://img.shields.io/badge/Version-3.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/helpers/_ingress.yaml
+++ b/charts/standard-application-stack/templates/helpers/_ingress.yaml
@@ -46,7 +46,7 @@
 {{- if eq .backendProtocolVersion "GRPC"}}
 {{- default "/grpc.health.v1.Health/Check" .healthcheck.path }}
 {{- else }}
-{{- default "/external-health-check" .healthcheck.path }}
+{{- default "/readiness" .healthcheck.path }}
 {{- end }}
 {{- end }}
 

--- a/charts/standard-application-stack/tests/ingress_test.yaml
+++ b/charts/standard-application-stack/tests/ingress_test.yaml
@@ -97,7 +97,7 @@ tests:
           value: "200"
       - equal:
           path: metadata.annotations.[alb.ingress.kubernetes.io/healthcheck-path]
-          value: /external-health-check
+          value: /readiness
 
   - it: Check no TLS set if ingressTLSSecrets and specificTlsHostsYaml is empty
     set:

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -391,7 +391,7 @@ ingress:
       # -- Period seconds
       intervalSeconds: 15
       # -- Healthcheck Request path
-      # path: /external-health-check
+      # path: /readiness
       # -- Port (defaults to port specified in Ingress used to direct traffic to service)
       # port: "8000"
       # -- Timeout seconds


### PR DESCRIPTION
We had it pointing to `/external-health-check` which is not in use, and in general more of a 'ping' type check.

The ALB needs to use the `/readiness` check for applications, since this is what determine when the pod is ready to receive traffic.