### PR TITLE
add aws-api-gateway-operator helm chart

### DIFF
--- a/charts/aws-api-gateway-operator/.helmignore
+++ b/charts/aws-api-gateway-operator/.helmignore
@@ -1,0 +1,26 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+crds/kustomization.yaml
+# Unit tests
+tests

--- a/charts/aws-api-gateway-operator/CHANGELOG.md
+++ b/charts/aws-api-gateway-operator/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Unreleased
+
+## [0.1.0] - 2022-06-07
+### Added
+- Added initial chart implementation

--- a/charts/aws-api-gateway-operator/Chart.lock
+++ b/charts/aws-api-gateway-operator/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: standard-application-stack
+  repository: https://mintel.github.io/helm-charts
+  version: 3.27.0
+digest: sha256:027124334a1ea01462ddb5e28375eb56eb1880ce6bf7a59ffaee7620c1ca07c3
+generated: "2022-06-09T17:57:50.49060471-05:00"

--- a/charts/aws-api-gateway-operator/Chart.yaml
+++ b/charts/aws-api-gateway-operator/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: aws-api-gateway-operator
+description: AWS API Gateway Operator Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: v1.0.2
+keywords:
+  - eks
+  - aws
+  - api gateway
+
+dependencies:
+  - condition: standard-application-stack.enabled
+    name: standard-application-stack
+    version: 3.27.0
+    repository: https://mintel.github.io/helm-charts

--- a/charts/aws-api-gateway-operator/README.md
+++ b/charts/aws-api-gateway-operator/README.md
@@ -1,0 +1,122 @@
+# aws-api-gateway-operator
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.2](https://img.shields.io/badge/AppVersion-v1.0.2-informational?style=flat-square)
+
+AWS API Gateway Operator Helm chart for Kubernetes
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://mintel.github.io/helm-charts | standard-application-stack | 3.27.0 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| global | object | `{"additionalLabels":{},"cloudProvider":{"accountId":""},"clusterDomain":"127.0.0.1.nip.io","clusterEnv":"${CLUSTER_ENV}","clusterName":"${CLUSTER_NAME}","name":"aws-api-gateway-operator","owner":"SRE","partOf":"aws-api-gateway-operator","runtimeEnvironment":"kubernetes"}` | Global variables for us in all charts and sub charts |
+| global.additionalLabels | object | `{}` | Additional labels to apply to all resources |
+| global.cloudProvider | object | `{"accountId":""}` | Global variables relating to cloud provider |
+| global.cloudProvider.accountId | string | `""` | AWS Account Id |
+| global.clusterDomain | string | `"127.0.0.1.nip.io"` | Kubernetes cluster domain |
+| global.clusterEnv | string | `"${CLUSTER_ENV}"` | Environment (local, dev, qa, prod) |
+| global.clusterName | string | `"${CLUSTER_NAME}"` | Kubernetes cluster name |
+| global.name | string | `"aws-api-gateway-operator"` | Name of the application |
+| global.owner | string | `"SRE"` | Team which "owns" the application |
+| global.partOf | string | `"aws-api-gateway-operator"` | Top level application each deployment is a part of |
+| global.runtimeEnvironment | string | `"kubernetes"` | Global variable definint RUNTIME_ENVIRONMENT |
+| rbac | object | `{"create":true}` | Specifies whether rbac resources should be created |
+| standard-application-stack | object | `{"affinity":{"enabled":false,"podAntiAffinity":{"node":"soft","zone":"hard"}},"args":["--aws-region=${CLUSTER_REGION}","--zap-development-config=false"],"command":["/app/manager"],"configMaps":[],"env":[],"envFrom":[],"externalSecret":{"enabled":false},"extraContainers":[],"extraInitContainers":[],"extraPorts":[],"extraSecrets":[],"image":{"pullPolicy":"IfNotPresent","registry":"registry.gitlab.com","repository":"mintel/satoshi/tools/aws-api-gateway-operator","tag":"v1.0.2"},"imagePullSecrets":[],"ingress":{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","deregistrationDelay":{"timeoutSeconds":5},"enabled":false,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"preStopDelay":{"delaySeconds":15,"enabled":true},"scheme":"internet-facing"},"allowLivenessUrl":false,"allowReadinessUrl":false,"blackbox":{"enabled":true,"probePath":"/external-health-check"},"enabled":false,"extraAnnotations":{},"extraHosts":[],"specificRulesHostsYaml":{},"specificTlsHostsYaml":{},"tls":true},"liveness":{"enabled":true,"initialDelaySeconds":15,"methodOverride":{"httpGet":{"path":"/healthz","port":8081,"scheme":"HTTP"}},"path":"/healthz","periodSeconds":20,"startup":{"failureThreshold":60,"periodSeconds":5}},"metrics":{"additionalMonitors":[],"basicAuth":{"enabled":false,"passwordKey":"","secretName":"","usernameKey":""},"enabled":true},"minReadySeconds":10,"networkPolicy":{"additionalAllowFroms":[],"enabled":true},"persistentVolumes":null,"podAnnotations":{},"podDisruptionBudget":{"enabled":true,"minAvailable":"50%"},"podSecurityContext":{"runAsUser":1000},"port":9443,"priorityClassName":"infra","readiness":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"methodOverride":{"httpGet":{"path":"/readyz","port":8081,"scheme":"HTTP"}},"path":"/readyz","timeoutSeconds":3},"replicas":2,"resources":{"limits":{"cpu":"1","memory":"256Mi"},"requests":{"cpu":"5m","memory":"50Mi"}},"securityContext":{},"service":{"annotations":{},"enabled":true,"labels":{},"type":"ClusterIP"},"serviceAccount":{"annotations":{},"automountServiceAccountToken":true,"clusterRoles":[],"create":true,"irsa":{"enabled":true,"nameOverride":""},"name":"","roles":[]},"singleReplicaOnly":false,"strategy":{"maxSurge":"15%","maxUnavailable":"10%","type":"RollingUpdate"},"terminationGracePeriodSeconds":30,"topologySpreadConstraints":{"enabled":true,"node":{"enabled":null,"maxSkew":1},"specificYaml":null,"zone":{"enabled":true,"maxSkew":1}},"volumeMounts":[],"volumes":null}` | values for the standard-application-stack subchart |
+| standard-application-stack.affinity | object | `{"enabled":false,"podAntiAffinity":{"node":"soft","zone":"hard"}}` | Configure the deployment affinity/anti-affinity rules ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity |
+| standard-application-stack.affinity.enabled | bool | `false` | Set to true to enable deployment affinity rules |
+| standard-application-stack.affinity.podAntiAffinity | object | `{"node":"soft","zone":"hard"}` | Configure pod anti-affinity rules |
+| standard-application-stack.affinity.podAntiAffinity.node | string | `"soft"` | Toggle whether node affinity should be required (hard) or preferred (soft) |
+| standard-application-stack.affinity.podAntiAffinity.zone | string | `"hard"` | Toggle whether zone affinity should be required (hard) or preferred (soft) |
+| standard-application-stack.args | list | `["--aws-region=${CLUSTER_REGION}","--zap-development-config=false"]` | Optional arguments to the container |
+| standard-application-stack.command | list | `["/app/manager"]` | Optional command to the container |
+| standard-application-stack.configMaps | list | `[]` | A list of configuration maps for this application |
+| standard-application-stack.env | list | `[]` | Optional environment variables injected into the container |
+| standard-application-stack.envFrom | list | `[]` | Optional environment variables injected into the container using envFrom (secrets/configmaps) |
+| standard-application-stack.externalSecret | object | `{"enabled":false}` | Define ExternalSecret from AWS ref: https://github.com/external-secrets/kubernetes-external-secrets |
+| standard-application-stack.extraContainers | list | `[]` | Enable extraContainers (oauth2-proxy is a common example) |
+| standard-application-stack.extraInitContainers | list | `[]` | Enable extra init-containers |
+| standard-application-stack.extraPorts | list | `[]` | Optional list of extra container ports to configure |
+| standard-application-stack.image | object | `{"pullPolicy":"IfNotPresent","registry":"registry.gitlab.com","repository":"mintel/satoshi/tools/aws-api-gateway-operator","tag":"v1.0.2"}` | Docker image values |
+| standard-application-stack.image.pullPolicy | string | `"IfNotPresent"` | Optional ImagePullPolicy ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images |
+| standard-application-stack.image.registry | string | `"registry.gitlab.com"` | Docker registry used to pull application image |
+| standard-application-stack.image.repository | string | `"mintel/satoshi/tools/aws-api-gateway-operator"` | Docker repository |
+| standard-application-stack.image.tag | string | `"v1.0.2"` | Container image tag |
+| standard-application-stack.imagePullSecrets | list | `[]` | Optional array of imagePullSecrets ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
+| standard-application-stack.ingress | object | `{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","deregistrationDelay":{"timeoutSeconds":5},"enabled":false,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"preStopDelay":{"delaySeconds":15,"enabled":true},"scheme":"internet-facing"},"allowLivenessUrl":false,"allowReadinessUrl":false,"blackbox":{"enabled":true,"probePath":"/external-health-check"},"enabled":false,"extraAnnotations":{},"extraHosts":[],"specificRulesHostsYaml":{},"specificTlsHostsYaml":{},"tls":true}` | Configure the ingress resource that allows you to access the application from public-internet ref: http://kubernetes.io/docs/user-guide/ingress/ |
+| standard-application-stack.ingress.alb.backendProtocol | string | `"HTTP"` | Application Version (HTTP / HTTPS) |
+| standard-application-stack.ingress.alb.backendProtocolVersion | string | `"HTTP1"` | Application Protocol Version (HTTP1 / HTTP2 / GRPC) |
+| standard-application-stack.ingress.alb.healthcheck.healthyThresholdCount | int | `2` | Success threshold |
+| standard-application-stack.ingress.alb.healthcheck.intervalSeconds | int | `15` | Period seconds |
+| standard-application-stack.ingress.alb.healthcheck.protocol | string | `"HTTP"` | Healthcheck protocol |
+| standard-application-stack.ingress.alb.healthcheck.timeoutSeconds | int | `5` | Timeout seconds |
+| standard-application-stack.ingress.alb.healthcheck.unhealthyThresholdCount | int | `2` | Failure threshold |
+| standard-application-stack.ingress.alb.preStopDelay.delaySeconds | int | `15` | The delay (sleep) to wait for. IMPORTANT: The terminationGracePeriodSeconds must be greater than this. |
+| standard-application-stack.ingress.alb.preStopDelay.enabled | bool | `true` | Enable an additional delay when the container is shutdown of delaySeconds. This allows ALB to fully de-register the pod (allows zero-downtime rollouts) |
+| standard-application-stack.ingress.alb.scheme | string | `"internet-facing"` | Public or private alb (internet-facing / internal) |
+| standard-application-stack.ingress.allowLivenessUrl | bool | `false` | Set to true to allow the liveness URL through the ingress |
+| standard-application-stack.ingress.allowReadinessUrl | bool | `false` | Set to true to allow the readiness URL through the ingress |
+| standard-application-stack.ingress.blackbox | object | `{"enabled":true,"probePath":"/external-health-check"}` | Configures annotations defining blackbox endpoints |
+| standard-application-stack.ingress.blackbox.enabled | bool | `true` | Set to true to tell blackboxes to hit endpoint |
+| standard-application-stack.ingress.blackbox.probePath | string | `"/external-health-check"` | Endpoint for blackboxes to hit |
+| standard-application-stack.ingress.enabled | bool | `false` | Set to true to enable ingress record generation |
+| standard-application-stack.ingress.extraAnnotations | object | `{}` | Additional Ingress annotations For a full list of possible ingress annotations, please see ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md |
+| standard-application-stack.ingress.extraHosts | list | `[]` | List of extra ingress hosts to setup |
+| standard-application-stack.ingress.specificRulesHostsYaml | object | `{}` | Optional ingress Rules Hosts Yaml that doesn't fit standard pattern |
+| standard-application-stack.ingress.specificTlsHostsYaml | object | `{}` | Optional ingress Tls Hosts Yaml that doesn't fit standard pattern |
+| standard-application-stack.ingress.tls | bool | `true` | Enable TLS configuration for the hostname defined at ingress.hostname parameter |
+| standard-application-stack.liveness.methodOverride.httpGet.path | string | `"/healthz"` | Request path for readinessProbe |
+| standard-application-stack.liveness.methodOverride.httpGet.port | int | `8081` | Port for readinessProbe |
+| standard-application-stack.liveness.methodOverride.httpGet.scheme | string | `"HTTP"` | Scheme (HTTP or HTTPS) |
+| standard-application-stack.liveness.startup.failureThreshold | int | `60` | Failure threshold for startupProbe |
+| standard-application-stack.liveness.startup.periodSeconds | int | `5` | Perios seconds for startupProbe |
+| standard-application-stack.metrics | object | `{"additionalMonitors":[],"basicAuth":{"enabled":false,"passwordKey":"","secretName":"","usernameKey":""},"enabled":true}` | Prometheus Exporter / Metrics |
+| standard-application-stack.metrics.basicAuth | object | `{"enabled":false,"passwordKey":"","secretName":"","usernameKey":""}` | Scheme (HTTP ot HTTPS)  scheme: HTTP |
+| standard-application-stack.metrics.enabled | bool | `true` | Enable Prometheus to access aplpication metrics endpoints |
+| standard-application-stack.minReadySeconds | int | `10` | Minimum number of seconds before deployments are ready |
+| standard-application-stack.networkPolicy | object | `{"additionalAllowFroms":[],"enabled":true}` | Define a default NetworkPolicy for allowing apps in the same 'app.kubernetes.io/part-of' group to communicate with eachother. ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/ |
+| standard-application-stack.persistentVolumes | string | `nil` | A list of persistent volume claims to be added to the pod |
+| standard-application-stack.podAnnotations | object | `{}` | Additional annotations to apply to the pod |
+| standard-application-stack.podDisruptionBudget | object | `{"enabled":true,"minAvailable":"50%"}` | Pod Disruption Budget ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/ |
+| standard-application-stack.podSecurityContext | object | `{"runAsUser":1000}` | Pod Security context for the container ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
+| standard-application-stack.port | int | `9443` | Set port to null to skip adding container Ports |
+| standard-application-stack.priorityClassName | string | `"infra"` | Optional name of PriorityClass to run pods with |
+| standard-application-stack.readiness | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"methodOverride":{"httpGet":{"path":"/readyz","port":8081,"scheme":"HTTP"}},"path":"/readyz","timeoutSeconds":3}` | Configure extra options for readiness probe ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes |
+| standard-application-stack.readiness.methodOverride.httpGet.path | string | `"/readyz"` | Request path for readinessProbe |
+| standard-application-stack.readiness.methodOverride.httpGet.port | int | `8081` | Port for readinessProbe |
+| standard-application-stack.readiness.methodOverride.httpGet.scheme | string | `"HTTP"` | Scheme (HTTP or HTTPS) |
+| standard-application-stack.replicas | int | `2` | Desired number of replicas for main deployment |
+| standard-application-stack.resources | object | `{"limits":{"cpu":"1","memory":"256Mi"},"requests":{"cpu":"5m","memory":"50Mi"}}` | Container resource requests and limits ref: http://kubernetes.io/docs/user-guide/compute-resources |
+| standard-application-stack.securityContext | object | `{}` | Security context for the container ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
+| standard-application-stack.service | object | `{"annotations":{},"enabled":true,"labels":{},"type":"ClusterIP"}` | Kubernetes svc configutarion |
+| standard-application-stack.service.annotations | object | `{}` | Annotations to add to service |
+| standard-application-stack.service.enabled | bool | `true` | Whether to create Service resource or not |
+| standard-application-stack.service.labels | object | `{}` | Provide any additional labels which may be required. |
+| standard-application-stack.service.type | string | `"ClusterIP"` | Kubernetes Service type |
+| standard-application-stack.serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"clusterRoles":[],"create":true,"irsa":{"enabled":true,"nameOverride":""},"name":"","roles":[]}` | ServiceAccount parameters ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
+| standard-application-stack.serviceAccount.annotations | object | `{}` | Additional Service Account annotations |
+| standard-application-stack.serviceAccount.automountServiceAccountToken | bool | `true` | Whether to automount the service account token or not |
+| standard-application-stack.serviceAccount.clusterRoles | list | `[]` | Define list of ClusterRole's to create and bind to the service account ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/ |
+| standard-application-stack.serviceAccount.create | bool | `true` | Determine whether a Service Account should be created or it should reuse a exiting one. |
+| standard-application-stack.serviceAccount.irsa | object | `{"enabled":true,"nameOverride":""}` | Configures IRSA for the Service Account |
+| standard-application-stack.serviceAccount.irsa.enabled | bool | `true` | Determines whether service account is IRSA enabled |
+| standard-application-stack.serviceAccount.irsa.nameOverride | string | `""` | Override for last component of role-arn, ie: accountid-clusterName-namespace-{nameOverride} |
+| standard-application-stack.serviceAccount.name | string | `""` | ServiceAccount to use. A name is generated using the mintel_common.fullname template if it is not set |
+| standard-application-stack.serviceAccount.roles | list | `[]` | Define list of Role's to create and bind to the service account ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/ |
+| standard-application-stack.singleReplicaOnly | bool | `false` | Explicitly stating that a single replica is required Should only be used if the image truly can't be run multiple times usually involving third party apps or prometheus exporters, etc |
+| standard-application-stack.strategy | object | `{"maxSurge":"15%","maxUnavailable":"10%","type":"RollingUpdate"}` | Defines deployment update strategy |
+| standard-application-stack.strategy.maxSurge | string | `"15%"` | Optional argument to define maximum number of pods allowed over defined replicas |
+| standard-application-stack.strategy.maxUnavailable | string | `"10%"` | Optional argument to define maximum number of pods that can be unavailable during update |
+| standard-application-stack.strategy.type | string | `"RollingUpdate"` | Type of strategy to use (Recreate or RollingUpdate) |
+| standard-application-stack.terminationGracePeriodSeconds | int | `30` | Configure terminationGracePeriodSeconds ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/ |
+| standard-application-stack.topologySpreadConstraints.node.enabled | string | `nil` | Set this to true/false to override the default behaviour (enabled for prod only) |
+| standard-application-stack.topologySpreadConstraints.specificYaml | string | `nil` | Specify custom topologySpreadConstraints yaml |
+| standard-application-stack.volumeMounts | list | `[]` | A list of volume mounts to be added to the pod |
+| standard-application-stack.volumes | string | `nil` | A list of volumes to be added to the pod |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.7.0](https://github.com/norwoodj/helm-docs/releases/v1.7.0)

--- a/charts/aws-api-gateway-operator/crds/crd-awsapigateways.yaml
+++ b/charts/aws-api-gateway-operator/crds/crd-awsapigateways.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: awsapigateways.mintel.cloud
+spec:
+  group: mintel.cloud
+  names:
+    kind: AWSAPIGateway
+    listKind: AWSAPIGatewayList
+    plural: awsapigateways
+    singular: awsapigateway
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: AWSAPIGateway is the Schema for the awsapigateways API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AWSAPIGatewaySpec defines the desired state of AWSAPIGateway
+            properties:
+              api-id:
+                description: ID of the gateway to modify
+                type: string
+              open-api-yaml:
+                description: full yaml definition of the OpenAPI spec to apply, including aws extenstions
+                type: string
+              protocol:
+                description: '"rest" or "http"'
+                type: string
+            required:
+            - api-id
+            - open-api-yaml
+            - protocol
+            type: object
+          status:
+            description: AWSAPIGatewayStatus defines the observed state of AWSAPIGateway
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/aws-api-gateway-operator/templates/NOTES.txt
+++ b/charts/aws-api-gateway-operator/templates/NOTES.txt
@@ -1,0 +1,1 @@
+AWS API Gateway Operator installed!

--- a/charts/aws-api-gateway-operator/templates/_helpers.tpl
+++ b/charts/aws-api-gateway-operator/templates/_helpers.tpl
@@ -1,0 +1,75 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because sometimes Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "mintel_common.fullname" -}}
+{{- printf "%s" .Values.global.name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Common Annotations */}}
+{{- define "mintel_common.commonAnnotations" -}}
+helm.sh/chart: {{ include "mintel_common.chart" . }}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mintel_common.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* Common labels */}}
+{{- define "mintel_common.labels" -}}
+name: {{ include "mintel_common.fullname" . }}
+{{ include "mintel_common.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.owner }}
+app.mintel.com/owner: .Values.owner }}
+{{- else if (and .Values.global .Values.global.owner) }}
+app.mintel.com/owner: {{ .Values.global.owner }}
+{{- end }}
+app.mintel.com/env: {{ .Values.global.clusterEnv }}
+{{- if (eq .Values.global.clusterEnv "local") }}
+app.mintel.com/region: {{default "local" $.Values.global.clusterRegion }}
+{{- else }}
+app.mintel.com/region: {{default "${CLUSTER_REGION}" $.Values.global.clusterRegion }}
+{{- end }}
+{{- if .Values.global }}
+{{- with .Values.global.additionalLabels }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}
+{{- with .Values.additionalLabels }}
+{{- toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/* Selector labels */}}
+{{- define "mintel_common.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mintel_common.fullname" . }}
+{{- if .Values.partOf }}
+app.kubernetes.io/part-of: {{ .Values.partOf }}
+{{- else if (and .Values.global .Values.global.partOf) }}
+app.kubernetes.io/part-of: {{ .Values.global.partOf }}
+{{- end }}
+{{- if .component }}
+app.kubernetes.io/component: {{ .component }}
+{{- else if .Values.component }}
+app.kubernetes.io/component: {{ .Values.component }}
+{{- else }}
+app.kubernetes.io/component: app
+{{- end }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "aws-api-gateway-operator.serviceAccountName" -}}
+{{- if (index .Values "standard-application-stack" "serviceAccount" "create") -}}
+    {{ default (include "mintel_common.fullname" .) (index .Values "standard-application-stack" "serviceAccount" "name") }}
+{{- else -}}
+    {{ default "default" (index .Values "standard-application-stack" "serviceAccount" "name") }}
+{{- end -}}
+{{- end -}}

--- a/charts/aws-api-gateway-operator/templates/rbac.yaml
+++ b/charts/aws-api-gateway-operator/templates/rbac.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.rbac.create }}
+{{- $data := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "component" .name }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "mintel_common.fullname" (index .Subcharts "standard-application-stack") }}-leader-election-role
+  namespace: {{ .Release.Namespace }}
+  annotations: {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
+  labels: {{ include "mintel_common.labels" $data | nindent 4 }}
+
+rules:
+- apiGroups: [""]
+  resources: [configmaps]
+  verbs: [create]
+- apiGroups: [""]
+  resources: [configmaps]
+  resourceNames: [aws-api-gateway-operator-leader]
+  verbs: [get, patch, update]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "mintel_common.fullname" (index .Subcharts "standard-application-stack") }}-leader-election-rolebinding
+  namespace: {{ .Release.Namespace }}
+  annotations: {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
+  labels: {{ include "mintel_common.labels" $data | nindent 4 }}
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "mintel_common.fullname" (index .Subcharts "standard-application-stack") }}-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: {{ template "aws-api-gateway-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "mintel_common.fullname" (index .Subcharts "standard-application-stack") }}-role
+  annotations: {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
+  labels: {{ include "mintel_common.labels" $data | nindent 4 }}
+
+rules:
+- apiGroups: ["mintel.cloud"]
+  resources: [awsapigateways]
+  verbs: [create, delete, get, list, patch, update, watch]
+- apiGroups: [""]
+  resources: [events]
+  verbs: [create, patch]
+- apiGroups: [""]
+  resources: [pods]
+  verbs: [get, list, watch]
+- apiGroups: [""]
+  resources: [nodes, namespaces, endpoints]
+  verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "mintel_common.fullname" (index .Subcharts "standard-application-stack") }}-rolebinding
+  annotations: {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
+  labels: {{ include "mintel_common.labels" $data | nindent 4 }}
+
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "mintel_common.fullname" (index .Subcharts "standard-application-stack") }}-role
+subjects:
+- kind: ServiceAccount
+  name: {{ template "aws-api-gateway-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/aws-api-gateway-operator/tests/rbac_test.yaml
+++ b/charts/aws-api-gateway-operator/tests/rbac_test.yaml
@@ -1,0 +1,18 @@
+suite: test rbac
+templates:
+  - rbac.yaml
+tests:
+  - it: role can access awsapigateway objects
+    set:
+      image.tag: latest
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: rules[0].resources
+          value:
+            - awsapigateways
+      - equal:
+          path: rules[0].verbs
+          value: [create, delete, get, list, patch, update, watch]

--- a/charts/aws-api-gateway-operator/values.yaml
+++ b/charts/aws-api-gateway-operator/values.yaml
@@ -1,0 +1,433 @@
+# Default values for aws-api-gateway-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Global variables for us in all charts and sub charts
+global:
+  # -- Name of the application
+  name: "aws-api-gateway-operator"
+  # -- Team which "owns" the application
+  owner: "SRE"
+  # -- Top level application each deployment is a part of
+  partOf: "aws-api-gateway-operator"
+  # -- Additional labels to apply to all resources
+  additionalLabels: {}
+  # -- Kubernetes cluster domain
+  clusterDomain: "127.0.0.1.nip.io"
+  # -- Environment (local, dev, qa, prod)
+  clusterEnv: "${CLUSTER_ENV}"
+  # -- Kubernetes cluster name
+  clusterName: "${CLUSTER_NAME}"
+  # -- Global variables relating to cloud provider
+  cloudProvider:
+    # -- AWS Account Id
+    accountId: ""
+  # -- Global variable definint RUNTIME_ENVIRONMENT
+  runtimeEnvironment: kubernetes
+
+# -- Specifies whether rbac resources should be created
+rbac:
+  create: true
+
+###
+# standard-application-stack subchart
+###
+# -- values for the standard-application-stack subchart
+standard-application-stack:
+
+  # -- Minimum number of seconds before deployments are ready
+  minReadySeconds: 10
+
+  # -- Desired number of replicas for main deployment
+  replicas: 2
+
+  # -- Explicitly stating that a single replica is required
+  # Should only be used if the image truly can't be run multiple times
+  # usually involving third party apps or prometheus exporters, etc
+  singleReplicaOnly: false
+
+  # -- Docker image values
+  image:
+    # -- Docker registry used to pull application image
+    registry: "registry.gitlab.com"
+    # -- Docker repository
+    repository: "mintel/satoshi/tools/aws-api-gateway-operator"
+    # -- Container image tag
+    tag: "v1.0.2"
+    # -- Optional ImagePullPolicy
+    # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    pullPolicy: IfNotPresent
+
+  # -- Optional array of imagePullSecrets
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  imagePullSecrets: []
+
+  # -- Main container port for the application
+  # -- Set port to null to skip adding container Ports
+  port: 9443
+
+  # -- Optional list of extra container ports to configure
+  extraPorts: []
+  # extraPorts:
+  #   - name: ""
+  #     containerPort: 1234
+
+  # -- Optional command to the container
+  command:
+    - /app/manager
+
+  # -- Optional arguments to the container
+  args:
+    - '--aws-region=${CLUSTER_REGION}'      # AWS region for the operator (required).
+    - '--zap-development-config=false'      # Enable Zap Development mode (WARN logging).
+
+  # -- Optional environment variables injected into the container
+  env: []
+  # env:
+  #   - name: APP_ENVIRONMENT
+  #     value: dev
+
+  # -- Optional environment variables injected into the container using envFrom (secrets/configmaps)
+  envFrom: []
+
+  # -- Optional name of PriorityClass to run pods with
+  priorityClassName: infra
+
+  # -- Additional annotations to apply to the pod
+  podAnnotations: {}
+
+  # -- Pod Security context for the container
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  podSecurityContext:
+    runAsUser: 1000
+  #  fsGroup: 2000
+
+  # -- Pod Disruption Budget
+  # ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 50%
+  #  maxUnavailable: 50%
+
+  # -- Security context for the container
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  securityContext: {}
+  # securityContext:
+  #   allowPrivilegeEscalation: false
+  #   readOnlyRootFilesystem: true
+  #   capabilities:
+  #     drop: ["ALL"]
+  #   readOnlyRootFilesystem: true
+  #   runAsNonRoot: true
+  #   runAsUser: 1000
+
+  # -- Kubernetes svc configutarion
+  service:
+    # -- Whether to create Service resource or not
+    enabled: true
+    # -- Kubernetes Service type
+    type: ClusterIP
+    # -- Annotations to add to service
+    annotations: {}
+    # -- Provide any additional labels which may be required.
+    labels: {}
+
+  # -- ServiceAccount parameters
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+  serviceAccount:
+    # -- Determine whether a Service Account should be created or it should reuse a exiting one.
+    create: true
+    # -- ServiceAccount to use. A name is generated using the mintel_common.fullname template if it is not set
+    name: ""
+    # -- Additional Service Account annotations
+    annotations: {}
+    # -- Configures IRSA for the Service Account
+    irsa:
+      # -- Determines whether service account is IRSA enabled
+      enabled: true
+      # -- Override for last component of role-arn, ie: accountid-clusterName-namespace-{nameOverride}
+      nameOverride: ""
+    # -- Whether to automount the service account token or not
+    automountServiceAccountToken: true
+
+    # -- Define list of Role's to create and bind to the service account
+    # ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+    roles: []
+    #  - name: 'main'
+    #    rules:
+    #    - apiGroups: []
+    #      resources: []
+    #      verbs: []
+
+    # -- Define list of ClusterRole's to create and bind to the service account
+    # ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+    clusterRoles: []
+    #  - name: 'main'
+    #    rules:
+    #    - apiGroups: []
+    #      resources: []
+    #      verbs: []
+
+  # # -- Configure extra options for liveness probe
+  # # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  liveness:
+    enabled: true
+    methodOverride:
+      httpGet:
+        # -- Request path for readinessProbe
+        path: /healthz
+        # -- Port for readinessProbe
+        port: 8081
+        # -- Scheme (HTTP or HTTPS)
+        scheme: HTTP
+    path: /healthz
+    periodSeconds: 20
+    initialDelaySeconds: 15
+    startup:
+      # -- Failure threshold for startupProbe
+      failureThreshold: 60
+      # -- Perios seconds for startupProbe
+      periodSeconds: 5
+
+  # -- Configure terminationGracePeriodSeconds
+  # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/
+  terminationGracePeriodSeconds: 30
+
+  # -- Configure extra options for readiness probe
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+  readiness:
+    enabled: true
+    methodOverride:
+      httpGet:
+        # -- Request path for readinessProbe
+        path: /readyz
+        # -- Port for readinessProbe
+        port: 8081
+        # -- Scheme (HTTP or HTTPS)
+        scheme: HTTP
+    path: /readyz
+    timeoutSeconds: 3
+    failureThreshold: 3
+    initialDelaySeconds: 5
+
+  # -- Container resource requests and limits
+  # ref: http://kubernetes.io/docs/user-guide/compute-resources
+  resources:
+    limits:
+      cpu: "1"
+      memory: 256Mi
+    requests:
+      cpu: 5m
+      memory: 50Mi
+
+  # -- Prometheus Exporter / Metrics
+  metrics:
+    # -- Enable Prometheus to access aplpication metrics endpoints
+    enabled: true
+    # -- Interval at which metrics should be scraped
+    # ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    #  interval: 30s
+    # -- URL path to the metrics endpoint
+    #  path: /metrics
+    # -- Name of the port to use for metrics endpoint
+    #  port: http
+    # -- Timeout after which the scrape is ended
+    # ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+    #  timeout: 10s
+    # -- Scheme (HTTP ot HTTPS)
+    #  scheme: HTTP
+    basicAuth:
+      enabled: false
+      secretName: ""
+      usernameKey: ""
+      passwordKey: ""
+    additionalMonitors: []
+
+  # -- Define ExternalSecret from AWS
+  # ref: https://github.com/external-secrets/kubernetes-external-secrets
+  externalSecret:
+    enabled: false
+    #  nameOverride: ""
+    #  pathOverride: ""
+    #  secretRefreshIntervalOverride: ""
+    #  secretStoreRefOverride: ""
+    #  localValues:
+    #    - name: TEST_SECRET
+    #      value: test_value
+  extraSecrets: []
+  #  - name: ""
+  #    pathOverride: ""
+  #    pathSuffix: ""
+  #    refreshIntervalOverride: ""
+  #    secretStoreRefOverride: ""
+  #    includeInMain: true # defaults to true if not set
+  #    localValues: []
+
+  # -- A list of configuration maps for this application
+  configMaps: []
+  #    # -- Name of the config map
+  #  - name: ""
+  #    # -- Whether or not to create the configmap
+  #    create: false
+  #    # -- List of configs (files) within the configmap
+  #    configs:
+  #      - name: ""
+  #        data: ""
+
+  # -- A list of volumes to be added to the pod
+  volumes:
+    #  - configMap:
+    #      name: portal-web-something
+    #    name: portal-web-something
+
+  # -- A list of persistent volume claims to be added to the pod
+  persistentVolumes:
+    #  - name: brms-drools-workbench-niogit
+      #    mode: ReadWriteOnce
+      #    size: 100Mi
+
+  # -- A list of volume mounts to be added to the pod
+  volumeMounts: []
+
+  # -- Configure the ingress resource that allows you to access the application from public-internet
+  # ref: http://kubernetes.io/docs/user-guide/ingress/
+  ingress:
+    # -- Set to true to enable ingress record generation
+    enabled: false
+    # -- Additional Ingress annotations
+    # For a full list of possible ingress annotations, please see
+    # ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+    extraAnnotations: {}
+    # -- Enable TLS configuration for the hostname defined at ingress.hostname parameter
+    tls: true
+    # -- List of extra ingress hosts to setup
+    extraHosts: []
+    #  extraHosts:
+    #    - name: ""
+    #      path: ""
+    #      pathType: "Prefix"
+    #      serviceName: ""
+    #      servicePort: ""
+    # -- Optional, defines number of seconds to set server-timeout to
+    #  serverTimeoutSeconds: 10
+    # -- Set to true to allow the liveness URL through the ingress
+    allowLivenessUrl: false
+    # -- Set to true to allow the readiness URL through the ingress
+    allowReadinessUrl: false
+    # -- Configures annotations defining blackbox endpoints
+    blackbox:
+      # -- Set to true to tell blackboxes to hit endpoint
+      enabled: true
+      # -- Endpoint for blackboxes to hit
+      probePath: /external-health-check
+    # -- Optional ingress Rules Hosts Yaml that doesn't fit standard pattern
+    specificRulesHostsYaml: {}
+    # -- Optional ingress Tls Hosts Yaml that doesn't fit standard pattern
+    specificTlsHostsYaml: {}
+    alb:
+      enabled: false
+      # -- Public or private alb (internet-facing / internal)
+      scheme: internet-facing
+      # -- Application Version (HTTP / HTTPS)
+      backendProtocol: HTTP
+      # -- Application Protocol Version (HTTP1 / HTTP2 / GRPC)
+      backendProtocolVersion: HTTP1
+
+      deregistrationDelay:
+        timeoutSeconds: 5
+
+      preStopDelay:
+        # -- Enable an additional delay when the container is shutdown of delaySeconds.
+        # This allows ALB to fully de-register the pod (allows zero-downtime rollouts)
+        enabled: true
+        # -- The delay (sleep) to wait for.
+        # IMPORTANT: The terminationGracePeriodSeconds must be greater than this.
+        delaySeconds: 15
+
+      healthcheck:
+        # -- Healthcheck protocol
+        protocol: HTTP
+        # -- Healthcheck success codes
+        # successCodes: "200"
+        # -- Period seconds
+        intervalSeconds: 15
+        # -- Healthcheck Request path
+        # path: /readiness
+        # -- Port (defaults to port specified in Ingress used to direct traffic to service)
+        # port: "8000"
+        # -- Timeout seconds
+        timeoutSeconds: 5
+        # -- Failure threshold
+        unhealthyThresholdCount: 2
+        # -- Success threshold
+        healthyThresholdCount: 2
+
+  # -- Define a default NetworkPolicy for allowing apps in the same 'app.kubernetes.io/part-of' group to communicate
+  # with eachother.
+  # ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+  networkPolicy:
+    enabled: true
+    additionalAllowFroms: []
+    #    - fromName: 'brms-bridge'
+    #      toName: ''
+    #      toPorts: []
+    #        - port: 8080
+    #          protocol: TCP
+
+  # -- Enable extra init-containers
+  extraInitContainers: []
+
+  # -- Enable extraContainers (oauth2-proxy is a common example)
+  extraContainers: []
+  # extraContainers:
+  # - name: oauth2-proxy
+  #   image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.3
+  #   ...
+
+  # -- Defines deployment update strategy
+  strategy:
+    # -- Type of strategy to use (Recreate or RollingUpdate)
+    type: RollingUpdate
+    # -- Optional argument to define maximum number of pods allowed over defined replicas
+    maxSurge: 15%
+    # -- Optional argument to define maximum number of pods that can be unavailable during update
+    maxUnavailable: 10%
+
+  topologySpreadConstraints:
+    enabled: true
+    zone:
+      enabled: true
+      maxSkew: 1
+    node:
+      # -- Set this to true/false to override the default behaviour (enabled for prod only)
+      enabled:
+      maxSkew: 1
+    # -- Specify custom topologySpreadConstraints yaml
+    specificYaml:
+
+  # -- Configure the deployment affinity/anti-affinity rules
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+  affinity:
+    # -- Set to true to enable deployment affinity rules
+    enabled: false
+    # -- Configure pod anti-affinity rules
+    podAntiAffinity:
+      # -- Toggle whether zone affinity should be required (hard) or preferred (soft)
+      zone: hard
+      # -- Toggle whether node affinity should be required (hard) or preferred (soft)
+      node: soft
+      # -- Optional weight to apply to soft affinity
+      #    weight: 200
+    # -- Specify custom affinity yaml
+    #  specificYaml:
+    #    podAntiAffinity:
+    #      preferredDuringSchedulingIgnoredDuringExecution:
+    #      - podAffinityTerm:
+    #          labelSelector:
+    #            matchExpressions:
+    #            - key: app.kubernetes.io/name
+    #              operator: In
+    #              values:
+    #              - portal-web
+    #          topologyKey: topology.kubernetes.io/zone
+    #        weight: 100


### PR DESCRIPTION
add helm chart for `aws-api-gateway-operator`

this was tested on a local k3d cluster and worked successfully

this is a refactor of https://github.com/mintel/helm-charts/pull/134, which now uses the standard-application-stack helm chart as the basis for the app. This adds the CRD for the api gateways and cluster roles to watch for changes to resources created using that CRD.