### PR TITLE
Fix basic-config service.selectorLabelsOverride reference

### DIFF
--- a/charts/basic-config/CHANGELOG.md
+++ b/charts/basic-config/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.1.1] - 2022-07-08
+### Fixed
+- Fixed `Service.selectorLabelsOverride` reference
+
 ## [v0.1.0] - 2022-07-04
 ### Added
 - Added service template

--- a/charts/basic-config/Chart.yaml
+++ b/charts/basic-config/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1

--- a/charts/basic-config/README.md
+++ b/charts/basic-config/README.md
@@ -1,6 +1,6 @@
 # basic-config
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for defining basic k8s configuration res
 

--- a/charts/basic-config/templates/service.yaml
+++ b/charts/basic-config/templates/service.yaml
@@ -16,5 +16,5 @@ spec:
   clusterIP: None
   {{- end }}
   type: {{ .Values.service.type }}
-  selector: {{ default (include "mintel_common.selectorLabels" .) .Values.selectorLabelsOverride | nindent 6 }}
+  selector: {{ default (include "mintel_common.selectorLabels" .) .Values.service.selectorLabelsOverride | nindent 6 }}
 {{- end }}


### PR DESCRIPTION
Should reference the value under the `service` key rather than directly on `.Values`.