### PR TITLE
Fix k8s label / name restrictions

### DIFF
--- a/charts/hybrid-consul-config-crds/Chart.yaml
+++ b/charts/hybrid-consul-config-crds/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2

--- a/charts/hybrid-consul-config-crds/README.md
+++ b/charts/hybrid-consul-config-crds/README.md
@@ -1,6 +1,6 @@
 # hybrid-consul-config-crds
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for defining Consul CRDs
 

--- a/charts/hybrid-consul-config-crds/templates/intention.yaml
+++ b/charts/hybrid-consul-config-crds/templates/intention.yaml
@@ -3,7 +3,7 @@
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: ServiceIntentions
 metadata:
-  name: {{ .name }}
+  name: {{ .name | replace "+" "_" | trunc 63 | trimSuffix "-" }}
   namespace: {{ $.Release.Namespace }}
 spec:
   destination:

--- a/charts/hybrid-consul-config-crds/templates/terminating-gateway.yaml
+++ b/charts/hybrid-consul-config-crds/templates/terminating-gateway.yaml
@@ -3,7 +3,7 @@
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: TerminatingGateway
 metadata:
-  name: {{ default "terminating-gateway" .terminatingGatewayNameOverride }}
+  name: {{ default "terminating-gateway" .terminatingGatewayNameOverride | replace "+" "_" | trunc 63 | trimSuffix "-" }}
   namespace: {{ $.Release.Namespace }}
 spec:
   services:


### PR DESCRIPTION
Mostly catches the limit of 63 chars - applies to `ServiceIntentions` and `TerminatinyGateways`