### PR TITLE
Feat: Pass Terraform CLoud Helm chart secrets to deployments correctly

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.51.0] - 2022-11-11
+### Added
+- Added ability to get correct secret names from terraform cloud helm chart
+
 ## [v3.50.0] - 2022-11-08
 ### Added
 - Added `includeS3Secret` flag for cronjobs

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.50.0
+version: 3.51.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.50.0](https://img.shields.io/badge/Version-3.50.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.51.0](https://img.shields.io/badge/Version-3.51.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -481,15 +481,19 @@ topologySpreadConstraints:
 {{/* Set instanceConfig.Name */}}
 {{- define "mintel_common.terraform_cloud.instanceConfigName" -}}
 {{- $name := ""}}
+{{- /* Use the instance config name if it is set explicitly */}}
 {{- if ( hasKey .InstanceCfg "name" ) }}
   {{- $name = .InstanceCfg.name }}
 {{- else }}
+  {{- /* Use the app name if this is just a default resource setting */}}
   {{- if eq .InstanceName "default" }}
     {{- $name = .Global.name }}
   {{- else }}
+    {{- /* Use the actual instance name otherwise */}}
     {{- $name = .InstanceName }}
   {{- end }}
 {{- end }}
+{{- /* If it is an S3 bucket, add the mntl- prefix if it does not exist */}}
 {{- if ( and ( eq .ResourceType "s3") ( not (hasPrefix "mntl" $name)))}}
   {{- $name = (printf "mntl-%s" $name) }}
 {{- end }}
@@ -498,13 +502,18 @@ topologySpreadConstraints:
 
 {{/* Build list of TF cloud secrets */}}
 {{- define "mintel_common.tf_cloud_external_secrets" -}}
+{{- /* Initialize empty list that will contain the names of all TF Cloud secrets */}}
 {{- $tfSecretList := list }}
+{{- /* Loop through all supported Terraform Cloud resources */}}
 {{- range include "mintel_common.terraformCloudResources" $ | split "," }}
   {{- $global := $.Values.global }}
   {{- $resourceType := . }}
   {{- $resourceConfig := (get $.Values .) }}
+  {{- /* Check if they have the keys enabled and outputSecret i.e. if the TF Cloud chart is being used in tandem */}}
   {{- if ( and (hasKey $resourceConfig "enabled") (hasKey $resourceConfig "outputSecret")) }}
+      {{- /* Check if the resource is enabled and the output secret for it is as well */}}
       {{- if ( and $resourceConfig.enabled $resourceConfig.outputSecret) }}
+        {{- /* Loop through all instances of every resource type that is enabled and add the secret name to a list */}}
         {{- range $instanceName, $instanceConfig := default ( dict "default" dict ) $resourceConfig.terraform.instances }}
           {{- $instanceDict := dict "Global" $global "InstanceCfg" $instanceConfig "InstanceName" $instanceName "ResourceType" $resourceType }}
           {{- $_ := set $instanceConfig "name" (include "mintel_common.terraform_cloud.instanceConfigName" $instanceDict | trim)}}

--- a/charts/standard-application-stack/templates/cronjobs.yaml
+++ b/charts/standard-application-stack/templates/cronjobs.yaml
@@ -97,6 +97,14 @@ spec:
                 {{- end }}
                 {{- end }}
                 {{- end }}
+                {{- if .Values.global.terraform.externalSecrets }}
+                  {{- range include "mintel_common.tf_cloud_external_secrets" . | split "," }}
+                  {{- if . }}
+                - secretRef:
+                    name: {{ . }}
+                  {{- end }}
+                  {{- end }}
+                {{- else }}
                 {{- if (and $.Values.mariadb $.Values.mariadb.enabled) }}
                 {{- if .includeMariadbSecret }}
                 - secretRef:
@@ -137,6 +145,7 @@ spec:
                 {{- if .includeOpensearchSecret }}
                 - secretRef:
                     name: {{ default (include "mintel_common.defaultOpensearchSecretName" $) $.Values.opensearch.secretNameOverride }}
+                {{- end }}
                 {{- end }}
                 {{- end }}
                 {{- if .includeBaseEnv }}

--- a/charts/standard-application-stack/templates/cronjobs.yaml
+++ b/charts/standard-application-stack/templates/cronjobs.yaml
@@ -97,8 +97,8 @@ spec:
                 {{- end }}
                 {{- end }}
                 {{- end }}
-                {{- if .Values.global.terraform.externalSecrets }}
-                  {{- range include "mintel_common.tf_cloud_external_secrets" . | split "," }}
+                {{- if $.Values.global.terraform.externalSecrets }}
+                  {{- range include "mintel_common.tf_cloud_external_secrets" $ | split "," }}
                   {{- if . }}
                 - secretRef:
                     name: {{ . }}

--- a/charts/standard-application-stack/templates/deployment-celery-beat.yaml
+++ b/charts/standard-application-stack/templates/deployment-celery-beat.yaml
@@ -80,6 +80,14 @@ spec:
                 name: {{ default (include "mintel_common.defaultAppSecretName" .) .Values.externalSecret.nameOverride }}
             {{- end }}
             {{- end }}
+            {{- if .Values.global.terraform.externalSecrets }}
+              {{- range include "mintel_common.tf_cloud_external_secrets" . | split "," }}
+              {{- if . }}
+            - secretRef:
+                name: {{ . }}
+              {{- end }}
+              {{- end }}
+            {{- else }}
             {{- if (and .Values.mariadb .Values.mariadb.enabled) }}
             - secretRef:
                 name: {{ default (include "mintel_common.defaultMariadbSecretName" .) .Values.mariadb.secretNameOverride }}
@@ -103,6 +111,7 @@ spec:
             {{- if (and .Values.s3 .Values.s3.enabled) }}
             - secretRef:
                 name: {{ default (include "mintel_common.defaultS3SecretName" .) .Values.s3.secretNameOverride }}
+            {{- end }}
             {{- end }}
             {{- with .Values.envFrom }}
             {{- toYaml . | nindent 12 }}

--- a/charts/standard-application-stack/templates/deployment-celery.yaml
+++ b/charts/standard-application-stack/templates/deployment-celery.yaml
@@ -153,6 +153,14 @@ spec:
                 name: {{ default (include "mintel_common.defaultAppSecretName" .) .Values.externalSecret.nameOverride }}
             {{- end }}
             {{- end }}
+            {{- if .Values.global.terraform.externalSecrets }}
+              {{- range include "mintel_common.tf_cloud_external_secrets" . | split "," }}
+              {{- if . }}
+            - secretRef:
+                name: {{ . }}
+              {{- end }}
+              {{- end }}
+            {{- else }}
             {{- if (and .Values.mariadb .Values.mariadb.enabled) }}
             - secretRef:
                 name: {{ default (include "mintel_common.defaultMariadbSecretName" .) .Values.mariadb.secretNameOverride }}
@@ -176,6 +184,7 @@ spec:
             {{- if (and .Values.s3 .Values.s3.enabled) }}
             - secretRef:
                 name: {{ default (include "mintel_common.defaultS3SecretName" .) .Values.s3.secretNameOverride }}
+            {{- end }}
             {{- end }}
             {{- with .Values.envFrom }}
             {{- toYaml . | nindent 12 }}

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -195,7 +195,7 @@ spec:
                 name: {{ default (include "mintel_common.defaultAppSecretName" .) .Values.externalSecret.nameOverride }}
             {{- end }}
             {{- end }}
-            {{- if .Values.global.terraform.externalSecrets }}
+            {{- if (and (ne .Values.global.clusterEnv "local") .Values.global.terraform.externalSecrets) }}
               {{- range include "mintel_common.tf_cloud_external_secrets" . | split "," }}
               {{- if . }}
             - secretRef:

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -195,37 +195,46 @@ spec:
                 name: {{ default (include "mintel_common.defaultAppSecretName" .) .Values.externalSecret.nameOverride }}
             {{- end }}
             {{- end }}
-            {{- if (and .Values.mariadb .Values.mariadb.enabled) }}
+            {{- if .Values.global.terraform.externalSecrets }}
+              {{- range include "mintel_common.tf_cloud_external_secrets" . | split "," }}
+              {{- if . }}
+            - secretRef:
+                name: {{ . }}
+              {{- end }}
+              {{- end }}
+            {{- else }}
+              {{- if (and .Values.mariadb .Values.mariadb.enabled) }}
             - secretRef:
                 name: {{ default (include "mintel_common.defaultMariadbSecretName" .) .Values.mariadb.secretNameOverride }}
-            {{- end }}
-            {{- if (and .Values.postgresql .Values.postgresql.enabled) }}
+              {{- end }}
+              {{- if (and .Values.postgresql .Values.postgresql.enabled) }}
             - secretRef:
                 name: {{ default (include "mintel_common.defaultPostgresqlSecretName" .) .Values.postgresql.secretNameOverride }}
-            {{- end }}
-            {{- if (and .Values.dynamodb .Values.dynamodb.enabled) }}
+              {{- end }}
+              {{- if (and .Values.dynamodb .Values.dynamodb.enabled) }}
             - secretRef:
                 name: {{ default (include "mintel_common.defaultDynamodbSecretName" .) .Values.dynamodb.secretNameOverride }}
-            {{- end }}
-            {{- if (and .Values.redis .Values.redis.enabled) }}
+              {{- end }}
+              {{- if (and .Values.redis .Values.redis.enabled) }}
             - secretRef:
                 name: {{ default (include "mintel_common.defaultRedisSecretName" .) .Values.redis.secretNameOverride }}
-            {{- end }}
-            {{- if (and .Values.s3 .Values.s3.enabled) }}
+              {{- end }}
+              {{- if (and .Values.s3 .Values.s3.enabled) }}
             - secretRef:
                 name: {{ default (include "mintel_common.defaultS3SecretName" .) .Values.s3.secretNameOverride }}
-            {{- end }}
-            {{- if (and .Values.sqs .Values.sqs.enabled) }}
+              {{- end }}
+              {{- if (and .Values.sqs .Values.sqs.enabled) }}
             - secretRef:
                 name: {{ default (include "mintel_common.defaultSqsSecretName" .) .Values.sqs.secretNameOverride }}
-            {{- end }}
-            {{- if (and .Values.elasticsearch .Values.elasticsearch.enabled) }}
+              {{- end }}
+              {{- if (and .Values.elasticsearch .Values.elasticsearch.enabled) }}
             - secretRef:
                 name: {{ default (include "mintel_common.defaultElasticsearchSecretName" .) .Values.elasticsearch.secretNameOverride }}
-            {{- end }}
-            {{- if (and .Values.opensearch .Values.opensearch.enabled) }}
+              {{- end }}
+              {{- if (and .Values.opensearch .Values.opensearch.enabled) }}
             - secretRef:
                 name: {{ default (include "mintel_common.defaultOpensearchSecretName" .) .Values.opensearch.secretNameOverride }}
+              {{- end }}
             {{- end }}
             {{- range .Values.extraSecrets }}
             {{- if (or (ne (hasKey . "includeInMain") true) .includeInMain) }}

--- a/charts/standard-application-stack/tests/deployment_s3_enabled_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_s3_enabled_test.yaml
@@ -22,6 +22,38 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].envFrom[0].secretRef.name
           value: test-app-s3
+  - it: Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm chart
+    set:
+      global.clusterEnv: qa
+      global.name: test-app
+      global.terraform.externalSecrets: true
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      s3:
+        enabled: true
+        outputSecret: true
+        terraform:
+          instances:
+            test-bucket: {}
+            test-bucket-another: {}
+      # Disable default application secret
+      externalSecret.enabled: false
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: mntl-test-bucket-s3
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[1].secretRef.name
+          value: mntl-test-bucket-another-s3
   - it: Check S3 secretName Override
     set:
       global.clusterEnv: qa


### PR DESCRIPTION
- feat: Add helpers to generate terraform cloud secret names
- feat: Update deployment.yaml, deployment-celery-beat.yaml, deployment-celery.yaml to pass these secrets to envFrom for deployments
- test: Add test for new feature
- docs: Update CHANGELOG.md