### PR TITLE
- Auto add mntl- prefix to S3 bucket name if not added explicitly

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.0] - 2022-06-07
+### Added
+- Auto add mntl- prefix to S3 bucket name if not added explicitly
+- Shorten IRSA workspace names
+- Remove hash trigger for IRSA as not needed with run triggers
+
 ## [v0.6.1] - 2022-06-07
 ### Fixed
 - Issue with IRSA workspace adding in null var

--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auto add mntl- prefix to S3 bucket name if not added explicitly
 - Shorten IRSA workspace names
 - Remove hash trigger for IRSA as not needed with run triggers
+- Add sync wave for Output secret
 
 ## [v0.6.1] - 2022-06-07
 ### Fixed

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.1
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 
@@ -27,9 +27,9 @@ A Helm chart for provisioning resources using Terraform Cloud
 | global.terraform.organization | string | `"Mintel"` | Name of our Terraform Cloud org |
 | global.terraform.secretsMountPath | string | `"/tmp/secrets"` | Where secrets are mounted inside the Terraform Operator container |
 | global.terraform.terraformVersion | string | `"1.0.7"` | Global Terraform version for all modules |
-| irsa.terraform.module | object | `{"source":"app.terraform.io/Mintel/app-iam/aws","version":" 0.1.0-beta.2"}` | Set override to stop IRSA from ending in global.name nameOverride: |
+| irsa.terraform.module | object | `{"source":"app.terraform.io/Mintel/app-iam/aws","version":"0.1.0-beta.4"}` | Set override to stop IRSA from ending in global.name nameOverride: |
 | irsa.terraform.module.source | string | `"app.terraform.io/Mintel/app-iam/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/app-iam/aws) |
-| irsa.terraform.module.version | string | `" 0.1.0-beta.2"` | Module version |
+| irsa.terraform.module.version | string | `"0.1.0-beta.4"` | Module version |
 | irsa.terraform.vars | object | `{}` |  |
 | mariadb.enabled | bool | `false` | Set to true to create a MariaDB RDS instance |
 | mariadb.terraform.defaultVars | object | See below | Vars to be applied to all instances defined below |

--- a/charts/terraform-cloud/templates/helpers/_workspace-output-secret.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace-output-secret.yaml
@@ -13,6 +13,7 @@ metadata:
   annotations:
     {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "-20"
 spec:
   dataFrom:
     - key: {{ $instanceConfig.output_secret_name | quote }}

--- a/charts/terraform-cloud/templates/irsa-workspace.yaml
+++ b/charts/terraform-cloud/templates/irsa-workspace.yaml
@@ -9,7 +9,7 @@
   {{- $tfVersion := $irsa.terraform.terraformVersion }}
   {{- $irsaConfig := $irsa.terraform.vars}}
   {{- if not (hasKey $irsaConfig "name") }}
-    {{- $_ := set $irsaConfig "name" (printf "app-iam-%s-%s-%s" $global.clusterName $.Release.Namespace (coalesce .Values.irsa.nameOverride $global.name)) }}
+    {{- $_ := set $irsaConfig "name" (printf "%s" (coalesce .Values.irsa.nameOverride $global.name)) }}
   {{- end }}
   {{- if not (hasKey $irsaConfig "aws_account_name") }}
     {{- $_ := set $irsaConfig "aws_account_name" $global.clusterEnv }}
@@ -26,9 +26,6 @@
   {{- if not (hasKey $irsaConfig "tfcloud_agent") }}
     {{- $_ := set $irsaConfig "tfcloud_agent" "true" }}
   {{ end }}
-  {{- if (not (hasKey $irsaConfig "trigger")) }}
-    {{- $_ := set $irsaConfig "trigger" ($.Values | toString | sha256sum) }}
-  {{- end }}
   {{- if (not (hasKey $irsaConfig "k8s_service_account_name")) }}
     {{- $_ := set $irsaConfig "k8s_service_account_name" $global.name }}
   {{- end }}

--- a/charts/terraform-cloud/templates/workspace.yaml
+++ b/charts/terraform-cloud/templates/workspace.yaml
@@ -22,6 +22,10 @@
           {{- $_ := set $instanceConfig "name" $instanceName }}
         {{- end }}
       {{- end }}
+      # For S3 add 'mntl-' prefix to name
+      {{- if ( and ( eq $resourceType "s3") ( not (hasPrefix "mntl" $instanceConfig.name)))}}
+        {{- $_ := set $instanceConfig "name" (printf "mntl-%s" $instanceConfig.name) }}
+      {{- end }}
       # Set instance.db_name for postgresql and mariadb if not provided
       {{- if ( and ( has $resourceType (list "postgresql" "mariadb") ) ( not ( hasKey $instanceConfig "db_name" ) ) ) }}
         {{- $_ := set $instanceConfig "db_name" ( $instanceConfig.name | snakecase ) }}

--- a/charts/terraform-cloud/tests/irsa_workspace_test.yaml
+++ b/charts/terraform-cloud/tests/irsa_workspace_test.yaml
@@ -21,7 +21,7 @@ tests:
           value: test-namespace
       - equal:
           path: metadata.name
-          value: dev-eu-west-1-cluster1-test-namespace-app-iam-cluster1-test-namespace-test-app-irsa
+          value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
       - equal:
           path: spec.module.source
           value: app.terraform.io/Mintel/app-iam/aws
@@ -44,7 +44,7 @@ tests:
               hcl: false
               key: name
               sensitive: false
-              value: app-iam-cluster1-test-namespace-test-app
+              value: test-app
       - contains:
           path: spec.variables
           content:

--- a/charts/terraform-cloud/tests/workspace_test.yaml
+++ b/charts/terraform-cloud/tests/workspace_test.yaml
@@ -4,6 +4,19 @@ templates:
 release:
   namespace: test-namespace
 tests:
+  - it: Dev S3 module workspace name does not repeat mntl-prefix
+    set:
+      global.name: mntl-test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      s3.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
   - it: Dev S3 module workspace
     set:
       global.name: test-app
@@ -21,7 +34,7 @@ tests:
           value: test-namespace
       - equal:
           path: metadata.name
-          value: dev-eu-west-1-cluster1-test-namespace-test-app-s3
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       - equal:
           path: spec.module.source
           value: app.terraform.io/Mintel/private-s3-bucket/aws
@@ -29,7 +42,7 @@ tests:
           count: 1
       - equal:
           path: metadata.annotations.[app.mintel.com/altManifestFileSuffix]
-          value: test-app-s3
+          value: mntl-test-app-s3
       - equal:
           path: metadata.annotations.[argocd.argoproj.io/sync-wave]
           value: "-40"
@@ -40,7 +53,7 @@ tests:
               hcl: false
               key: name
               sensitive: false
-              value: test-app
+              value: mntl-test-app
       - contains:
           path: spec.variables
           content:
@@ -80,7 +93,7 @@ tests:
             hcl: false
             key: output_secret_name
             sensitive: false
-            value: test-namespace/test-app/s3
+            value: test-namespace/mntl-test-app/s3
       - contains:
           path: spec.variables
           content:

--- a/charts/terraform-cloud/values.yaml
+++ b/charts/terraform-cloud/values.yaml
@@ -44,7 +44,7 @@ irsa:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/app-iam/aws)
       source: app.terraform.io/Mintel/app-iam/aws
       # -- Module version
-      version: "0.1.0-beta.3"
+      version: "0.1.0-beta.4"
       # -- Vars to be applied to all instances defined below
     vars: {}
 


### PR DESCRIPTION
- Shorten IRSA workspace names
- Remove hash trigger for IRSA as not needed with run triggers