### PR TITLE
Fix Terraform secrets list to respect secretNameOverride

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.53.1] - 2022-12-28
+### Fixed
+- Fix list of Terraform secrets to respect `secretNameOverride`
+
 ## [v3.53.0] - 2022-12-16
 ### Added
 - Added template for `Job` resources, including config to support ArgoCD sync phases and waves.

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.53.0
+version: 3.53.1
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.53.0](https://img.shields.io/badge/Version-3.53.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.53.1](https://img.shields.io/badge/Version-3.53.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/tests/deployment_mariadb_enabled_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_mariadb_enabled_test.yaml
@@ -1,0 +1,67 @@
+suite: Test MariaDB Enabled Deployment
+templates:
+  - deployment.yaml
+release:
+  namespace: test-namespace
+tests:
+  - it: Check MariaDB envfrom secretRef is present
+    set:
+      global.clusterEnv: qa
+      global.name: test-app
+      mariadb.enabled: true
+      # Disable default application secret
+      externalSecret.enabled: false
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: test-app-mariadb
+  - it: Check MariaDB secretName Override
+    set:
+      global.clusterEnv: qa
+      global.name: test-app
+      mariadb.enabled: true
+      mariadb.secretNameOverride: overrideName
+      # Disable default application secret
+      externalSecret.enabled: false
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: overrideName
+      - equal:
+          path: metadata.annotations.[secret.reloader.stakater.com/reload]
+          value: overrideName
+  - it: Check MariaDB envfrom secretRef is present for local environment
+    set:
+      global.clusterEnv: local
+      global.name: test-app
+      mariadb.enabled: true
+      # Disable default application secret
+      externalSecret.enabled: false
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.annotations.[secret.reloader.stakater.com/reload]
+          value: test-app-mariadb
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].secretRef.name
+          value: test-app-mariadb

--- a/charts/standard-application-stack/tests/deployment_s3_enabled_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_s3_enabled_test.yaml
@@ -50,10 +50,10 @@ tests:
           count: 1
       - equal:
           path: spec.template.spec.containers[0].envFrom[0].secretRef.name
-          value: mntl-test-bucket-s3
+          value: mntl-test-bucket-another-s3
       - equal:
           path: spec.template.spec.containers[0].envFrom[1].secretRef.name
-          value: mntl-test-bucket-another-s3
+          value: mntl-test-bucket-s3
   - it: Check S3 stakater secret reloader annotation contains correct secrets for multiple instances of TF Cloud helm chart
     set:
       global.clusterEnv: qa
@@ -83,7 +83,7 @@ tests:
           count: 1
       - equal:
           path: metadata.annotations.[secret.reloader.stakater.com/reload]
-          value: test-app-app,mntl-test-bucket-s3,mntl-test-bucket-another-s3,test-app-extra-secret-1
+          value: mntl-test-bucket-another-s3,mntl-test-bucket-s3,test-app-app,test-app-extra-secret-1
   - it: Check S3 secretName Override
     set:
       global.clusterEnv: qa


### PR DESCRIPTION
The Terraform resources created by the standard-application-stack Helm chart have a `secretNameOverride` value that can change the name of the Kubernetes secret the Terraform outputs get written to. The `mintel_common.tf_cloud_external_secrets` helper template was not respecting that value.