### PR TITLE
INFRA-25882: Drop chart-version from most resources

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.48.0] - 2022-09-29
+### Changed
+- Remove `helm.sh/chart` annotation to avoid merge-request noise (keep on main Deployment/CronJob)
+
 ## [v3.47.0] - 2022-09-27
 ### Changed
 - Disable `topologySpreadConstraints` when autoscaling from zero is enabled

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.47.0
+version: 3.48.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -41,7 +41,6 @@ matchExpressions:
 
 {{/* Common Annotations */}}
 {{- define "mintel_common.commonAnnotations" -}}
-helm.sh/chart: {{ include "mintel_common.chart" . }}
 {{- end -}}
 
 {{/* Common labels */}}

--- a/charts/standard-application-stack/templates/cronjobs.yaml
+++ b/charts/standard-application-stack/templates/cronjobs.yaml
@@ -6,7 +6,9 @@ kind: CronJob
 metadata:
   name: {{ include "mintel_common.fullname" $data }}
   labels: {{ include "mintel_common.labels" $data | nindent 4 }}
-  annotations: {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}
+  annotations:
+    {{- include "mintel_common.commonAnnotations" $ | nindent 4 }}
+    helm.sh/chart: {{ include "mintel_common.chart" $ }}
   namespace: {{ $.Release.Namespace }}
 spec:
   concurrencyPolicy: {{ coalesce .concurrencyPolicy $.Values.cronjobs.defaults.concurrencyPolicy }}

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- include "mintel_common.commonAnnotations" . | nindent 4 }}
+    helm.sh/chart: {{ include "mintel_common.chart" . }}
     {{- if (and .Values.liveness (not .Values.liveness.enabled)) }}
     app.mintel.com/opa-skip-liveness-probe-check.main: "true"
     {{- end }}

--- a/charts/standard-application-stack/tests/service_test.yaml
+++ b/charts/standard-application-stack/tests/service_test.yaml
@@ -100,6 +100,9 @@ tests:
       global.owner: my-team
       ingress.enabled: true
       ingress.alb.enabled: false
+      # Add annotations to allow for isNull check
+      service.annotations:
+        k: v
     asserts:
       - isKind:
           of: Service
@@ -111,6 +114,9 @@ tests:
       global.name: test-app
       ingress.enabled: true
       ingress.alb.enabled: false
+      # Add annotations to allow for isNull check
+      service.annotations:
+        k: v
     asserts:
       - isKind:
           of: Service


### PR DESCRIPTION
This appears in every resource right now and makes code-reviews a struggle - it's probably still useful, so for now just keep it on main workloads (Deployment/Statefulset/Cronojbs)