### PR TITLE
Terraform Cloud helm chart

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.3.0] - 2022-05-25
+### Added
+- Added app.mintel.com/altName to workspace spec to be used in manifest generation
+
+### Changed
+- Changed workspace-output-secret secret store to aws-secrets-manager-local
+
 ## [v0.2.0] - 2022-05-24
 ### Changed
 - Changed workspace-output-secret name to match what is currently used in standard app stack i.e app_name-resource_type

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 

--- a/charts/terraform-cloud/templates/helpers/_workspace-output-secret.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace-output-secret.yaml
@@ -18,7 +18,7 @@ spec:
     - key: {{ (printf "%s/%s/%s" $.Release.Namespace .name $resourceType ) }}
   refreshInterval: 5m0s
   secretStoreRef:
-    name: aws-secrets-manager-default
+    name: aws-secrets-manager-local
     kind: SecretStore
   target:
     creationPolicy: Owner

--- a/charts/terraform-cloud/templates/helpers/_workspace.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace.yaml
@@ -14,6 +14,7 @@ metadata:
   labels: {{ include "mintel_common.labels" $ | nindent 4 }}
   annotations:
     {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}
+    app.mintel.com/altName: "{{ $.Release.Namespace }}-{{ .name }}-{{ $resourceType | kebabcase }}"
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   agentPoolID: {{ $global.terraform.agentPoolID | quote }}

--- a/charts/terraform-cloud/tests/workspace_output_secret_test.yaml
+++ b/charts/terraform-cloud/tests/workspace_output_secret_test.yaml
@@ -33,4 +33,4 @@ tests:
           count: 1
       - equal:
           path: spec.secretStoreRef.name
-          value: aws-secrets-manager-default
+          value: aws-secrets-manager-local

--- a/charts/terraform-cloud/tests/workspace_test.yaml
+++ b/charts/terraform-cloud/tests/workspace_test.yaml
@@ -27,6 +27,9 @@ tests:
           value: app.terraform.io/Mintel/private-s3-bucket/aws
       - hasDocuments:
           count: 1
+      - equal:
+          path: metadata.annotations.[app.mintel.com/altName]
+          value: test-namespace-test-app-s3
       - contains:
           path: spec.variables
           content:


### PR DESCRIPTION
- feat: Added app.mintel.com/altName to workspace spec to be used in manifest generation
- fix: Changed workspace-output-secret secret store to aws-secrets-manager-local