### PR TITLE
Add support for ALB Service Owner annotation

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.39.0] - 2022-08-12
+### Added
+- Added support for ALB Owner label being set on `Service
+- Added extra `Service` unit-tests
+
 ## [v3.38.0] - 2022-08-12
 ### Changed
 - Make AWS ALB (`alb-public-apps-default`) the default Ingress

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.38.0
+version: 3.39.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.38.0](https://img.shields.io/badge/Version-3.38.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.39.0](https://img.shields.io/badge/Version-3.39.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/service.yaml
+++ b/charts/standard-application-stack/templates/service.yaml
@@ -9,6 +9,10 @@ metadata:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
     {{- if .Values.service.annotations }}
     {{ toYaml .Values.service.annotations | nindent 4 }}
+    {{ toYaml .Values.service.annotations | nindent 4 }}
+    {{- end }}
+    {{- if (and .Values.global.owner (and .Values.ingress.enabled .Values.ingress.alb.enabled)) }}
+    'alb.ingress.kubernetes.io/tags': 'Owner={{.Values.global.owner}}'
     {{- end }}
 spec:
   ports:

--- a/charts/standard-application-stack/tests/service_test.yaml
+++ b/charts/standard-application-stack/tests/service_test.yaml
@@ -24,7 +24,7 @@ tests:
           path: metadata.labels.[name]
           value: test-app
 
-  - it: Check default port set 
+  - it: Check default port set
     set:
       global.name: test-app
       component: exporter
@@ -98,7 +98,7 @@ tests:
     set:
       global.name: test-app
       global.owner: my-team
-      ingress.enabled: true 
+      ingress.enabled: true
       ingress.alb.enabled: false
     asserts:
       - isKind:
@@ -109,7 +109,7 @@ tests:
   - it: Check ALB annotation not set when when Owner missing
     set:
       global.name: test-app
-      ingress.enabled: true 
+      ingress.enabled: true
       ingress.alb.enabled: false
     asserts:
       - isKind:

--- a/charts/standard-application-stack/tests/service_test.yaml
+++ b/charts/standard-application-stack/tests/service_test.yaml
@@ -4,25 +4,7 @@ templates:
 release:
   namespace: test-namespace
 tests:
-  - it: Sets name
-    set:
-      global.name: test-app
-    asserts:
-      - isKind:
-          of: Service
-      - equal:
-          path: metadata.namespace
-          value: test-namespace
-      - equal:
-          path: metadata.name
-          value: test-app
-      - equal:
-          path: metadata.labels.[app.kubernetes.io/name]
-          value: test-app
-      - equal:
-          path: metadata.labels.[name]
-          value: test-app
-  - it: Sets name and component
+  - it: Check name, namespace and labels
     set:
       global.name: test-app
       component: exporter
@@ -41,3 +23,96 @@ tests:
       - equal:
           path: metadata.labels.[name]
           value: test-app
+
+  - it: Check default port set 
+    set:
+      global.name: test-app
+      component: exporter
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].port
+          value: 8000
+
+  - it: Check port can be overridden
+    set:
+      global.name: test-app
+      component: exporter
+      port: 1234
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].port
+          value: 1234
+
+  - it: Check extraPorts
+    set:
+      global.name: test-app
+      component: exporter
+      extraPorts:
+        - name: p1
+          containerPort: 8081
+        - name: p2
+          containerPort: 8082
+        - name: p3
+          containerPort: 8083
+          containerName: custom
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[1].name
+          value: main-p1
+      - equal:
+          path: spec.ports[1].port
+          value: 8081
+      - equal:
+          path: spec.ports[2].name
+          value: main-p2
+      - equal:
+          path: spec.ports[2].port
+          value: 8082
+          path: spec.ports[3].name
+          value: custom-p3
+      - equal:
+          path: spec.ports[3].port
+          value: 8083
+
+  - it: Check ALB annotation can be set when enabled
+    set:
+      global.name: test-app
+      global.owner: my-team
+      global.clusterEnv: qa
+      ingress.enabled: true
+      ingress.alb.enabled: true
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.annotations.[alb.ingress.kubernetes.io/tags]
+          value: Owner=my-team
+
+  - it: Check ALB annotation not set when ALB Ingress is disabled
+    set:
+      global.name: test-app
+      global.owner: my-team
+      ingress.enabled: true 
+      ingress.alb.enabled: false
+    asserts:
+      - isKind:
+          of: Service
+      - isNull:
+          path: metadata.annotations.[alb.ingress.kubernetes.io/tags]
+
+  - it: Check ALB annotation not set when when Owner missing
+    set:
+      global.name: test-app
+      ingress.enabled: true 
+      ingress.alb.enabled: false
+    asserts:
+      - isKind:
+          of: Service
+      - isNull:
+          path: metadata.annotations.[alb.ingress.kubernetes.io/tags]


### PR DESCRIPTION
See https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/ingress/annotations/#ingress-annotations

Annotations on the `Service` have higher priority than on the `Ingress`. We cannot set the `Owner` label on the `Ingress` because that ends up adding it to the LB (which is a shared resource).

We can set the `Owner` tag on the `Service` which will propagate through to the `TargetGroup` (which is specific for each app). At this point we can scrape metrics which return the health of the `TargetGroup`, and provide access to the `Owner` label (via a join to `aws_applicationelb_info`)

---

Also added a bunch of `Service` tests.