### PR TITLE
INFRA-27862: Make argocd sync-wave configurable

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.26.0] - 2022-10-19
+### Added
+- Added option to configure ArgoCD `sync-wave` per resource-type
+
 ## [v0.25.3] - 2022-10-14
 ### Changed
 - Bump version of sshKeyPairSecret module

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.25.3
+version: 0.26.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -10,6 +10,7 @@ A Helm chart for provisioning resources using Terraform Cloud
 |-----|------|---------|-------------|
 | activeMQ.enabled | bool | `false` | Set to true to create an activeMQ AWS amazonMQ instance |
 | activeMQ.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
+| activeMQ.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/amazonmq/aws","version":"0.0.2"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | activeMQ.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | activeMQ.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | activeMQ.terraform.module.source | string | `"app.terraform.io/Mintel/amazonmq/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/amazonmq/aws) |
@@ -25,6 +26,7 @@ A Helm chart for provisioning resources using Terraform Cloud
 | auroraMySql.terraform.module.version | string | `"0.0.3"` | Module version |
 | auroraPostgresql.enabled | bool | `false` | Set to true to create a PostgreSQL Aurora RDS cluster |
 | auroraPostgresql.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
+| auroraPostgresql.terraform | object | `{"defaultVars":{"engine":"aurora-postgresql","engine_version":"14.3","instance_class":"db.t3.medium","port":5432},"instances":{},"module":{"source":"app.terraform.io/Mintel/rds-aurora/aws","version":"0.0.3"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | auroraPostgresql.terraform.defaultVars | object | See below | Vars to be applied to all instances defined below |
 | auroraPostgresql.terraform.defaultVars.engine | string | `"aurora-postgresql"` | Database engine to use (should always be "aurora-postgresql") |
 | auroraPostgresql.terraform.defaultVars.engine_version | string | `"14.3"` | Aurora PostgreSQL version |
@@ -35,6 +37,7 @@ A Helm chart for provisioning resources using Terraform Cloud
 | auroraPostgresql.terraform.module.version | string | `"0.0.3"` | Module version |
 | dynamodb.enabled | bool | `false` | Set to true to create a DynamoDB instance |
 | dynamodb.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
+| dynamodb.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/dynamodb/aws","version":"1.0.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | dynamodb.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | dynamodb.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | dynamodb.terraform.module.source | string | `"app.terraform.io/Mintel/dynamodb/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/dynamodb/aws) |
@@ -53,11 +56,13 @@ A Helm chart for provisioning resources using Terraform Cloud
 | global.terraform.secretsMountPath | string | `"/tmp/secrets"` | Where secrets are mounted inside the Terraform Operator container |
 | global.terraform.terraformVersion | string | `"1.0.7"` | Global Terraform version for all modules |
 | irsa.enabled | bool | `false` | Set to true to explicitly instantiate this module if there's need to access resources created elsewhere |
+| irsa.terraform | object | `{"module":{"source":"app.terraform.io/Mintel/app-iam/aws","version":"2.0.0"},"vars":{}}` | Set ArgoCD syncWave for this resource (default -20) syncWave: -20 |
 | irsa.terraform.module.source | string | `"app.terraform.io/Mintel/app-iam/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/app-iam/aws) |
 | irsa.terraform.module.version | string | `"2.0.0"` | Module version |
 | irsa.terraform.vars | object | See below | Vars to be applied to all instances defined below |
 | mariadb.enabled | bool | `false` | Set to true to create a MariaDB RDS instance |
 | mariadb.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
+| mariadb.terraform | object | `{"defaultVars":{"engine":"mariadb","engine_version":"10.5","port":3306},"instances":{},"module":{"source":"app.terraform.io/Mintel/rds/aws","version":"1.0.2"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | mariadb.terraform.defaultVars | object | See below | Vars to be applied to all instances defined below |
 | mariadb.terraform.defaultVars.engine | string | `"mariadb"` | Database engine to use (should always be "mariadb") |
 | mariadb.terraform.defaultVars.engine_version | string | `"10.5"` | MariaDB version |
@@ -67,6 +72,7 @@ A Helm chart for provisioning resources using Terraform Cloud
 | mariadb.terraform.module.version | string | `"1.0.2"` | Module version |
 | memcached.enabled | bool | `false` | Set to true to create a memcached Elasticache resource |
 | memcached.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
+| memcached.terraform | object | `{"defaultVars":{"instance_type":"cache.t4g.micro","num_cache_nodes":1},"instances":{},"module":{"source":"app.terraform.io/Mintel/memcached/aws","version":"1.0.1"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | memcached.terraform.defaultVars | object | See below | Vars to be applied to all instances defined below |
 | memcached.terraform.defaultVars.instance_type | string | `"cache.t4g.micro"` | EC2 instance type to use (https://aws.amazon.com/elasticache/pricing) |
 | memcached.terraform.defaultVars.num_cache_nodes | int | `1` | Number of nodes to create in the cluster |
@@ -75,6 +81,7 @@ A Helm chart for provisioning resources using Terraform Cloud
 | memcached.terraform.module.version | string | `"1.0.1"` | Module version |
 | opensearch.enabled | bool | `false` | Set to true to create an Opensearch cluster |
 | opensearch.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
+| opensearch.terraform | object | `{"defaultVars":null,"instances":{},"module":{"source":"app.terraform.io/Mintel/opensearch/aws","version":"1.1.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | opensearch.terraform.defaultVars | string | `nil` | Vars to be applied to all instances defined below |
 | opensearch.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | opensearch.terraform.module.source | string | `"app.terraform.io/Mintel/opensearch/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/opensearch/aws) |
@@ -90,35 +97,41 @@ A Helm chart for provisioning resources using Terraform Cloud
 | postgresql.terraform.module.version | string | `"1.0.2"` | Module version |
 | redis.enabled | bool | `false` | Set to true to create a Redis Elasticache resource |
 | redis.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
+| redis.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/redis/aws","version":"1.0.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | redis.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | redis.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | redis.terraform.module.source | string | `"app.terraform.io/Mintel/redis/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/redis/aws) |
 | redis.terraform.module.version | string | `"1.0.0"` | Module version |
 | s3.enabled | bool | `false` | Set to true to create an S3 bucket |
 | s3.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
+| s3.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/private-s3-bucket/aws","version":"1.1.2"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | s3.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | s3.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | s3.terraform.module.source | string | `"app.terraform.io/Mintel/private-s3-bucket/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/private-s3-bucket/aws) |
 | s3.terraform.module.version | string | `"1.1.2"` | Module version |
 | sns.enabled | bool | `false` | Set to true to create an SNS resource |
 | sns.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
+| sns.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/sns/aws","version":"1.0.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | sns.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | sns.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | sns.terraform.module.source | string | `"app.terraform.io/Mintel/sns/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/sns/aws) |
 | sns.terraform.module.version | string | `"1.0.0"` | Module version |
 | sqs.enabled | bool | `false` | Set to true to create an SQS resource |
 | sqs.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
+| sqs.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/sqs/aws","version":"1.0.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | sqs.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | sqs.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | sqs.terraform.module.source | string | `"app.terraform.io/Mintel/sqs/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/sqs/aws) |
 | sqs.terraform.module.version | string | `"1.0.0"` | Module version |
 | sshKeyPairSecret.enabled | bool | `false` | Set to true to create AWS secret manager secrets for an SSH key pair |
+| sshKeyPairSecret.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/ssh-keypair-secret/aws","version":"0.0.5"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | sshKeyPairSecret.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | sshKeyPairSecret.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | sshKeyPairSecret.terraform.module.source | string | `"app.terraform.io/Mintel/ssh-keypair-secret/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/ssh-keypair-secret/aws) |
 | sshKeyPairSecret.terraform.module.version | string | `"0.0.5"` | Module version |
 | staticWebsite.enabled | bool | `false` | Set to true to create static website (a public bucket and associated resources) |
 | staticWebsite.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
+| staticWebsite.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/public-static-website/aws","version":"1.0.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | staticWebsite.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | staticWebsite.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | staticWebsite.terraform.module.source | string | `"app.terraform.io/Mintel/public-static-website/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/public-static-website/aws) |

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 0.25.3](https://img.shields.io/badge/Version-0.25.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.26.0](https://img.shields.io/badge/Version-0.26.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 

--- a/charts/terraform-cloud/templates/helpers/_workspace.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace.yaml
@@ -5,6 +5,7 @@
 {{- $moduleSource := index . 4 }}
 {{- $moduleVersion := index . 5 }}
 {{- $tfVersion := index . 6}}
+{{- $resourceCfg := index . 7}}
 {{- $global := $.Values.global }}
 {{- $workspaceDict := dict "Global" $global "Release" $.Release "InstanceCfg" $instanceCfg "ResourceType" $resourceType }}
 {{- with index . 1 }}
@@ -22,10 +23,10 @@ metadata:
     {{ include "mintel_common.terraform_cloud.operatorAnnotations" $workspaceDict | nindent 4 }}
     {{- if (eq $resourceType "irsa") }}
     app.mintel.com/altManifestFileSuffix: "{{ $global.name }}-{{ $resourceType | kebabcase }}"
-    argocd.argoproj.io/sync-wave: "-20"
+    argocd.argoproj.io/sync-wave: "{{ default -20 $resourceCfg.syncWave }}"
     {{- else }}
     app.mintel.com/altManifestFileSuffix: "{{ $instanceCfg.name }}-{{ $resourceType | kebabcase }}"
-    argocd.argoproj.io/sync-wave: "-40"
+    argocd.argoproj.io/sync-wave: "{{ default -40 $resourceCfg.syncWave }}"
     {{- end}}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:

--- a/charts/terraform-cloud/templates/helpers/_workspace.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace.yaml
@@ -23,10 +23,10 @@ metadata:
     {{ include "mintel_common.terraform_cloud.operatorAnnotations" $workspaceDict | nindent 4 }}
     {{- if (eq $resourceType "irsa") }}
     app.mintel.com/altManifestFileSuffix: "{{ $global.name }}-{{ $resourceType | kebabcase }}"
-    argocd.argoproj.io/sync-wave: "{{ default -20 $resourceCfg.syncWave }}"
+    argocd.argoproj.io/sync-wave: "{{ default -20 (default $resourceCfg.syncWave $instanceCfg.syncWave) }}"
     {{- else }}
     app.mintel.com/altManifestFileSuffix: "{{ $instanceCfg.name }}-{{ $resourceType | kebabcase }}"
-    argocd.argoproj.io/sync-wave: "{{ default -40 $resourceCfg.syncWave }}"
+    argocd.argoproj.io/sync-wave: "{{ default -40 (default $resourceCfg.syncWave $instanceCfg.syncWave) }}"
     {{- end}}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
@@ -49,6 +49,7 @@ spec:
   {{- $_ := unset $instanceCfg "workspaceOwner" }}
   {{- $_ := unset $instanceCfg "workspaceTags" }}
   {{- $_ := unset $instanceCfg "outputSecretMap" }}
+  {{- $_ := unset $instanceCfg "syncWave" }}
   {{- range $varKey, $varVal := $instanceCfg }}
     {{- if kindIs "map" $varVal}}
       {{- include "mintel_common.terraform_cloud.tfVar" (merge (dict "key" $varKey) $varVal) | indent 2 }}

--- a/charts/terraform-cloud/templates/irsa-workspace.yaml
+++ b/charts/terraform-cloud/templates/irsa-workspace.yaml
@@ -33,5 +33,5 @@
     {{- $_ := set $irsaConfig "k8s_namespace" $.Release.Namespace }}
   {{- end }}
   # Create the CRD
-  {{- include "mintel_common.terraform_cloud.workspace" (list $ . $irsaConfig "irsa" $moduleSource $moduleVersion $tfVersion) }}
+  {{- include "mintel_common.terraform_cloud.workspace" (list $ . $irsaConfig "irsa" $moduleSource $moduleVersion $tfVersion $irsa) }}
 {{- end }}

--- a/charts/terraform-cloud/templates/workspace.yaml
+++ b/charts/terraform-cloud/templates/workspace.yaml
@@ -59,7 +59,7 @@
       {{- $instanceConfig = mergeOverwrite (include "mintel_common.terraform_cloud.defaultVarValues" $instanceDict | fromJson ) $instanceConfig }}
       # Create the CRD
 ---
-      {{- include "mintel_common.terraform_cloud.workspace" (list $ . $instanceConfig $resourceType $moduleSource $moduleVersion $tfVersion) }}
+      {{- include "mintel_common.terraform_cloud.workspace" (list $ . $instanceConfig $resourceType $moduleSource $moduleVersion $tfVersion $resourceConfig) }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/terraform-cloud/tests/irsa_workspace_test.yaml
+++ b/charts/terraform-cloud/tests/irsa_workspace_test.yaml
@@ -110,7 +110,6 @@ tests:
           value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
       - hasDocuments:
           count: 1
-
   - it: IRSA created with modified syncWave
     set:
       global.name: test-app
@@ -138,7 +137,6 @@ tests:
       - equal:
           path: metadata.annotations.[argocd.argoproj.io/sync-wave]
           value: "-100"
-
   - it: IRSA created with default (0) syncWave
     set:
       global.name: test-app

--- a/charts/terraform-cloud/tests/irsa_workspace_test.yaml
+++ b/charts/terraform-cloud/tests/irsa_workspace_test.yaml
@@ -110,3 +110,59 @@ tests:
           value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
       - hasDocuments:
           count: 1
+
+  - it: IRSA created with modified syncWave
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      irsa.enabled: true
+      irsa.syncWave: "-100"
+    asserts:
+      - isKind:
+          of: Workspace
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: metadata.name
+          value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
+      - equal:
+          path: spec.module.source
+          value: app.terraform.io/Mintel/app-iam/aws
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.annotations.[argocd.argoproj.io/sync-wave]
+          value: "-100"
+
+  - it: IRSA created with default (0) syncWave
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      irsa.enabled: true
+      irsa.syncWave: "0"
+    asserts:
+      - isKind:
+          of: Workspace
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: metadata.name
+          value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
+      - equal:
+          path: spec.module.source
+          value: app.terraform.io/Mintel/app-iam/aws
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.annotations.[argocd.argoproj.io/sync-wave]
+          value: "0"

--- a/charts/terraform-cloud/tests/workspace_test.yaml
+++ b/charts/terraform-cloud/tests/workspace_test.yaml
@@ -270,3 +270,65 @@ tests:
       - equal:
           path: metadata.annotations.[app.mintel.com/terraform-allow-destroy]
           value: "false"
+
+  - it: Dev S3 module workspace with modified syncWave
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      s3.enabled: true
+      s3.syncWave: "200"
+    asserts:
+      - isKind:
+          of: Workspace
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: metadata.name
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      - equal:
+          path: spec.module.source
+          value: app.terraform.io/Mintel/private-s3-bucket/aws
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.annotations.[app.mintel.com/altManifestFileSuffix]
+          value: mntl-test-app-s3
+      - equal:
+          path: metadata.annotations.[argocd.argoproj.io/sync-wave]
+          value: "200"
+
+  - it: Dev S3 module workspace with default (0) syncWave
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      s3.enabled: true
+      s3.syncWave: "0"
+    asserts:
+      - isKind:
+          of: Workspace
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: metadata.name
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      - equal:
+          path: spec.module.source
+          value: app.terraform.io/Mintel/private-s3-bucket/aws
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.annotations.[app.mintel.com/altManifestFileSuffix]
+          value: mntl-test-app-s3
+      - equal:
+          path: metadata.annotations.[argocd.argoproj.io/sync-wave]
+          value: "0"

--- a/charts/terraform-cloud/tests/workspace_test.yaml
+++ b/charts/terraform-cloud/tests/workspace_test.yaml
@@ -270,7 +270,31 @@ tests:
       - equal:
           path: metadata.annotations.[app.mintel.com/terraform-allow-destroy]
           value: "false"
-
+  - it: Dev S3 module workspace with multiple instances
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      s3:
+        enabled: true
+        terraform:
+          instances:
+            test-bucket: {}
+            test-bucket-another: {}
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.name
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-s3
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-another-s3
+        documentIndex: 1
   - it: Dev S3 module workspace with modified syncWave
     set:
       global.name: test-app
@@ -301,7 +325,6 @@ tests:
       - equal:
           path: metadata.annotations.[argocd.argoproj.io/sync-wave]
           value: "200"
-
   - it: Dev S3 module workspace with default (0) syncWave
     set:
       global.name: test-app
@@ -332,3 +355,30 @@ tests:
       - equal:
           path: metadata.annotations.[argocd.argoproj.io/sync-wave]
           value: "0"
+  - it: Dev S3 module workspace with multiple instances and syncWave overrides
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      s3:
+        enabled: true
+        terraform:
+          instances:
+            test-bucket:
+              syncWave: "200"
+            test-bucket-another:
+              syncWave: "300"
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.annotations.[argocd.argoproj.io/sync-wave]
+          value: "200"
+        documentIndex: 0
+      - equal:
+          path: metadata.annotations.[argocd.argoproj.io/sync-wave]
+          value: "300"
+        documentIndex: 1

--- a/charts/terraform-cloud/values.yaml
+++ b/charts/terraform-cloud/values.yaml
@@ -36,6 +36,8 @@ global:
 irsa:
   # -- Set to true to explicitly instantiate this module if there's need to access resources created elsewhere
   enabled: false
+  # -- Set ArgoCD syncWave for this resource (default -20)
+  # syncWave: -20
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     # terraformVersion:
@@ -67,6 +69,8 @@ dynamodb:
   enabled: false
   # -- Set to true to create an AWS secret manager external secret with outputs
   outputSecret: true
+  # -- Set ArgoCD syncWave for this resource (default -40)
+  # syncWave: -40
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     # terraformVersion:
@@ -106,6 +110,8 @@ sqs:
   enabled: false
   # -- Set to true to create an AWS secret manager external secret with outputs
   outputSecret: true
+  # -- Set ArgoCD syncWave for this resource (default -40)
+  # syncWave: -40
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     # terraformVersion:
@@ -138,6 +144,8 @@ sns:
   enabled: false
   # -- Set to true to create an AWS secret manager external secret with outputs
   outputSecret: true
+  # -- Set ArgoCD syncWave for this resource (default -40)
+  # syncWave: -40
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     # terraformVersion:
@@ -170,6 +178,8 @@ staticWebsite:
   enabled: false
   # -- Set to true to create an AWS secret manager external secret with outputs
   outputSecret: true
+  # -- Set ArgoCD syncWave for this resource (default -40)
+  # syncWave: -40
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     # terraformVersion:
@@ -202,6 +212,8 @@ mariadb:
   enabled: false
   # -- Set to true to create an AWS secret manager external secret with outputs
   outputSecret: true
+  # -- Set ArgoCD syncWave for this resource (default -40)
+  # syncWave: -40
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     # terraformVersion:
@@ -292,6 +304,8 @@ memcached:
   enabled: false
   # -- Set to true to create an AWS secret manager external secret with outputs
   outputSecret: true
+  # -- Set ArgoCD syncWave for this resource (default -40)
+  # syncWave: -40
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     # terraformVersion:
@@ -329,6 +343,8 @@ opensearch:
   enabled: false
   # -- Set to true to create an AWS secret manager external secret with outputs
   outputSecret: true
+  # -- Set ArgoCD syncWave for this resource (default -40)
+  # syncWave: -40
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     # terraformVersion:
@@ -412,6 +428,8 @@ auroraPostgresql:
   enabled: false
   # -- Set to true to create an AWS secret manager external secret with outputs
   outputSecret: true
+  # -- Set ArgoCD syncWave for this resource (default -40)
+  # syncWave: -40
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     # terraformVersion:
@@ -459,6 +477,8 @@ redis:
   enabled: false
   # -- Set to true to create an AWS secret manager external secret with outputs
   outputSecret: true
+  # -- Set ArgoCD syncWave for this resource (default -40)
+  # syncWave: -40
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     # terraformVersion:
@@ -497,6 +517,8 @@ s3:
   enabled: false
   # -- Set to true to create an AWS secret manager external secret with outputs
   outputSecret: true
+  # -- Set ArgoCD syncWave for this resource (default -40)
+  # syncWave: -40
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     # terraformVersion:
@@ -531,6 +553,8 @@ activeMQ:
   enabled: false
   # -- Set to true to create an AWS secret manager external secret with outputs
   outputSecret: true
+  # -- Set ArgoCD syncWave for this resource (default -40)
+  # syncWave: -40
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     # terraformVersion:
@@ -595,6 +619,8 @@ stepFunctionEks:
 sshKeyPairSecret:
   # -- Set to true to create AWS secret manager secrets for an SSH key pair
   enabled: false
+  # -- Set ArgoCD syncWave for this resource (default -40)
+  # syncWave: -40
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     module:


### PR DESCRIPTION
Make syncWave per resource configurable (defaults remain the same).

- `syncWave` can be configured at either the `resourceCfg` or `instanceCfg` level.
- Ensure `syncWave` env-var is not passed through to tf-module when defined on the `instanceCfg`
- Added extra tests 