### PR TITLE
Fix logic around ALB NetworkPolicy and increase test-coverage

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,17 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.21.2] - 2022-05-13
+### Fixed
+- Fix logic around ALB NetworkPolicy and increase test coverage
+
 ## [v3.21.1] - 2022-05-13
 ### Fixed
 - Fixing changelog
-
 
 ## [v3.21.0] - 2022-05-13
 ### Fixed
 - extraSecrets pathOverride was not referenced correctly
 
 ### Added
-- add nameOverride option to kubelock
+- Add nameOverride option to kubelock
 
 ## [v3.20.2] - 2022-05-13
 ### Fixed

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.21.1
+version: 3.21.2
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.20.3](https://img.shields.io/badge/Version-3.20.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.21.2](https://img.shields.io/badge/Version-3.21.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.20.2](https://img.shields.io/badge/Version-3.20.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.20.3](https://img.shields.io/badge/Version-3.20.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/network-policy.yaml
+++ b/charts/standard-application-stack/templates/network-policy.yaml
@@ -41,18 +41,26 @@ spec:
           protocol: {{ .protocol }}
         {{- end }}
 {{- end }}
-
 {{- end }}
 
 {{- if and .Values.ingress.enabled .Values.ingress.alb.enabled }}
-{{- if eq .Values.ingress.alb.scheme "internet-facing" }}
-# We generate this network policy if routing through the public ALB
-# to allow the health-checks on the registered targets to pass
+# We generate this network policy if routing through the public or
+# internal ALB to allow Ingress traffic and healthchecks
+#
+# If oauthProxy is enabled, by default we assume that traffic is allowed
+# to the oauthProxy port 4180, otherwise the main container port.
+# Healthchecks can be on a different port to the main application port, so
+# we allow this to be specified as well.
 ---
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkpolicy.apiVersion" . }}
 metadata:
+  {{- if eq .Values.ingress.alb.scheme "internet-facing" }}
   name: {{ printf "allow-aws-alb-to-%s" .Values.global.name }}
+  {{- else }}
+  # Assume internal facing
+  name: {{ printf "allow-aws-alb-internal-to-%s" .Values.global.name }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "mintel_common.labels" . | nindent 4 }}
   annotations: {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
@@ -62,51 +70,36 @@ spec:
       app.kubernetes.io/part-of: {{ .Values.global.partOf }}
   ingress:
     - from:
+      {{- if eq .Values.ingress.alb.scheme "internet-facing" }}
       - ipBlock:
           cidr: "${AWS_PUBLIC_SUBNET_CIDR_BLOCKS_0}"
       - ipBlock:
           cidr: "${AWS_PUBLIC_SUBNET_CIDR_BLOCKS_1}"
       - ipBlock:
           cidr: "${AWS_PUBLIC_SUBNET_CIDR_BLOCKS_2}"
-      ports:
-      {{- if .Values.oauthProxy.enabled }}
-      - port: {{ default "4180" .Values.ingress.alb.healthcheck.port }}
-        protocol: TCP
       {{- else }}
-      - port: {{ default .Values.port .Values.ingress.alb.healthcheck.port }}
-        protocol: TCP
-      {{- end }}
-{{- end }}
-{{- if eq .Values.ingress.alb.scheme "internal" }}
-# On an internal alb, use the private-app subnet CIDR blocks
----
-kind: NetworkPolicy
-apiVersion: {{ include "common.capabilities.networkpolicy.apiVersion" . }}
-metadata:
-  name: {{ printf "allow-aws-alb-internal-to-%s" .Values.global.name }}
-  namespace: {{ .Release.Namespace }}
-  labels: {{ include "mintel_common.labels" . | nindent 4 }}
-  annotations: {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/part-of: {{ .Values.global.partOf }}
-  ingress:
-    - from:
+      # Assume internal facing
       - ipBlock:
           cidr: "${AWS_PRIVATE_APP_SUBNET_CIDR_BLOCKS_0}"
       - ipBlock:
           cidr: "${AWS_PRIVATE_APP_SUBNET_CIDR_BLOCKS_1}"
       - ipBlock:
           cidr: "${AWS_PRIVATE_APP_SUBNET_CIDR_BLOCKS_2}"
-      ports:
-      {{- if .Values.oauthProxy.enabled }}
-      - port: {{ default "4180" .Values.ingress.alb.healthcheck.port }}
-        protocol: TCP
-      {{- else }}
-      - port: {{ default .Values.port .Values.ingress.alb.healthcheck.port }}
-        protocol: TCP
       {{- end }}
-{{- end }}
+      ports:
+      {{ $ports := list }}
+      {{- if .Values.oauthProxy.enabled }}
+      {{ $ports = append $ports 4180 }}
+      {{- else }}
+      {{ $ports = append $ports .Values.port}}
+      {{- end }}
+      {{ if .Values.ingress.alb.healthcheck.port }}
+      {{ $ports = append $ports .Values.ingress.alb.healthcheck.port }}
+      {{- end }}
+      {{ $ports := sortAlpha $ports | uniq }}
+      {{- range $ports }}
+        - port: {{ . }}
+          protocol: TCP
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/standard-application-stack/tests/networkpolicy_test.yaml
+++ b/charts/standard-application-stack/tests/networkpolicy_test.yaml
@@ -90,7 +90,7 @@ tests:
           value:
             - port: 4180
               protocol: TCP
-  - it: Check ALB NetworkPolicy ports set with oauth2proxy
+  - it: Check ALB NetworkPolicy ports set with oauth2proxy and healthcheck
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -121,7 +121,7 @@ tests:
       # Disable default app networkpolicy
       networkPolicy.enabled: false
       ingress.alb.enabled: true
-      port: 8080
+      port: 4180
       oauthProxy.enabled: true
       ingress.alb.healthcheck.port: 4180
     asserts:

--- a/charts/standard-application-stack/tests/networkpolicy_test.yaml
+++ b/charts/standard-application-stack/tests/networkpolicy_test.yaml
@@ -70,6 +70,7 @@ tests:
           value:
             - port: 8080
               protocol: TCP
+
   - it: Check ALB NetworkPolicy ports set with oauth2proxy
     set:
       global.clusterEnv: qa
@@ -90,6 +91,7 @@ tests:
           value:
             - port: 4180
               protocol: TCP
+
   - it: Check ALB NetworkPolicy ports set with oauth2proxy and healthcheck
     set:
       global.clusterEnv: qa

--- a/charts/standard-application-stack/tests/networkpolicy_test.yaml
+++ b/charts/standard-application-stack/tests/networkpolicy_test.yaml
@@ -17,13 +17,23 @@ tests:
       - equal:
           path: metadata.name
           value: allow-aws-alb-to-example-app
+      - equal:
+          path: spec.ingress[0].from
+          value:
+            - ipBlock:
+                cidr: ${AWS_PUBLIC_SUBNET_CIDR_BLOCKS_0}
+            - ipBlock:
+                cidr: ${AWS_PUBLIC_SUBNET_CIDR_BLOCKS_1}
+            - ipBlock:
+                cidr: ${AWS_PUBLIC_SUBNET_CIDR_BLOCKS_2}
+
   - it: Check ALB NetworkPolicy created if internal alb selected
     set:
       global.clusterEnv: qa
       ingress.enabled: true
       # Disable default app networkpolicy
       networkPolicy.enabled: false
-      ingress.alb.enabled: healthyThresholdCount
+      ingress.alb.enabled: true
       ingress.alb.scheme: internal
     asserts:
       - isKind:
@@ -31,3 +41,97 @@ tests:
       - equal:
           path: metadata.name
           value: allow-aws-alb-internal-to-example-app
+      - equal:
+          path: spec.ingress[0].from
+          value:
+            - ipBlock:
+                cidr: ${AWS_PRIVATE_APP_SUBNET_CIDR_BLOCKS_0}
+            - ipBlock:
+                cidr: ${AWS_PRIVATE_APP_SUBNET_CIDR_BLOCKS_1}
+            - ipBlock:
+                cidr: ${AWS_PRIVATE_APP_SUBNET_CIDR_BLOCKS_2}
+
+  - it: Check ALB NetworkPolicy ports set for default conatiner
+    set:
+      global.clusterEnv: qa
+      ingress.enabled: true
+      # Disable default app networkpolicy
+      networkPolicy.enabled: false
+      ingress.alb.enabled: true
+      port: 8080
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: allow-aws-alb-to-example-app
+      - equal:
+          path: spec.ingress[0].ports
+          value:
+            - port: 8080
+              protocol: TCP
+  - it: Check ALB NetworkPolicy ports set with oauth2proxy
+    set:
+      global.clusterEnv: qa
+      ingress.enabled: true
+      # Disable default app networkpolicy
+      networkPolicy.enabled: false
+      ingress.alb.enabled: true
+      port: 8080
+      oauthProxy.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: allow-aws-alb-to-example-app
+      - equal:
+          path: spec.ingress[0].ports
+          value:
+            - port: 4180
+              protocol: TCP
+  - it: Check ALB NetworkPolicy ports set with oauth2proxy
+    set:
+      global.clusterEnv: qa
+      ingress.enabled: true
+      # Disable default app networkpolicy
+      networkPolicy.enabled: false
+      ingress.alb.enabled: true
+      port: 8080
+      oauthProxy.enabled: true
+      ingress.alb.healthcheck.port: 9999
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: allow-aws-alb-to-example-app
+      - equal:
+          path: spec.ingress[0].ports
+          value:
+            - port: 4180
+              protocol: TCP
+            - port: 9999
+              protocol: TCP
+
+  - it: Check ALB NetworkPolicy ports are unique
+    set:
+      global.clusterEnv: qa
+      ingress.enabled: true
+      # Disable default app networkpolicy
+      networkPolicy.enabled: false
+      ingress.alb.enabled: true
+      port: 8080
+      oauthProxy.enabled: true
+      ingress.alb.healthcheck.port: 4180
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: allow-aws-alb-to-example-app
+      - equal:
+          path: spec.ingress[0].ports
+          value:
+            - port: 4180
+              protocol: TCP


### PR DESCRIPTION
- Handle logic better around default-container port / oauthProxy port, and healthcheck port (multiple ports should be allowed)
- Avoid duplicate list of ports in ALB networkpolicy
- Re-factor code to avoid duplication 
- Adds extra tests for this (specifically testing port and subnets for public/internal schemes)