### PR TITLE
Add hosts from extraIngresses to EXTRA_ALLOWED_HOSTS env var

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Make `EXTRA_ALLOWED_HOSTS` env var unique and alphabetically sorted
 
 ## [v3.52.1] - 2022-12-15
 ### Fixed

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v3.52.2] - 2022-12-15
 ### Changed
 - Make `EXTRA_ALLOWED_HOSTS` env var unique and alphabetically sorted
 

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Make `EXTRA_ALLOWED_HOSTS` env var unique and alphabetically sorted
 
+### Fixed
+- Add hosts from `extraIngresses` to `EXTRA_ALLOWED_HOSTS` env var
+
 ## [v3.52.1] - 2022-12-15
 ### Fixed
 - Pass non-default terraform cloud secrets to stakater annotation correctly

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.52.1
+version: 3.52.2
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.52.1](https://img.shields.io/badge/Version-3.52.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.52.2](https://img.shields.io/badge/Version-3.52.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -440,7 +440,13 @@ Build comma separated list of configmaps
   {{- if (and .Values.oauthProxy.enabled .Values.oauthProxy.ingressHost) -}}
   {{- $hosts = append $hosts .Values.oauthProxy.ingressHost }}
   {{- end }}
-  value: {{ uniq $hosts | sortAlpha | join "," }}
+  {{- range .Values.ingress.extraIngresses }}
+    {{- $hosts = append $hosts .defaultHost -}}
+    {{- range .extraHosts }}
+    {{- $hosts = append $hosts .name -}}
+    {{- end }}
+  {{- end }}
+  value: {{ uniq $hosts | compact | sortAlpha | join "," }}
 {{- end }}
 {{- end -}}
 

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -440,7 +440,7 @@ Build comma separated list of configmaps
   {{- if (and .Values.oauthProxy.enabled .Values.oauthProxy.ingressHost) -}}
   {{- $hosts = append $hosts .Values.oauthProxy.ingressHost }}
   {{- end }}
-  value: {{ join "," $hosts }}
+  value: {{ uniq $hosts | sortAlpha | join "," }}
 {{- end }}
 {{- end -}}
 

--- a/charts/standard-application-stack/tests/ingress_test.yaml
+++ b/charts/standard-application-stack/tests/ingress_test.yaml
@@ -175,6 +175,25 @@ tests:
           count: 1
         template: deployment.yaml
 
+  - it: Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses
+    template: deployment.yaml
+    set:
+      global.clusterEnv: qa
+      ingress.enabled: true
+      ingress.defaultHost: test.default.com
+      ingress.extraHosts:
+        - name: extra.default.com
+      ingress.extraIngresses:
+        - defaultHost: test.extraIngress.com
+          extraHosts:
+            - name: extra.extraIngress.com
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_ALLOWED_HOSTS
+            value: 'extra.default.com,extra.extraIngress.com,test.default.com,test.extraIngress.com'
+          count: 1
 
   - it: Check extraHosts with oauthProxy.ingressHost (different)
     template: ingress.yaml

--- a/charts/standard-application-stack/tests/ingress_test.yaml
+++ b/charts/standard-application-stack/tests/ingress_test.yaml
@@ -1,10 +1,12 @@
 suite: Test Ingresses
 templates:
   - ingress.yaml
+  - deployment.yaml
 release:
   namespace: test-namespace
 tests:
   - it: Check ALB className set by default
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -14,6 +16,7 @@ tests:
           value: alb-public-apps-default
 
   - it: Check HAProxy className set if ALB is disabled
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -24,6 +27,7 @@ tests:
           value: haproxy
 
   - it: Check ALB default health-check port
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -35,6 +39,7 @@ tests:
           value: "8080"
 
   - it: Check ALB custom health-check port
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -47,6 +52,7 @@ tests:
           value: "9999"
 
   - it: Check ALB health-check port with oauthProxy enabled
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -58,6 +64,7 @@ tests:
           value: "4180"
 
   - it: Check ALB gRPC default settings
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -75,6 +82,7 @@ tests:
           value: /grpc.health.v1.Health/Check
 
   - it: Check ALB gRPC custom settings
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -94,6 +102,7 @@ tests:
           value: /grpc.health.v1.Readiness/Check
 
   - it: Check ALB HTTP2 default settings
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -117,6 +126,7 @@ tests:
           value: "443"
 
   - it: Check no TLS set if ingressTLSSecrets and specificTlsHostsYaml is empty
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       global.ingressTLSSecrets: null
@@ -129,6 +139,7 @@ tests:
           path: spec.tls
 
   - it: Check TLS set if ingressTLSSecrets is not empty
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       global.ingressTLSSecrets.example_org: star-example-org
@@ -141,7 +152,9 @@ tests:
           path: spec.tls
 
   - it: Check extraHosts
+    template: ingress.yaml
     set:
+      global.name: AppyMcAppface
       global.clusterEnv: qa
       ingress.enabled: true
       ingress.defaultHost: test.default.com
@@ -154,8 +167,17 @@ tests:
       - equal:
           path: spec.rules[1].host
           value: extra.default.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_ALLOWED_HOSTS
+            value: 'extra.default.com,test.default.com'
+          count: 1
+        template: deployment.yaml
+
 
   - it: Check extraHosts with oauthProxy.ingressHost (different)
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -174,8 +196,16 @@ tests:
       - equal:
           path: spec.rules[2].host
           value: auth.default.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_ALLOWED_HOSTS
+            value: 'auth.default.com,extra.default.com,test.default.com'
+          count: 1
+        template: deployment.yaml
 
   - it: Check extraHosts with oauthProxy.ingressHost (same as extra host)
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -191,8 +221,16 @@ tests:
       - equal:
           path: spec.rules[1].host
           value: auth.default.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_ALLOWED_HOSTS
+            value: 'auth.default.com,test.default.com'
+          count: 1
+        template: deployment.yaml
 
   - it: Check extraHosts with TLS
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -208,8 +246,16 @@ tests:
       - equal:
           path: spec.tls[0].hosts[1]
           value: extra.default.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_ALLOWED_HOSTS
+            value: 'extra.default.com,test.default.com'
+          count: 1
+        template: deployment.yaml
 
   - it: Check extraHosts with TLS and oauthProxy.ingressHost (different)
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -230,8 +276,16 @@ tests:
       - equal:
           path: spec.tls[0].hosts[2]
           value: auth.default.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_ALLOWED_HOSTS
+            value: 'auth.default.com,extra.default.com,test.default.com'
+          count: 1
+        template: deployment.yaml
 
   - it: Check extraHosts with TLS and oauthProxy.ingressHost (same as extra host)
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -249,8 +303,16 @@ tests:
       - equal:
           path: spec.tls[0].hosts[1]
           value: auth.default.com
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: EXTRA_ALLOWED_HOSTS
+            value: 'auth.default.com,test.default.com'
+          count: 1
+        template: deployment.yaml
 
   - it: Check ingress name override
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -269,6 +331,7 @@ tests:
           value: ingress-override
 
   - it: Check ingress name suffix setting
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -287,6 +350,7 @@ tests:
           value: example-app-suffix
 
   - it: Default ingress with path based routing
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true
@@ -320,6 +384,7 @@ tests:
           value: 5678
 
   - it: Multiple ingresses with different names
+    template: ingress.yaml
     set:
       global.clusterEnv: qa
       ingress.enabled: true


### PR DESCRIPTION
The hosts from `ingress.extraIngresses` should also be included in the `EXTRA_ALLOWED_HOSTS` env var.