### PR TITLE
Bump S3 refs:

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [v0.16.0] - 2022-06-27
+### Added
+- Add shortened name label to deal with char limit
+
 ### Fixed
 - Bump default s3, rds and opensearch versions to deliver new S3 versioning fix
 

--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.16.0] - 2022-06-27
+### Fixed
+- Bump default s3, rds and opensearch versions to deliver new S3 versioning fix
+
 ## [v0.15.1] - 2022-06-27
 ### Fixed
 - Bumped version of opensearch module to fixed version

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.1
+version: 0.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 
@@ -37,7 +37,7 @@ A Helm chart for provisioning resources using Terraform Cloud
 | mariadb.terraform.defaultVars.port | int | `3306` | MariaDB port |
 | mariadb.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | mariadb.terraform.module.source | string | `"app.terraform.io/Mintel/rds/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds/aws) |
-| mariadb.terraform.module.version | string | `"0.1.0-beta.2"` | Module version |
+| mariadb.terraform.module.version | string | `"0.1.0-beta.3"` | Module version |
 | memcached.enabled | bool | `false` | Set to true to create a memcached Elasticache resource |
 | memcached.terraform.defaultVars | object | See below | Vars to be applied to all instances defined below |
 | memcached.terraform.defaultVars.instance_type | string | `"cache.t4g.micro"` | EC2 instance type to use (https://aws.amazon.com/elasticache/pricing) |
@@ -49,7 +49,7 @@ A Helm chart for provisioning resources using Terraform Cloud
 | opensearch.terraform.defaultVars | string | `nil` | Vars to be applied to all instances defined below |
 | opensearch.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | opensearch.terraform.module.source | string | `"app.terraform.io/Mintel/opensearch/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/opensearch/aws) |
-| opensearch.terraform.module.version | string | `"0.1.0-beta.5"` | Module version |
+| opensearch.terraform.module.version | string | `"0.1.0-beta.6"` | Module version |
 | postgresql.enabled | bool | `false` | Set to true to create a PostgreSQL RDS instance |
 | postgresql.terraform.defaultVars | object | See below | Vars to be applied to all instances defined below |
 | postgresql.terraform.defaultVars.engine | string | `"postgres"` | Database engine to use (should always be "postgres") |
@@ -57,7 +57,7 @@ A Helm chart for provisioning resources using Terraform Cloud
 | postgresql.terraform.defaultVars.port | int | `5432` | PostgreSQL port |
 | postgresql.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | postgresql.terraform.module.source | string | `"app.terraform.io/Mintel/rds/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds/aws) |
-| postgresql.terraform.module.version | string | `"0.1.0-beta.2"` | Module version |
+| postgresql.terraform.module.version | string | `"0.1.0-beta.3"` | Module version |
 | redis.enabled | bool | `false` | Set to true to create a Redis Elasticache resource |
 | redis.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | redis.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |

--- a/charts/terraform-cloud/templates/helpers/_workspace-output-secret.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace-output-secret.yaml
@@ -8,7 +8,9 @@ apiVersion: external-secrets.io/v1alpha1
 kind: ExternalSecret
 metadata:
   name: "{{ .name | kebabcase }}-{{ $resourceType | kebabcase }}"
-  labels: {{ include "mintel_common.labels" $ | nindent 4 }}
+  labels:
+    name: {{ printf "%s-%s" (.name | kebabcase) ($resourceType | kebabcase) | trunc 63 }}
+    {{ include "mintel_common.labels" $ | nindent 4 }}
   namespace: {{ $.Release.Namespace | quote }}
   annotations:
     {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}

--- a/charts/terraform-cloud/templates/helpers/_workspace.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace.yaml
@@ -13,7 +13,9 @@ kind: Workspace
 metadata:
   name: {{ default (include "mintel_common.terraform_cloud.workspaceName" $workspaceDict | trim | quote) $instanceCfg.workspaceNameOverride }}
   namespace: {{ $.Release.Namespace | quote }}
-  labels: {{ include "mintel_common.labels" $ | nindent 4 }}
+  labels:
+    {{ include "mintel_common.labels" $ | nindent 4 }}
+    name: {{ printf "%s-%s" ($instanceCfg.name | kebabcase) ($resourceType | kebabcase) | trunc 63 }}
   annotations:
     {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}
     {{- if (eq $resourceType "irsa") }}

--- a/charts/terraform-cloud/tests/workspace_test.yaml
+++ b/charts/terraform-cloud/tests/workspace_test.yaml
@@ -4,6 +4,20 @@ templates:
 release:
   namespace: test-namespace
 tests:
+  - it: Dev S3 module name label override
+    set:
+      global.name: mntl-test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      s3:
+        enabled: true
+      asserts:
+        - equal:
+            path: metadata.labels.name
+            value: mntl-test-app-s3
   - it: Dev S3 module workspace name override
     set:
       global.name: mntl-test-app

--- a/charts/terraform-cloud/values.yaml
+++ b/charts/terraform-cloud/values.yaml
@@ -152,7 +152,7 @@ mariadb:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds/aws)
       source: app.terraform.io/Mintel/rds/aws
       # -- Module version
-      version: "0.1.0-beta.2"
+      version: "0.1.0-beta.3"
     # -- Vars to be applied to all instances defined below
     # @default -- See below
     defaultVars:
@@ -210,7 +210,7 @@ opensearch:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/opensearch/aws)
       source: app.terraform.io/Mintel/opensearch/aws
       # -- Module version
-      version: "0.1.0-beta.5"
+      version: "0.1.0-beta.6"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       ### Set to override the generated workspace name for example if the generated name is above the char limit
@@ -236,7 +236,7 @@ postgresql:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds/aws)
       source: app.terraform.io/Mintel/rds/aws
       # -- Module version
-      version: "0.1.0-beta.2"
+      version: "0.1.0-beta.3"
     # -- Vars to be applied to all instances defined below
     # @default -- See below
     defaultVars:


### PR DESCRIPTION
- Bump default s3, rds and opensearch versions to deliver new S3 versioning fix