### PR TITLE
CPT-1092: ALB Ingress should listen on port 80 as well

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.22.2] - 2022-05-20
+### Fixed
+- ALB Ingress should listen on port 80 as well (redirect rule to 443 is in place)
+
 ## [v3.22.1] - 2022-05-18
 ### Fixed
 - Fixed oauthProxy regex for healthchecks (requires exact match)

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.22.1
+version: 3.22.2
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.22.1](https://img.shields.io/badge/Version-3.22.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.22.2](https://img.shields.io/badge/Version-3.22.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/ingress.yaml
+++ b/charts/standard-application-stack/templates/ingress.yaml
@@ -57,7 +57,7 @@ metadata:
 
     {{- if (and .Values.ingress.alb .Values.ingress.alb.enabled) }}
     {{- with .Values.ingress.alb }}
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/target-group-attributes: "deregistration_delay.timeout_seconds={{ default 10 .deregistrationDelay.timeoutSeconds }}"
     alb.ingress.kubernetes.io/target-type: "ip"
     external-dns.alpha.kubernetes.io/ttl: "60"

--- a/charts/standard-application-stack/tests/ingress_test.yaml
+++ b/charts/standard-application-stack/tests/ingress_test.yaml
@@ -109,6 +109,9 @@ tests:
       - equal:
           path: metadata.annotations.[alb.ingress.kubernetes.io/healthcheck-path]
           value: /readiness
+      - equal:
+          path: metadata.annotations.[alb.ingress.kubernetes.io/listen-ports]
+          value: '[{"HTTP": 80}, {"HTTPS": 443}]'
 
   - it: Check no TLS set if ingressTLSSecrets and specificTlsHostsYaml is empty
     set:


### PR DESCRIPTION
There's an ALB redirect in place (80->443).

We wish to maintain this behaviour because:
- It's still default browser setup
- Existing clients may be expecting this