### PR TITLE
Make AWS ALB the default Ingress

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.38.0] - 2022-08-12
+### Changed
+- Make AWS ALB (`alb-public-apps-default`) the default Ingress
+
 ## [v3.37.1] - 2022-08-02
 ### Fixed
 - Stopped VPA template applying to local environment

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.37.1
+version: 3.38.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.37.0](https://img.shields.io/badge/Version-3.37.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.38.0](https://img.shields.io/badge/Version-3.38.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -123,7 +123,7 @@ A generic chart to support most common application requirements
 | image.repository | string | `"test"` | Docker repository |
 | image.tag | string | `"auto-replaced"` | Container image tag |
 | imagePullSecrets | list | `[]` | Optional array of imagePullSecrets ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
-| ingress | object | `{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","deregistrationDelay":{"timeoutSeconds":5},"enabled":false,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"preStopDelay":{"delaySeconds":15,"enabled":true},"scheme":"internet-facing"},"allowLivenessUrl":false,"allowReadinessUrl":false,"blackbox":{"enabled":true,"probePath":"/external-health-check"},"enabled":false,"extraAnnotations":{},"extraHosts":[],"specificRulesHostsYaml":{},"specificTlsHostsYaml":{},"tls":true}` | Configure the ingress resource that allows you to access the application from public-internet ref: http://kubernetes.io/docs/user-guide/ingress/ |
+| ingress | object | `{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","deregistrationDelay":{"timeoutSeconds":5},"enabled":true,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"preStopDelay":{"delaySeconds":15,"enabled":true},"scheme":"internet-facing"},"allowLivenessUrl":false,"allowReadinessUrl":false,"blackbox":{"enabled":true,"probePath":"/external-health-check"},"enabled":false,"extraAnnotations":{},"extraHosts":[],"specificRulesHostsYaml":{},"specificTlsHostsYaml":{},"tls":true}` | Configure the ingress resource that allows you to access the application from public-internet ref: http://kubernetes.io/docs/user-guide/ingress/ |
 | ingress.alb.backendProtocol | string | `"HTTP"` | Application Version (HTTP / HTTPS) |
 | ingress.alb.backendProtocolVersion | string | `"HTTP1"` | Application Protocol Version (HTTP1 / HTTP2 / GRPC) |
 | ingress.alb.healthcheck.healthyThresholdCount | int | `2` | Success threshold |

--- a/charts/standard-application-stack/templates/helpers/_deployment.yaml
+++ b/charts/standard-application-stack/templates/helpers/_deployment.yaml
@@ -12,21 +12,20 @@ shutdown and helps achieve zero downtime rollouts.
 Note, this cannot be used in conjunction with a custom lifecycle rule.
 */}}
 {{- define "mintel_common.deployment.lifecycle" -}}
-{{- with .Values.ingress.alb }}
-{{- if (and .enabled .preStopDelay.enabled ) }}
+{{- with .Values.ingress }}
+{{- if (and .enabled (and .alb.enabled .alb.preStopDelay.enabled )) }}
 lifecycle:
   preStop:
     exec:
       command:
         - '/bin/sh'
         - '-c'
-        - {{ printf "echo 'Called preStop hook with %ds delay' > /proc/1/fd/1 ; sleep %d ; Completed preStop hook" (.preStopDelay.delaySeconds|int) (.preStopDelay.delaySeconds|int) }}
+        - {{ printf "echo 'Called preStop hook with %ds delay' > /proc/1/fd/1 ; sleep %d ; Completed preStop hook" (.alb.preStopDelay.delaySeconds|int) (.alb.preStopDelay.delaySeconds|int) }}
 {{- else }}
 {{- if $.Values.lifecycle }}
 lifecycle:
 {{ toYaml $.Values.lifecycle | nindent 10 }}
 {{- end }}
-
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/standard-application-stack/tests/deployment_lifecycle_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_lifecycle_test.yaml
@@ -33,6 +33,14 @@ tests:
     asserts:
       - isNull:
           path: spec.template.spec.containers[0].lifecycle
+  - it: Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disabled)
+    set:
+      global.clusterEnv: qa
+      ingress.enabled:  false
+      ingress.alb.enabled: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].lifecycle
   - it: Check lifecycle rules
     set:
       global.clusterEnv: qa

--- a/charts/standard-application-stack/tests/ingress_test.yaml
+++ b/charts/standard-application-stack/tests/ingress_test.yaml
@@ -4,24 +4,24 @@ templates:
 release:
   namespace: test-namespace
 tests:
-  - it: Check HAProxy className set by default
+  - it: Check ALB className set by default
     set:
       global.clusterEnv: qa
       ingress.enabled: true
-    asserts:
-      - equal:
-          path: spec.ingressClassName
-          value: haproxy
-
-  - it: Check ALB className set if enabled
-    set:
-      global.clusterEnv: qa
-      ingress.enabled: true
-      ingress.alb.enabled: true
     asserts:
       - equal:
           path: spec.ingressClassName
           value: alb-public-apps-default
+
+  - it: Check HAProxy className set if ALB is disabled
+    set:
+      global.clusterEnv: qa
+      ingress.enabled: true
+      ingress.alb.enabled: false
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: haproxy
 
   - it: Check ALB default health-check port
     set:

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -384,7 +384,7 @@ ingress:
   # -- Optional ingress Tls Hosts Yaml that doesn't fit standard pattern
   specificTlsHostsYaml: {}
   alb:
-    enabled: false
+    enabled: true
     # -- Public or private alb (internet-facing / internal)
     scheme: internet-facing
     # -- Application Version (HTTP / HTTPS)


### PR DESCRIPTION
Nearly all our apps use AWS ALB instead of HAProxy, so make it the default

- Adjust unit-tests
- Added extra checks around lifecycle hook for ALB (make sure both ingress.enabled and ingress.alb.enabled are set)