### PR TITLE
Cpt 1530 handle pdb and replias when autoscaling

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v3.41.0] - 2022-99-05
+## [v3.42.0] - 2022-09-14
+### Added
+- When autoscaling is enabled, drop PodDisruptionBudget when minReplcaCount is set to 1
+
+### Fixed
+- Fixed date on previous changelog entry
+
+## [v3.41.0] - 2022-09-13
 ### Added
 - Added support for https://keda.sh to handle autoscaling
 

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added extra tests around autoscaling/pdbs
 
 ### Fixed
+- Fixed celery PodDisruptionBudget to only check for `celery.podDisruptionBudget.enabled`
 - Fixed date on previous changelog entry
 
 ## [v3.41.0] - 2022-09-13

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v3.42.0] - 2022-09-14
 ### Added
-- Added extra support for autoscaling (conditionally drop pod-disruption-budget and setting of replicas)
+- Added extra support for autoscaling (conditionally drop pdbs and setting of replicas)
+- Added extra tests around autoscaling/pdbs
 
 ### Fixed
 - Fixed date on previous changelog entry

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v3.42.0] - 2022-09-14
 ### Added
-- When autoscaling is enabled, drop PodDisruptionBudget when minReplcaCount is set to 1
+- Added extra support for autoscaling (conditionally drop pod-disruption-budget and setting of replicas)
 
 ### Fixed
 - Fixed date on previous changelog entry

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.41.0
+version: 3.42.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.41.0](https://img.shields.io/badge/Version-3.41.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.42.0](https://img.shields.io/badge/Version-3.42.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -49,10 +49,12 @@ spec:
   minReadySeconds: {{ . }}
   {{- end }}
   {{- end }}
+  {{- if not .Values.autoscaling.enabled }}
   {{- if .Values.singleReplicaOnly }}
   replicas: 1
   {{- else }}
   replicas: {{ .Values.replicas }}
+  {{- end }}
   {{- end }}
   selector:
     matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 6 }}

--- a/charts/standard-application-stack/templates/helpers/_pdb.yaml
+++ b/charts/standard-application-stack/templates/helpers/_pdb.yaml
@@ -1,0 +1,21 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+Helpers to determine if PodDisruptionBudgets should be enabled
+*/}}
+
+{{- define "mintel_common.pdb.createPDB" -}}
+{{- $createPDB := "false" }}
+{{- if .Values.podDisruptionBudget.enabled }}
+  {{- if .Values.autoscaling.enabled }}
+    {{- if (gt (.Values.autoscaling.minReplicaCount | int) 1) }}
+      {{- $createPDB = "true" }}
+    {{- end }}
+  {{- else }}
+    {{- if (gt (.Values.replicas | int) 1) }}
+      {{- $createPDB = "true" }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{ $createPDB }}
+{{- end }}

--- a/charts/standard-application-stack/templates/pdbs.yaml
+++ b/charts/standard-application-stack/templates/pdbs.yaml
@@ -1,4 +1,4 @@
-{{- if (and (gt (.Values.replicas | int) 1) .Values.podDisruptionBudget.enabled) }}
+{{- if eq ((include "mintel_common.pdb.createPDB" .) | trim) "true" }}
 {{- if eq .Values.cronjobsOnly false }}
 ---
 apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}

--- a/charts/standard-application-stack/templates/pdbs.yaml
+++ b/charts/standard-application-stack/templates/pdbs.yaml
@@ -18,6 +18,7 @@ spec:
   selector:
     matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 6 }}
 {{- end }}
+{{- end }}
 
 {{- if (and .Values.celery .Values.celery.enabled) }}
 {{- if (and (gt (.Values.celery.replicas | int) 1) .Values.celery.podDisruptionBudget.enabled) }}
@@ -39,6 +40,5 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{ include "mintel_common.selectorLabels" $data | nindent 6 }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/standard-application-stack/tests/deployment_replicas_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_replicas_test.yaml
@@ -1,9 +1,16 @@
-suite: Test Deployment Single Replica Logic
+suite: Test Deployment Replica Logic
 templates:
   - deployment.yaml
 release:
   namespace: test-namespace
 tests:
+  - it: Check replicas unset when autoscaling is enabled
+    set:
+      global.clusterEnv: qa
+      autoscaling.enabled: true
+    asserts:
+      - isNull:
+          path: spec.replicas
   - it: Check singleReplicaOnly applied
     set:
       global.clusterEnv: qa

--- a/charts/standard-application-stack/tests/pdb_test.yaml
+++ b/charts/standard-application-stack/tests/pdb_test.yaml
@@ -1,0 +1,50 @@
+suite: Test Pod Disruption Budgets
+templates:
+  - pdbs.yaml
+release:
+  namespace: test-namespace
+tests:
+  - it: Creates a PDB when replicas > 1
+    set:
+      global.clusterEnv: qa
+      replicas: 2
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: example-app
+
+  - it: Does not create a PDB when replicas = 1
+    set:
+      global.clusterEnv: qa
+      replicas: 1
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Creates a PDB when autoscaling is disabled and autoscaling.minReplicaCount is set
+    set:
+      global.clusterEnv: qa
+      autoscaling.enabled: false
+      autoscaling.minReplicaCount: 2
+    asserts:
+      - isKind:
+          of: PodDisruptionBudget
+      - hasDocuments:
+          count: 1
+
+  - it: Does not create a PDB when autoscaling.minReplicaCount  = 1 and autoscaling is enabled
+    set:
+      global.clusterEnv: qa
+      replicas: 2
+      autoscaling.enabled: true
+      autoscaling.minReplicaCount: 1
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## Autoscaling
- Avoid setting `spec.replicas` when autoscaling is enabled (HPA manages this)
- Avoid creating a pod-disruption-budget when `autoscaling.minReplicaCount` < 2 (similar to `spec.replicas` behaviour)
  - i.e. If there's only 1 pod, there's no point in having a PDB created
  -  Introduced dedicated helper for this 
- Added extra tests
## Celery PDB Fix

Previously the celery pdb enabling/disabling was also controlled by the main workloads `podDisruptionBudget.enabled` flag. 

Pretty sure this is a bug, so I've removed this.