### PR TITLE
Adding extra helpers for keda

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.46.0] - 2022-09-26
+### Added
+- Added Keda `enableZeroReplicas` option
+- Added Keda AWS trigger handling for `awsRegion` and `identityOwner` vars
+
 ## [v3.45.0] - 2022-09-21
 ### Added
 - Added support for multiple ingresses per app

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v3.46.0] - 2022-09-26
 ### Added
 - Added Keda `enableZeroReplicas` option
-- Added Keda AWS trigger handling for `awsRegion` and `identityOwner` vars
+- Added Keda AWS trigger default handling for `awsRegion` and `identityOwner`
+- Added Keda Prometheus trigger default handling for `serverAddress`
 
 ## [v3.45.0] - 2022-09-21
 ### Added

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.45.0
+version: 3.46.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.45.0](https://img.shields.io/badge/Version-3.45.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.46.0](https://img.shields.io/badge/Version-3.46.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -29,7 +29,7 @@ A generic chart to support most common application requirements
 | affinity.podAntiAffinity.zone | string | `"hard"` | Toggle whether zone affinity should be required (hard) or preferred (soft) |
 | allowSingleReplica | bool | `false` | Explicitly allow the number of replicas to equal 1 Useful for backend event based services where we may only want a single replica but still want rolling updates etc |
 | args | list | `[]` | Optional arguments to the container |
-| autoscaling | object | `{"advanced":{},"cooldownPeriod":300,"enabled":false,"fallback":{"failureThreshold":3,"replicas":2},"maxReplicaCount":5,"minReplicaCount":2,"pollingInterval":30,"scaleTargetRef":{"apiVersion":"apps/v1","envSourceContainerName":"","kind":"Deployment"},"triggers":{}}` | Handle autoscaling via https://keda.sh Creates a ScaledObject for the workload ref: https://keda.sh/docs/2.8/concepts/scaling-deployments/ |
+| autoscaling | object | `{"advanced":{},"cooldownPeriod":300,"enableZeroReplicas":false,"enabled":false,"fallback":{"failureThreshold":3,"replicas":2},"maxReplicaCount":5,"minReplicaCount":2,"pollingInterval":30,"scaleTargetRef":{"apiVersion":"apps/v1","envSourceContainerName":"","kind":"Deployment"},"triggers":{}}` | Handle autoscaling via https://keda.sh Creates a ScaledObject for the workload ref: https://keda.sh/docs/2.8/concepts/scaling-deployments/ |
 | celery | object | `{"args":["celery"],"enabled":false,"liveness":{"enabled":false},"metrics":{"enabled":true},"podDisruptionBudget":{"enabled":true,"minAvailable":"50%"},"readiness":{"enabled":false},"replicas":2,"resources":{"limits":{},"requests":{}},"startup":{"failureThreshold":60,"methodOverride":{},"periodSeconds":5}}` | Configure celery deployment Defaults to same image as main deployment but with the "celery" argument |
 | celery.args | list | `["celery"]` | Arguments to the celery container |
 | celery.enabled | bool | `false` | Set to true to enable a celery deployment |

--- a/charts/standard-application-stack/templates/helpers/_ingress.yaml
+++ b/charts/standard-application-stack/templates/helpers/_ingress.yaml
@@ -157,4 +157,3 @@ alb.ingress.kubernetes.io/unhealthy-threshold-count: "{{ default 2 .alb.healthch
 {{- define "mintel_common.ingressLabels" -}}
 {{ include "mintel_common.labels" . | replace (include "mintel_common.fullname" .) (include "mintel_common.ingressName" .)}}
 {{- end -}}
-

--- a/charts/standard-application-stack/templates/keda-scaled-object.yaml
+++ b/charts/standard-application-stack/templates/keda-scaled-object.yaml
@@ -58,10 +58,13 @@ spec:
   {{- range .custom  }}
   - type: {{ .type }}
     metadata:
+    {{- if and (not (hasKey .metadata  "serverAddress")) (eq "prometheus" .type) }}
+      serverAddress: 'http://prometheus-k8s.monitoring.svc:9090'
+    {{- end }}
     {{- if and (not (hasKey .metadata  "identityOwner")) (hasPrefix "aws-" .type) }}
       identityOwner: 'operator'
     {{- end }}
-    {{- if not (hasKey .metadata "awsRegion") }}
+    {{- if and (not (hasKey .metadata  "awsRegion")) (hasPrefix "aws-" .type) }}
       awsRegion: {{ $.Values.global.clusterRegion }}
     {{- end }}
     {{- range $k, $v := .metadata }}

--- a/charts/standard-application-stack/templates/keda-scaled-object.yaml
+++ b/charts/standard-application-stack/templates/keda-scaled-object.yaml
@@ -11,13 +11,16 @@ spec:
   cooldownPeriod: {{ include "mintel_common.keda.scaledObject.cooldownPeriod" .}}
   maxReplicaCount: {{ include "mintel_common.keda.scaledObject.maxReplicaCount" .}}
   minReplicaCount: {{ include "mintel_common.keda.scaledObject.minReplicaCount" .}}
+  {{- if .enableZeroReplicas }}
+  idleReplicaCount: 0
+  {{- end }}
   pollingInterval: {{ include "mintel_common.keda.scaledObject.pollingInterval" .}}
   scaleTargetRef:
     apiVersion: {{ .scaleTargetRef.apiVersion }}
     {{- if $.Values.statefulset }}
     kind: StatefulSet
     {{- else }}
-    kind: {{ .scaleTargetRef.kind}}
+    kind: {{ .scaleTargetRef.kind }}
     {{- end }}
     name: {{ include "mintel_common.fullname" $ }}
     {{- if .scaleTargetRef.envSourceContainerName }}
@@ -52,8 +55,18 @@ spec:
     metadata:
       value: "{{ .targetMemoryAverageValue }}"
   {{- end }}
-  {{- if .custom }}
-  {{- toYaml .custom | nindent 2 }}
+  {{- range .custom  }}
+  - type: {{ .type }}
+    metadata:
+    {{- if and (not (hasKey .metadata  "identityOwner")) (hasPrefix "aws-" .type) }}
+      identityOwner: 'operator'
+    {{- end }}
+    {{- if not (hasKey .metadata "awsRegion") }}
+      awsRegion: {{ $.Values.global.clusterRegion }}
+    {{- end }}
+    {{- range $k, $v := .metadata }}
+      {{ $k }}: {{ $v }}
+  {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/standard-application-stack/templates/keda-scaled-object.yaml
+++ b/charts/standard-application-stack/templates/keda-scaled-object.yaml
@@ -65,7 +65,7 @@ spec:
       awsRegion: {{ $.Values.global.clusterRegion }}
     {{- end }}
     {{- range $k, $v := .metadata }}
-      {{ $k }}: {{ $v }}
+      {{ $k }}: "{{ $v }}"
   {{- end }}
   {{- end }}
   {{- end }}

--- a/charts/standard-application-stack/tests/ingress_test.yaml
+++ b/charts/standard-application-stack/tests/ingress_test.yaml
@@ -348,5 +348,3 @@ tests:
           path: spec.rules[0].host
           value: ops-media.mintel.com
         documentIndex: 1
-
-

--- a/charts/standard-application-stack/tests/keda_scaled_object_test.yaml
+++ b/charts/standard-application-stack/tests/keda_scaled_object_test.yaml
@@ -540,7 +540,7 @@ tests:
           path: spec.idleReplicaCount
           value: 0
 
-  - it: Check AWS trigger vars automatically populated
+  - it: Check trigger vars automatically populated
     set:
       global.clusterEnv: qa
       global.clusterRegion: eu-west-2
@@ -556,6 +556,9 @@ tests:
           metadata:
             queueURL: test-queue
             queueLength: 2
+        - type: prometheus
+          metadata:
+            metricName: http_requests_total
     asserts:
       - isKind:
           of: ScaledObject
@@ -593,8 +596,12 @@ tests:
               identityOwner: operator
               queueURL: test-queue
               queueLength: "2"
+          - type: prometheus
+            metadata:
+              metricName: http_requests_total
+              serverAddress: http://prometheus-k8s.monitoring.svc:9090
 
-  - it: Check AWS trigger vars can be overriden
+  - it: Check trigger vars can be overriden
     set:
       global.clusterEnv: qa
       global.clusterRegion: eu-west-2
@@ -614,6 +621,10 @@ tests:
             identityOwner: pod
             queueURL: test-queue
             queueLength: 2
+        - type: prometheus
+          metadata:
+            metricName: http_requests_total
+            serverAddress: http://alt-prometheus-k8s.monitoring.svc:9090
     asserts:
       - isKind:
           of: ScaledObject
@@ -651,3 +662,7 @@ tests:
               identityOwner: pod
               queueURL: test-queue
               queueLength: "2"
+          - type: prometheus
+            metadata:
+              metricName: http_requests_total
+              serverAddress: http://alt-prometheus-k8s.monitoring.svc:9090

--- a/charts/standard-application-stack/tests/keda_scaled_object_test.yaml
+++ b/charts/standard-application-stack/tests/keda_scaled_object_test.yaml
@@ -592,7 +592,7 @@ tests:
               awsRegion: eu-west-2
               identityOwner: operator
               queueURL: test-queue
-              queueLength: 2
+              queueLength: "2"
 
   - it: Check AWS trigger vars can be overriden
     set:
@@ -650,4 +650,4 @@ tests:
               awsRegion: us-east-2
               identityOwner: pod
               queueURL: test-queue
-              queueLength: 2
+              queueLength: "2"

--- a/charts/standard-application-stack/tests/keda_scaled_object_test.yaml
+++ b/charts/standard-application-stack/tests/keda_scaled_object_test.yaml
@@ -510,3 +510,144 @@ tests:
       - equal:
           path: spec.minReplicaCount
           value: 2
+
+  - it: Check idleReplicaCount is equal to 0 when enableZeroReplicas is set
+    set:
+      global.clusterEnv: qa
+      autoscaling.enabled: true
+      autoscaling.enableZeroReplicas: true
+    asserts:
+      - isKind:
+          of: ScaledObject
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: example-app
+      - equal:
+          path: spec.scaleTargetRef.apiVersion
+          value: apps/v1
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: example-app
+      - equal:
+          path: spec.idleReplicaCount
+          value: 0
+
+  - it: Check AWS trigger vars automatically populated
+    set:
+      global.clusterEnv: qa
+      global.clusterRegion: eu-west-2
+      autoscaling.enabled: true
+      autoscaling.triggers.custom:
+        - type: aws-cloudwatch
+          metadata:
+            namespace: AWS/SQS
+            dimensionName: QueueName
+            dimensionValue: test-queue
+            metricName: ApproximateNumberOfMessagesVisible
+        - type: aws-sqs-queue
+          metadata:
+            queueURL: test-queue
+            queueLength: 2
+    asserts:
+      - isKind:
+          of: ScaledObject
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: example-app
+      - equal:
+          path: spec.scaleTargetRef.apiVersion
+          value: apps/v1
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: example-app
+      - equal:
+          path: spec.triggers
+          value:
+          - type: aws-cloudwatch
+            metadata:
+              awsRegion: eu-west-2
+              identityOwner: operator
+              namespace: AWS/SQS
+              dimensionName: QueueName
+              dimensionValue: test-queue
+              metricName: ApproximateNumberOfMessagesVisible
+          - type: aws-sqs-queue
+            metadata:
+              awsRegion: eu-west-2
+              identityOwner: operator
+              queueURL: test-queue
+              queueLength: 2
+
+  - it: Check AWS trigger vars can be overriden
+    set:
+      global.clusterEnv: qa
+      global.clusterRegion: eu-west-2
+      autoscaling.enabled: true
+      autoscaling.triggers.custom:
+        - type: aws-cloudwatch
+          metadata:
+            awsRegion: us-east-2
+            identityOwner: pod
+            namespace: AWS/SQS
+            dimensionName: QueueName
+            dimensionValue: test-queue
+            metricName: ApproximateNumberOfMessagesVisible
+        - type: aws-sqs-queue
+          metadata:
+            awsRegion: us-east-2
+            identityOwner: pod
+            queueURL: test-queue
+            queueLength: 2
+    asserts:
+      - isKind:
+          of: ScaledObject
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: example-app
+      - equal:
+          path: spec.scaleTargetRef.apiVersion
+          value: apps/v1
+      - equal:
+          path: spec.scaleTargetRef.kind
+          value: Deployment
+      - equal:
+          path: spec.scaleTargetRef.name
+          value: example-app
+      - equal:
+          path: spec.triggers
+          value:
+          - type: aws-cloudwatch
+            metadata:
+              awsRegion: us-east-2
+              identityOwner: pod
+              namespace: AWS/SQS
+              dimensionName: QueueName
+              dimensionValue: test-queue
+              metricName: ApproximateNumberOfMessagesVisible
+          - type: aws-sqs-queue
+            metadata:
+              awsRegion: us-east-2
+              identityOwner: pod
+              queueURL: test-queue
+              queueLength: 2

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -153,9 +153,13 @@ autoscaling:
     # targetMemoryAverageValue: 80
 
     # A list of custom triggers
+    # ref: https://keda.sh/docs/2.8/scalers/
     #  custom:
-    #    # ref: https://keda.sh/docs/1.4/scalers/prometheus/
-    #    type: 'prometheus',
+    #  - type: 'aws-sqs-queue'
+    #    metadata:
+    #      queueURL: 'https://my-queue-url'
+    #      queueLength: "20"
+    #  - type: 'prometheus'
     #    metadata:
     #      metricName: 'http_requests_total',
     #      query: 'sum(rate(http_requests_total{service="podinfo-http"}[2m]))',

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -115,6 +115,12 @@ autoscaling:
   maxReplicaCount: 5  # max value allowed 10
   minReplicaCount: 2  # min value allowed 1
 
+  # Enable zero replicas (sets idleReplicaCount=0)
+  # ref: https://keda.sh/docs/2.8/concepts/scaling-deployments/#idlereplicacount
+  # NOTE: Due to limitations in HPA controller the only supported value for this
+  # property is 0, it will not work correctly otherwise (hence the boolean flag).
+  enableZeroReplicas: false
+
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -163,7 +163,6 @@ autoscaling:
     #    metadata:
     #      metricName: 'http_requests_total',
     #      query: 'sum(rate(http_requests_total{service="podinfo-http"}[2m]))',
-    #      serverAddress: 'http://prometheus-k8s.monitoring.svc:9090',
     #      threshold: '5',
 
 # -- Optional name of PriorityClass to run pods with

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -21,8 +21,8 @@ A Helm chart for provisioning resources using Terraform Cloud
 | auroraMySql.terraform.defaultVars.engine_version | string | `"5.7.mysql_aurora.2.10.2"` | Aurora MySQL version |
 | auroraMySql.terraform.defaultVars.port | int | `3306` | Aurora MySQL port |
 | auroraMySql.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
-| auroraMySql.terraform.module.source | string | `"app.terraform.io/Mintel/rds-aurora/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds-aurora/aws) |
-| auroraMySql.terraform.module.version | string | `"0.0.3"` | Module version |
+| auroraMySql.terraform.module.source | string | `"app.terraform.io/Mintel/rds-aurora/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds/aws) |
+| auroraMySql.terraform.module.version | string | `"0.0.2"` | Module version |
 | auroraPostgresql.enabled | bool | `false` | Set to true to create a PostgreSQL Aurora RDS cluster |
 | auroraPostgresql.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
 | auroraPostgresql.terraform.defaultVars | object | See below | Vars to be applied to all instances defined below |
@@ -31,8 +31,8 @@ A Helm chart for provisioning resources using Terraform Cloud
 | auroraPostgresql.terraform.defaultVars.instance_class | string | `"db.t3.medium"` | Instance type |
 | auroraPostgresql.terraform.defaultVars.port | int | `5432` | Aurora PostgreSQL port |
 | auroraPostgresql.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
-| auroraPostgresql.terraform.module.source | string | `"app.terraform.io/Mintel/rds-aurora/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds-aurora/aws) |
-| auroraPostgresql.terraform.module.version | string | `"0.0.3"` | Module version |
+| auroraPostgresql.terraform.module.source | string | `"app.terraform.io/Mintel/rds-aurora/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds/aws) |
+| auroraPostgresql.terraform.module.version | string | `"0.0.1"` | Module version |
 | dynamodb.enabled | bool | `false` | Set to true to create a DynamoDB instance |
 | dynamodb.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
 | dynamodb.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -21,8 +21,8 @@ A Helm chart for provisioning resources using Terraform Cloud
 | auroraMySql.terraform.defaultVars.engine_version | string | `"5.7.mysql_aurora.2.10.2"` | Aurora MySQL version |
 | auroraMySql.terraform.defaultVars.port | int | `3306` | Aurora MySQL port |
 | auroraMySql.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
-| auroraMySql.terraform.module.source | string | `"app.terraform.io/Mintel/rds-aurora/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds/aws) |
-| auroraMySql.terraform.module.version | string | `"0.0.2"` | Module version |
+| auroraMySql.terraform.module.source | string | `"app.terraform.io/Mintel/rds-aurora/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds-aurora/aws) |
+| auroraMySql.terraform.module.version | string | `"0.0.3"` | Module version |
 | auroraPostgresql.enabled | bool | `false` | Set to true to create a PostgreSQL Aurora RDS cluster |
 | auroraPostgresql.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
 | auroraPostgresql.terraform.defaultVars | object | See below | Vars to be applied to all instances defined below |
@@ -31,8 +31,8 @@ A Helm chart for provisioning resources using Terraform Cloud
 | auroraPostgresql.terraform.defaultVars.instance_class | string | `"db.t3.medium"` | Instance type |
 | auroraPostgresql.terraform.defaultVars.port | int | `5432` | Aurora PostgreSQL port |
 | auroraPostgresql.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
-| auroraPostgresql.terraform.module.source | string | `"app.terraform.io/Mintel/rds-aurora/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds/aws) |
-| auroraPostgresql.terraform.module.version | string | `"0.0.1"` | Module version |
+| auroraPostgresql.terraform.module.source | string | `"app.terraform.io/Mintel/rds-aurora/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds-aurora/aws) |
+| auroraPostgresql.terraform.module.version | string | `"0.0.3"` | Module version |
 | dynamodb.enabled | bool | `false` | Set to true to create a DynamoDB instance |
 | dynamodb.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
 | dynamodb.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |


### PR DESCRIPTION
- Added Keda `enableZeroReplicas` option
- Added Keda AWS trigger handling for `awsRegion` and `identityOwner` vars
  - Avoids user having to specify AWS region/auth-modes (can override if required).
- Added Keda Prometheus trigger handling for `serverAddress`
