### PR TITLE
CPT-1074: Fixed oauthProxy regex for --skip-auth-regex paths

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.22.1] - 2022-05-18
+### Fixed
+- Fixed oauthProxy regex for healthchecks (requires exact match)
+
 ## [v3.22.0] - 2022-05-17
 ### Removed
 - Removed support for Ingress v1beta1

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.22.0
+version: 3.22.1
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.22.0](https://img.shields.io/badge/Version-3.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.22.1](https://img.shields.io/badge/Version-3.22.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -191,7 +191,7 @@ A generic chart to support most common application requirements
 | oauthProxy.secretRefreshIntervalOverride | string | `""` | Optional: ExternalSecret refreshInterval override |
 | oauthProxy.secretStoreRefOverride | string | `""` | Optional: full SecretStoreRef override for oauth ExternalSecret |
 | oauthProxy.secretSuffix | string | `""` | Optional: oauth secret suffix, eg '-oauth' |
-| oauthProxy.skipAuthRegexes | list | `[]` | Optional: list of URL endpoints to bypass oauth-proxy for Note that default health check and readiness urls are already skipped |
+| oauthProxy.skipAuthRegexes | list | `[]` | Optional: list of URL endpoints to bypass oauth-proxy for Health check and readiness urls are skipped automatically |
 | oauthProxy.type | string | `"portal"` | Identifies oauth-proxy as auth'ing with a mintel portal instance |
 | oauthProxy.userIdClaim | string | `""` | Optional: Claim contains the user ID |
 | opensearch | object | `{"awsEsProxy":{"enabled":false,"port":9200,"resources":{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"64Mi"}}},"enabled":false,"secretRefreshIntervalOverride":"","secretStoreRefOverride":""}` | Configures AWS Opensearch deployment/connections |

--- a/charts/standard-application-stack/templates/_oauth-proxy.tpl
+++ b/charts/standard-application-stack/templates/_oauth-proxy.tpl
@@ -9,12 +9,12 @@
     - --upstream=http://localhost:{{ .proxiedService.port }}
     - --http-address=http://0.0.0.0:4180
     - --provider=oidc
-    - --skip-auth-regex=/ping
-    - --skip-auth-regex={{ default "/healthz" .Values.liveness.path }}
-    - --skip-auth-regex={{ default "/readiness" .Values.readiness.path }}
-    - --skip-auth-regex={{ default "/external-health-check" .Values.ingress.blackbox.probePath }}
+    - --skip-auth-regex=^/ping$
+    - --skip-auth-regex=^{{ default "/healthz" .Values.liveness.path }}$
+    - --skip-auth-regex=^{{ default "/readiness" .Values.readiness.path }}$
+    - --skip-auth-regex=^{{ default "/external-health-check" .Values.ingress.blackbox.probePath }}$
     {{- range .proxiedService.oauthProxy.skipAuthRegexes }}
-    - --skip-auth-regex={{ . }}
+    - --skip-auth-regex={{ if not (hasPrefix "^" . )}}^{{ end }}{{ . }}{{ if not (hasSuffix "$" . )}}${{ end }}
     {{- end }}
     - --skip-provider-button=true
     - --skip-jwt-bearer-tokens=true

--- a/charts/standard-application-stack/tests/oauth2proxy_test.yaml
+++ b/charts/standard-application-stack/tests/oauth2proxy_test.yaml
@@ -33,10 +33,10 @@ tests:
             - --upstream=http://localhost:8000
             - --http-address=http://0.0.0.0:4180
             - --provider=oidc
-            - --skip-auth-regex=/ping
-            - --skip-auth-regex=/healthz
-            - --skip-auth-regex=/readiness
-            - --skip-auth-regex=/external-health-check
+            - --skip-auth-regex=^/ping$
+            - --skip-auth-regex=^/healthz$
+            - --skip-auth-regex=^/readiness$
+            - --skip-auth-regex=^/external-health-check$
             - --skip-provider-button=true
             - --skip-jwt-bearer-tokens=true
             - --ssl-insecure-skip-verify=true
@@ -63,11 +63,11 @@ tests:
             - --upstream=http://localhost:8000
             - --http-address=http://0.0.0.0:4180
             - --provider=oidc
-            - --skip-auth-regex=/ping
-            - --skip-auth-regex=/healthz
-            - --skip-auth-regex=/readiness
-            - --skip-auth-regex=/external-health-check
-            - --skip-auth-regex=/readyz
+            - --skip-auth-regex=^/ping$
+            - --skip-auth-regex=^/healthz$
+            - --skip-auth-regex=^/readiness$
+            - --skip-auth-regex=^/external-health-check$
+            - --skip-auth-regex=^/readyz$
             - --skip-provider-button=true
             - --skip-jwt-bearer-tokens=true
             - --ssl-insecure-skip-verify=true
@@ -80,6 +80,38 @@ tests:
             - --cookie-secure=false
             - --user-id-claim=sub
             - --scope=openid profile email
+  - it: Check setting skip-auth-regex from extra passed in values when they already contain start/end meta-characters
+    set:
+      global.clusterEnv: qa
+      global.name: test-app
+      oauthProxy.enabled: true
+      oauthProxy.skipAuthRegexes: ['^/readyz$']
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].args
+          value:
+            - --redirect-url=https:///oauth2/callback
+            - --upstream=http://localhost:8000
+            - --http-address=http://0.0.0.0:4180
+            - --provider=oidc
+            - --skip-auth-regex=^/ping$
+            - --skip-auth-regex=^/healthz$
+            - --skip-auth-regex=^/readiness$
+            - --skip-auth-regex=^/external-health-check$
+            - --skip-auth-regex=^/readyz$
+            - --skip-provider-button=true
+            - --skip-jwt-bearer-tokens=true
+            - --ssl-insecure-skip-verify=true
+            - --ssl-upstream-insecure-skip-verify=true
+            - --oidc-groups-claim=groups
+            - --metrics-address=http://0.0.0.0:9090
+            - --email-domain=*
+            - --oidc-issuer-url=https://oauth.mintel.com
+            - --insecure-oidc-allow-unverified-email=true
+            - --cookie-secure=false
+            - --user-id-claim=sub
+            - --scope=openid profile email
+
   - it: Check setting skip-auth-regex from overridden health-check values
     set:
       global.clusterEnv: qa
@@ -96,10 +128,10 @@ tests:
             - --upstream=http://localhost:8000
             - --http-address=http://0.0.0.0:4180
             - --provider=oidc
-            - --skip-auth-regex=/ping
-            - --skip-auth-regex=/healthz-overridden
-            - --skip-auth-regex=/readiness-overridden
-            - --skip-auth-regex=/external-health-check-overridden
+            - --skip-auth-regex=^/ping$
+            - --skip-auth-regex=^/healthz-overridden$
+            - --skip-auth-regex=^/readiness-overridden$
+            - --skip-auth-regex=^/external-health-check-overridden$
             - --skip-provider-button=true
             - --skip-jwt-bearer-tokens=true
             - --ssl-insecure-skip-verify=true

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -498,7 +498,7 @@ oauthProxy:
   # -- Optional: full SecretStoreRef override for oauth ExternalSecret
   secretStoreRefOverride: ""
   # -- Optional: list of URL endpoints to bypass oauth-proxy for
-  # Note that default health check and readiness urls are already skipped
+  # Health check and readiness urls are skipped automatically
   skipAuthRegexes: []
   # -- Container resource requests and limits
   # ref: http://kubernetes.io/docs/user-guide/compute-resources


### PR DESCRIPTION
oauth2proxy allows health check urls to be passed through to the upstream.

For example `$service/healthz` is allowed to pass through (without authentication).

However, previous to this fix, you could also access `$service/foo/healthz`.

This fix ensures that there's an exact match on the health check paths.

