### PR TITLE
Replace default with coalesce in some cases, other clean up

### DIFF
--- a/charts/aws-api-gateway-operator/CHANGELOG.md
+++ b/charts/aws-api-gateway-operator/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.1.1] - 2022-12-29
 ### Changed
 - Refactor use of the `default` template function (sometimes use `coalesce`)
 - Remove pointless `print` and `printf` function calls

--- a/charts/aws-api-gateway-operator/CHANGELOG.md
+++ b/charts/aws-api-gateway-operator/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Refactor use of the `default` template function (sometimes use `coalesce`)
+- Remove pointless `print` and `printf` function calls
 
 ## [v0.1.0] - 2022-06-07
 ### Added

--- a/charts/aws-api-gateway-operator/CHANGELOG.md
+++ b/charts/aws-api-gateway-operator/CHANGELOG.md
@@ -4,8 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
+### Changed
+- Refactor use of the `default` template function (sometimes use `coalesce`)
 
-## [0.1.0] - 2022-06-07
+## [v0.1.0] - 2022-06-07
 ### Added
 - Added initial chart implementation

--- a/charts/aws-api-gateway-operator/Chart.yaml
+++ b/charts/aws-api-gateway-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: aws-api-gateway-operator
 description: AWS API Gateway Operator Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: v1.0.2
 keywords:
   - eks

--- a/charts/aws-api-gateway-operator/README.md
+++ b/charts/aws-api-gateway-operator/README.md
@@ -1,6 +1,6 @@
 # aws-api-gateway-operator
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.2](https://img.shields.io/badge/AppVersion-v1.0.2-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.2](https://img.shields.io/badge/AppVersion-v1.0.2-informational?style=flat-square)
 
 AWS API Gateway Operator Helm chart for Kubernetes
 

--- a/charts/aws-api-gateway-operator/templates/_helpers.tpl
+++ b/charts/aws-api-gateway-operator/templates/_helpers.tpl
@@ -5,7 +5,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because sometimes Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "mintel_common.fullname" -}}
-{{- printf "%s" .Values.global.name | trunc 63 | trimSuffix "-" -}}
+{{- .Values.global.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/* Common Annotations */}}

--- a/charts/aws-api-gateway-operator/templates/_helpers.tpl
+++ b/charts/aws-api-gateway-operator/templates/_helpers.tpl
@@ -32,9 +32,9 @@ app.mintel.com/owner: {{ .Values.global.owner }}
 {{- end }}
 app.mintel.com/env: {{ .Values.global.clusterEnv }}
 {{- if (eq .Values.global.clusterEnv "local") }}
-app.mintel.com/region: {{default "local" $.Values.global.clusterRegion }}
+app.mintel.com/region: {{ $.Values.global.clusterRegion | default "local" }}
 {{- else }}
-app.mintel.com/region: {{default "${CLUSTER_REGION}" $.Values.global.clusterRegion }}
+app.mintel.com/region: {{ $.Values.global.clusterRegion | default "${CLUSTER_REGION}" }}
 {{- end }}
 {{- if .Values.global }}
 {{- with .Values.global.additionalLabels }}
@@ -68,8 +68,8 @@ Create the name of the service account to use
 */}}
 {{- define "aws-api-gateway-operator.serviceAccountName" -}}
 {{- if (index .Values "standard-application-stack" "serviceAccount" "create") -}}
-    {{ default (include "mintel_common.fullname" .) (index .Values "standard-application-stack" "serviceAccount" "name") }}
+    {{ (index .Values "standard-application-stack" "serviceAccount" "name") | default (include "mintel_common.fullname" .) }}
 {{- else -}}
-    {{ default "default" (index .Values "standard-application-stack" "serviceAccount" "name") }}
+    {{ (index .Values "standard-application-stack" "serviceAccount" "name") | default "default"  }}
 {{- end -}}
 {{- end -}}

--- a/charts/basic-config/CHANGELOG.md
+++ b/charts/basic-config/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor use of the `default` template function (sometimes use `coalesce`)
 - Remove pointless `print` and `printf` function calls
 
+### Fixed
+- Make spacing inside `{{ }}` consistent
+
 ## [v0.2.0] - 2022-07-13
 ### Added
 - Allow `Service` and `ExternalSecret` to be named explicitly using `nameOverride` option

--- a/charts/basic-config/CHANGELOG.md
+++ b/charts/basic-config/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Refactor use of the `default` template function (sometimes use `coalesce`)
+- Remove pointless `print` and `printf` function calls
 
 ## [v0.2.0] - 2022-07-13
 ### Added

--- a/charts/basic-config/CHANGELOG.md
+++ b/charts/basic-config/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.2.1] - 2022-12-29
 ### Changed
 - Refactor use of the `default` template function (sometimes use `coalesce`)
 - Remove pointless `print` and `printf` function calls

--- a/charts/basic-config/CHANGELOG.md
+++ b/charts/basic-config/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+- Refactor use of the `default` template function (sometimes use `coalesce`)
 
 ## [v0.2.0] - 2022-07-13
 ### Added

--- a/charts/basic-config/Chart.yaml
+++ b/charts/basic-config/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1

--- a/charts/basic-config/README.md
+++ b/charts/basic-config/README.md
@@ -1,6 +1,6 @@
 # basic-config
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for defining basic k8s configuration res
 

--- a/charts/basic-config/templates/_capabilities.tpl
+++ b/charts/basic-config/templates/_capabilities.tpl
@@ -8,10 +8,10 @@ Return the target Kubernetes version
     {{- if .Values.global.kubeVersion }}
     {{- .Values.global.kubeVersion -}}
     {{- else }}
-    {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+    {{- .Values.kubeVersion | default .Capabilities.KubeVersion.Version -}}
     {{- end -}}
 {{- else }}
-{{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- .Values.kubeVersion | default .Capabilities.KubeVersion.Version -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/basic-config/templates/_capabilities.tpl
+++ b/charts/basic-config/templates/_capabilities.tpl
@@ -17,37 +17,37 @@ Return the target Kubernetes version
 
 {{/* Return the appropriate apiVersion for RBAC resources. */}}
 {{- define "common.capabilities.rbac.apiVersion" -}}
-{{- print "rbac.authorization.k8s.io/v1" -}}
+rbac.authorization.k8s.io/v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for External Secrets. */}}
 {{- define "common.capabilities.externalsecret.apiVersion" -}}
-{{- print "external-secrets.io/v1alpha1" -}}
+external-secrets.io/v1alpha1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for Secrets. */}}
 {{- define "common.capabilities.secret.apiVersion" -}}
-{{- print "v1" -}}
+v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for Configmaps */}}
 {{- define "common.capabilities.configmap.apiVersion" -}}
-{{- print "v1" -}}
+v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for Service Accounts. */}}
 {{- define "common.capabilities.serviceaccount.apiVersion" -}}
-{{- print "v1" -}}
+v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for Services. */}}
 {{- define "common.capabilities.service.apiVersion" -}}
-{{- print "v1" -}}
+v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for NetworkPolicy. */}}
 {{- define "common.capabilities.networkpolicy.apiVersion" -}}
-{{- print "networking.k8s.io/v1" -}}
+networking.k8s.io/v1
 {{- end -}}
 
 

--- a/charts/basic-config/templates/_helpers.tpl
+++ b/charts/basic-config/templates/_helpers.tpl
@@ -60,7 +60,7 @@ app.mintel.com/region: {{ $.Values.global.clusterRegion | default "${CLUSTER_REG
 {{- define "mintel_common.serviceLabels" -}}
 {{ include "mintel_common.labels" . }}
 {{- with .Values.service.labels }}
-{{- toYaml .}}
+{{- toYaml . }}
 {{- end }}
 {{- end -}}
 

--- a/charts/basic-config/templates/_helpers.tpl
+++ b/charts/basic-config/templates/_helpers.tpl
@@ -37,9 +37,9 @@ app.mintel.com/owner: {{ .Values.global.owner }}
 {{- end }}
 app.mintel.com/env: {{ .Values.global.clusterEnv }}
 {{- if (eq .Values.global.clusterEnv "local") }}
-app.mintel.com/region: {{default "local" $.Values.global.clusterRegion }}
+app.mintel.com/region: {{ $.Values.global.clusterRegion | default "local" }}
 {{- else }}
-app.mintel.com/region: {{default "${CLUSTER_REGION}" $.Values.global.clusterRegion }}
+app.mintel.com/region: {{ $.Values.global.clusterRegion | default "${CLUSTER_REGION}" }}
 {{- end }}
 {{- if .Values.global }}
 {{- with .Values.global.additionalLabels }}
@@ -53,7 +53,7 @@ app.mintel.com/region: {{default "${CLUSTER_REGION}" $.Values.global.clusterRegi
 
 {{/* Service name */}}
 {{- define "mintel_common.serviceName" -}}
-{{ default (include "mintel_common.fullname" .) $.Values.service.nameOverride }}
+{{ $.Values.service.nameOverride | default (include "mintel_common.fullname" .) }}
 {{- end -}}
 
 {{/* Service labels */}}

--- a/charts/basic-config/templates/_helpers.tpl
+++ b/charts/basic-config/templates/_helpers.tpl
@@ -10,7 +10,7 @@ We truncate at 63 chars because sometimes Kubernetes name fields are limited to 
 {{- else if .component }}
 {{- printf "%s-%s" .Values.global.name .component | trimSuffix .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s" .Values.global.name | trunc 63 | trimSuffix "-" -}}
+{{- .Values.global.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/basic-config/templates/secrets.yaml
+++ b/charts/basic-config/templates/secrets.yaml
@@ -5,7 +5,7 @@
 apiVersion: {{ include "common.capabilities.secret.apiVersion" $ }}
 kind: Secret
 metadata:
-  name: {{ default (include "mintel_common.fullname" $secretData) .nameOverride }}
+  name: {{ .nameOverride | default (include "mintel_common.fullname" $secretData) }}
   labels: {{ include "mintel_common.labels" $secretData | nindent 4 }}
   annotations: {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}
   namespace: {{ $.Release.Namespace }}
@@ -19,7 +19,7 @@ data:
 apiVersion: {{ include "common.capabilities.externalsecret.apiVersion" $ }}
 kind: ExternalSecret
 metadata:
-  name: {{ default (include "mintel_common.fullname" $secretData) .nameOverride}}
+  name: {{ .nameOverride | default (include "mintel_common.fullname" $secretData) }}
   labels: {{ include "mintel_common.labels" $secretData | nindent 4 }}
   namespace: {{ $.Release.Namespace }}
   annotations:
@@ -27,10 +27,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ coalesce .pathOverride (printf "%s/%s/%s" $.Release.Namespace (include "mintel_common.fullname" $) .name) }}
-  refreshInterval: {{ default "5m0s" .refreshIntervalOverride }}
+    - key: {{ .pathOverride | default (printf "%s/%s/%s" $.Release.Namespace (include "mintel_common.fullname" $) .name) }}
+  refreshInterval: {{ .refreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
-    name: {{ default "aws-secrets-manager-local" .secretStoreRefOverride }}
+    name: {{ .secretStoreRefOverride | default "aws-secrets-manager-local" }}
     kind: SecretStore
   target:
     creationPolicy: Owner

--- a/charts/basic-config/templates/service-account-cluster-role-bindings.yaml
+++ b/charts/basic-config/templates/service-account-cluster-role-bindings.yaml
@@ -16,7 +16,7 @@ roleRef:
   name: {{ include "mintel_common.fullname" $roleData }}
 subjects:
   - kind: ServiceAccount
-    name: {{ default (include "mintel_common.fullname" $) $.Values.serviceAccount.name }}
+    name: {{ $.Values.serviceAccount.name | default (include "mintel_common.fullname" $) }}
     apiGroup: rbac.authorization.k8s.io
 {{- end }}
 

--- a/charts/basic-config/templates/service-account-cluster-role-bindings.yaml
+++ b/charts/basic-config/templates/service-account-cluster-role-bindings.yaml
@@ -8,7 +8,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "mintel_common.fullname" $roleData }}
   namespace: {{ $.Release.Namespace }}
-  labels: {{ include "mintel_common.labels" $roleData | nindent 4}}
+  labels: {{ include "mintel_common.labels" $roleData | nindent 4 }}
   annotations: {{ include "mintel_common.commonAnnotations" $roleData | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/basic-config/templates/service-account-role-bindings.yaml
+++ b/charts/basic-config/templates/service-account-role-bindings.yaml
@@ -16,7 +16,7 @@ roleRef:
   name: {{ include "mintel_common.fullname" $roleData }}
 subjects:
   - kind: ServiceAccount
-    name: {{ default (include "mintel_common.fullname" $) $.Values.serviceAccount.name }}
+    name: {{ $.Values.serviceAccount.name | default (include "mintel_common.fullname" $) }}
     namespace: {{ $.Release.Namespace }}
 {{- end }}
 

--- a/charts/basic-config/templates/service-account-role-bindings.yaml
+++ b/charts/basic-config/templates/service-account-role-bindings.yaml
@@ -8,7 +8,7 @@ kind: RoleBinding
 metadata:
   name: {{ include "mintel_common.fullname" $roleData }}
   namespace: {{ $.Release.Namespace }}
-  labels: {{ include "mintel_common.labels" $roleData | nindent 4}}
+  labels: {{ include "mintel_common.labels" $roleData | nindent 4 }}
   annotations: {{ include "mintel_common.commonAnnotations" $roleData | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/basic-config/templates/service-accounts.yaml
+++ b/charts/basic-config/templates/service-accounts.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
   namespace: {{ .Release.Namespace }}
-  labels: {{ include "mintel_common.labels" . | nindent 4}}
+  labels: {{ include "mintel_common.labels" . | nindent 4 }}
   {{- if (or .Values.serviceAccount.annotations (and .Values.serviceAccount.irsa.enabled (ne .Values.global.clusterEnv "local"))) }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}

--- a/charts/basic-config/templates/service-accounts.yaml
+++ b/charts/basic-config/templates/service-accounts.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.serviceaccount.apiVersion" . }}
 kind: ServiceAccount
 metadata:
-  name: {{ default (include "mintel_common.fullname" .) .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "mintel_common.labels" . | nindent 4}}
   {{- if (or .Values.serviceAccount.annotations (and .Values.serviceAccount.irsa.enabled (ne .Values.global.clusterEnv "local"))) }}

--- a/charts/basic-config/templates/service.yaml
+++ b/charts/basic-config/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.service.apiVersion" . }}
 kind: Service
 metadata:
-  name: {{ default (include "mintel_common.serviceName" .) }}
+  name: {{ include "mintel_common.serviceName" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "mintel_common.serviceLabels" . | nindent 4 }}
   annotations:
@@ -15,5 +15,5 @@ spec:
   clusterIP: None
   {{- end }}
   type: {{ .Values.service.type }}
-  selector: {{ default (include "mintel_common.selectorLabels" .) (toYaml .Values.service.selectorLabelsOverride | nindent 6) }}
+  selector: {{ (toYaml .Values.service.selectorLabelsOverride | nindent 6) | default (include "mintel_common.selectorLabels" .) }}
 {{- end }}

--- a/charts/hybrid-consul-config-crds/Chart.yaml
+++ b/charts/hybrid-consul-config-crds/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3

--- a/charts/hybrid-consul-config-crds/README.md
+++ b/charts/hybrid-consul-config-crds/README.md
@@ -1,6 +1,6 @@
 # hybrid-consul-config-crds
 
-![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for defining Consul CRDs
 

--- a/charts/hybrid-consul-config-crds/templates/intention.yaml
+++ b/charts/hybrid-consul-config-crds/templates/intention.yaml
@@ -17,7 +17,7 @@ spec:
         - action: {{ .action }}
         {{- end }}
       {{- else }}
-      action: {{ default "allow" .action }}
+      action: {{ .action | default "allow" }}
       {{- end }}
     {{- end }}
 {{- end }}

--- a/charts/hybrid-consul-config-crds/templates/terminating-gateway.yaml
+++ b/charts/hybrid-consul-config-crds/templates/terminating-gateway.yaml
@@ -3,7 +3,7 @@
 apiVersion: consul.hashicorp.com/v1alpha1
 kind: TerminatingGateway
 metadata:
-  name: {{ default "terminating-gateway" .terminatingGatewayNameOverride | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+  name: {{ .terminatingGatewayNameOverride | default "terminating-gateway" | replace "+" "_" | trunc 63 | trimSuffix "-" }}
   namespace: {{ $.Release.Namespace }}
 spec:
   services:

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Refactor use of the `default` template function (sometimes use `coalesce`)
 - Remove pointless print functions from templates
+- Make concatenated lists sorted and unique
 
 ## [v3.53.1] - 2022-12-27
 ### Fixed

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v3.53.2] - 2022-12-29
 ### Changed
 - Refactor use of the `default` template function (sometimes use `coalesce`)
 - Remove pointless print functions from templates

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Refactor use of the `default` template function (sometimes use `coalesce`)
+- Remove pointless print functions from templates
 
 ## [v3.53.1] - 2022-12-27
 ### Fixed

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove pointless print functions from templates
 - Make concatenated lists sorted and unique
 
+### Fixed
+- Make spacing inside `{{ }}` consistent
+
 ## [v3.53.1] - 2022-12-27
 ### Fixed
 - Fix list of Terraform secrets to respect `secretNameOverride`

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Refactor use of the `default` template function (sometimes use `coalesce`)
 
-## [v3.53.1] - 2022-12-28
+## [v3.53.1] - 2022-12-27
 ### Fixed
 - Fix list of Terraform secrets to respect `secretNameOverride`
 

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.53.1
+version: 3.53.2
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.53.1](https://img.shields.io/badge/Version-3.53.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.53.2](https://img.shields.io/badge/Version-3.53.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/_capabilities.tpl
+++ b/charts/standard-application-stack/templates/_capabilities.tpl
@@ -17,91 +17,91 @@ Return the target Kubernetes version
 
 {{/* Return the appropriate apiVersion for policy. */}}
 {{- define "common.capabilities.policy.apiVersion" -}}
-{{- print "policy/v1" -}}
+policy/v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for cronjob. */}}
 {{- define "common.capabilities.cronjob.apiVersion" -}}
-{{- print "batch/v1" -}}
+batch/v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for job. */}}
 {{- define "common.capabilities.job.apiVersion" -}}
-{{- print "batch/v1" -}}
+batch/v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for deployment. */}}
 {{- define "common.capabilities.deployment.apiVersion" -}}
-{{- print "apps/v1" -}}
+apps/v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for statefulset. */}}
 {{- define "common.capabilities.statefulset.apiVersion" -}}
-{{- print "apps/v1" -}}
+apps/v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for ingress */}}
 {{- define "common.capabilities.ingress.apiVersion" -}}
 {{- if .Values.ingress.apiVersion -}}
 {{- .Values.ingress.apiVersion -}}
-{{- else }}
-{{- print "networking.k8s.io/v1" -}}
-{{- end }}
+{{- else -}}
+networking.k8s.io/v1
+{{- end -}}
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for RBAC resources. */}}
 {{- define "common.capabilities.rbac.apiVersion" -}}
-{{- print "rbac.authorization.k8s.io/v1" -}}
+rbac.authorization.k8s.io/v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for CRDs. */}}
 {{- define "common.capabilities.crd.apiVersion" -}}
-{{- print "apiextensions.k8s.io/v1" -}}
+apiextensions.k8s.io/v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for Pod Monitors. */}}
 {{- define "common.capabilities.podmonitor.apiVersion" -}}
-{{- print "monitoring.coreos.com/v1" -}}
+monitoring.coreos.com/v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for Service Monitors. */}}
 {{- define "common.capabilities.servicemonitor.apiVersion" -}}
-{{- print "monitoring.coreos.com/v1" -}}
+monitoring.coreos.com/v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for External Secrets. */}}
 {{- define "common.capabilities.externalsecret.apiVersion" -}}
-{{- print "external-secrets.io/v1alpha1" -}}
+external-secrets.io/v1alpha1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for Secrets. */}}
 {{- define "common.capabilities.secret.apiVersion" -}}
-{{- print "v1" -}}
+v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for Configmaps */}}
 {{- define "common.capabilities.configmap.apiVersion" -}}
-{{- print "v1" -}}
+v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for Service Accounts. */}}
 {{- define "common.capabilities.serviceaccount.apiVersion" -}}
-{{- print "v1" -}}
+v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for Services. */}}
 {{- define "common.capabilities.service.apiVersion" -}}
-{{- print "v1" -}}
+v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for PersistentVolumeClaim. */}}
 {{- define "common.capabilities.pvc.apiVersion" -}}
-{{- print "v1" -}}
+v1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for NetworkPolicy. */}}
 {{- define "common.capabilities.networkpolicy.apiVersion" -}}
-{{- print "networking.k8s.io/v1" -}}
+networking.k8s.io/v1
 {{- end -}}
 
 {{/*
@@ -118,5 +118,5 @@ This check is introduced as a regexMatch instead of {{ if .Capabilities.HelmVers
 
 {{/* Return the appropriate apiVersion for VerticalPodAutoscaler. */}}
 {{- define "common.capabilities.verticalPodAutoscaler.apiVersion" -}}
-{{- print "autoscaling.k8s.io/v1" -}}
+autoscaling.k8s.io/v1
 {{- end -}}

--- a/charts/standard-application-stack/templates/_capabilities.tpl
+++ b/charts/standard-application-stack/templates/_capabilities.tpl
@@ -8,10 +8,10 @@ Return the target Kubernetes version
     {{- if .Values.global.kubeVersion }}
     {{- .Values.global.kubeVersion -}}
     {{- else }}
-    {{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+    {{- .Values.kubeVersion | default .Capabilities.KubeVersion.Version -}}
     {{- end -}}
 {{- else }}
-{{- default .Capabilities.KubeVersion.Version .Values.kubeVersion -}}
+{{- .Values.kubeVersion | default .Capabilities.KubeVersion.Version -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -292,7 +292,7 @@ Build comma separated list of secrets
 {{- $secretList = append $secretList (.nameOverride | default (printf "%s-%s" (include "mintel_common.fullname" $) .name) ) -}}
 {{- end }}
 {{- end }}
-{{- uniq $secretList | compact | sortAlpha | join "," -}}
+{{- $secretList | sortAlpha | uniq | compact | join "," -}}
 {{- end -}}
 
 {{/*
@@ -307,7 +307,7 @@ Build comma separated list of configmaps
 {{- range .Values.configMaps }}
 {{- $configmapList = append $configmapList (printf "%s-%s" (include "mintel_common.fullname" $) .name) }}
 {{- end }}
-{{- join "," $configmapList -}}
+{{- $configmapList | sortAlpha | uniq | compact | join "," -}}
 {{- end -}}
 
 {{/* Outputs Event Bus env variables */}}
@@ -424,7 +424,7 @@ Build comma separated list of configmaps
 {{- $endpoints = append $endpoints (printf "%s=http://%s-localstack:%s" (. | trim) (include "mintel_common.fullname" $) (default 4566 ($.Values.localstack.port | toString))) -}}
 {{- end }}
 - name: AWS_ENDPOINTS
-  value: {{ join "," $endpoints }}
+  value: {{ $endpoints | sortAlpha | uniq | compact | join "," }}
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -446,7 +446,7 @@ Build comma separated list of configmaps
     {{- $hosts = append $hosts .name -}}
     {{- end }}
   {{- end }}
-  value: {{ uniq $hosts | compact | sortAlpha | join "," }}
+  value: {{ $hosts | sortAlpha | uniq | compact | join "," }}
 {{- end }}
 {{- end -}}
 
@@ -489,7 +489,7 @@ topologySpreadConstraints:
 {{/* Supported resources */}}
 {{- define "mintel_common.terraformCloudResources" -}}
 {{- $terraformCloudResources := (list "opensearch" "postgresql" "redis" "s3" "mariadb" "dynamodb" "sqs") -}}
-{{ join "," $terraformCloudResources }}
+{{ $terraformCloudResources | sortAlpha | uniq | compact | join ","}}
 {{- end -}}
 
 {{/* Set instanceConfig.Name */}}
@@ -532,5 +532,5 @@ topologySpreadConstraints:
     {{- end }}
   {{- end }}
 {{- end }}
-{{- uniq $tfSecretList | compact | sortAlpha | join "," -}}
+{{- $tfSecretList | sortAlpha | uniq | compact | join "," -}}
 {{- end -}}

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -55,9 +55,9 @@ app.mintel.com/owner: {{ .Values.global.owner }}
 {{- end }}
 app.mintel.com/env: {{ .Values.global.clusterEnv }}
 {{- if (eq .Values.global.clusterEnv "local") }}
-app.mintel.com/region: {{default "local" $.Values.global.clusterRegion }}
+app.mintel.com/region: {{$.Values.global.clusterRegion | default "local" }}
 {{- else }}
-app.mintel.com/region: {{default "${CLUSTER_REGION}" $.Values.global.clusterRegion }}
+app.mintel.com/region: {{ $.Values.global.clusterRegion | default "${CLUSTER_REGION}" }}
 {{- end }}
 {{- if .Values.global }}
 {{- with .Values.global.additionalLabels }}
@@ -115,12 +115,12 @@ Return the proper Application image name
 {{- define "mintel_common.image" -}}
 {{- $registryName := "" }}
 {{- if (eq .Values.global.clusterEnv "local") }}
-{{- $registryName = default "k3d-default.localhost:5000" .Values.image.registry -}}
+{{- $registryName = .Values.image.registry | default "k3d-default.localhost:5000" -}}
 {{- else }}
-{{- $registryName = default "registry.gitlab.com" .Values.image.registry -}}
+{{- $registryName = .Values.image.registry | default "registry.gitlab.com" -}}
 {{- end }}
 {{- $repositoryName := required "Must specify a docker repository." .Values.image.repository -}}
-{{- $tag := default "auto-replaced" .Values.image.tag | toString -}}
+{{- $tag := .Values.image.tag | default "auto-replaced" | toString -}}
 {{- printf "%s/%s:%s" $registryName $repositoryName $tag -}}
 {{- end -}}
 
@@ -151,7 +151,7 @@ Create a default oauth external secret name.
 */}}
 {{- define "mintel_common.defaultOauthSecretName" -}}
 {{- $fullname := include "mintel_common.fullname" . }}
-{{- printf "%s-%s" $fullname (default "oauth" .Values.oauthProxy.secretSuffix) }}
+{{- printf "%s-%s" $fullname (.Values.oauthProxy.secretSuffix | default "oauth") }}
 {{- end -}}
 
 {{/*
@@ -250,10 +250,10 @@ Build comma separated list of secrets
 {{- define "mintel_common.secretList" -}}
 {{- $secretList := list -}}
 {{- if (and .Values.externalSecret .Values.externalSecret.enabled) }}
-{{- $secretList = append $secretList (default (include "mintel_common.defaultAppSecretName" .) .Values.externalSecret.nameOverride) -}}
+{{- $secretList = append $secretList (.Values.externalSecret.nameOverride | default (include "mintel_common.defaultAppSecretName" .)) -}}
 {{- end }}
 {{- if (and .Values.oauthProxy .Values.oauthProxy.enabled) }}
-{{- $secretList = append $secretList (default (include "mintel_common.defaultOauthSecretName" .) .Values.oauthProxy.secretNameOverride) -}}
+{{- $secretList = append $secretList (.Values.oauthProxy.secretNameOverride | default (include "mintel_common.defaultOauthSecretName" .)) -}}
 {{- end }}
 {{- if (and (ne .Values.global.clusterEnv "local") .Values.global.terraform.externalSecrets) }}
   {{- range include "mintel_common.tf_cloud_external_secrets" . | split "," }}
@@ -263,33 +263,33 @@ Build comma separated list of secrets
   {{- end }}
 {{- else }}
     {{- if (and .Values.mariadb .Values.mariadb.enabled) }}
-    {{- $secretList = append $secretList (default (include "mintel_common.defaultMariadbSecretName" .) .Values.mariadb.secretNameOverride) -}}
+    {{- $secretList = append $secretList (.Values.mariadb.secretNameOverride | default (include "mintel_common.defaultMariadbSecretName" .)) -}}
     {{- end }}
     {{- if (and .Values.dynamodb .Values.dynamodb.enabled) }}
-    {{- $secretList = append $secretList (default (include "mintel_common.defaultDynamodbSecretName" .) .Values.dynamodb.secretNameOverride) -}}
+    {{- $secretList = append $secretList (.Values.dynamodb.secretNameOverride | default (include "mintel_common.defaultDynamodbSecretName" .)) -}}
     {{- end }}
     {{- if (and .Values.postgresql .Values.postgresql.enabled) }}
-    {{- $secretList = append $secretList (default (include "mintel_common.defaultPostgresqlSecretName" .) .Values.postgresql.secretNameOverride) -}}
+    {{- $secretList = append $secretList (.Values.postgresql.secretNameOverride | default (include "mintel_common.defaultPostgresqlSecretName" .)) -}}
     {{- end }}
     {{- if (and .Values.redis .Values.redis.enabled) }}
-    {{- $secretList = append $secretList (default (include "mintel_common.defaultRedisSecretName" .) .Values.redis.secretNameOverride) -}}
+    {{- $secretList = append $secretList (.Values.redis.secretNameOverride | default (include "mintel_common.defaultRedisSecretName" .)) -}}
     {{- end }}
     {{- if (and .Values.s3 .Values.s3.enabled) }}
-    {{- $secretList = append $secretList (default (include "mintel_common.defaultS3SecretName" .) .Values.s3.secretNameOverride) -}}
+    {{- $secretList = append $secretList (.Values.s3.secretNameOverride | default (include "mintel_common.defaultS3SecretName" .)) -}}
     {{- end }}
     {{- if (and .Values.elasticsearch .Values.elasticsearch.enabled) }}
-    {{- $secretList = append $secretList (default (include "mintel_common.defaultElasticsearchSecretName" .) .Values.elasticsearch.secretNameOverride) -}}
+    {{- $secretList = append $secretList (.Values.elasticsearch.secretNameOverride | default (include "mintel_common.defaultElasticsearchSecretName" .)) -}}
     {{- end }}
     {{- if (and .Values.opensearch .Values.opensearch.enabled) }}
-    {{- $secretList = append $secretList (default (include "mintel_common.defaultOpensearchSecretName" .) .Values.opensearch.secretNameOverride) -}}
+    {{- $secretList = append $secretList (.Values.opensearch.secretNameOverride | default (include "mintel_common.defaultOpensearchSecretName" .)) -}}
     {{- end }}
     {{- if (and .Values.sqs .Values.sqs.enabled) }}
-    {{- $secretList = append $secretList (default (include "mintel_common.defaultSqsSecretName" .) .Values.sqs.secretNameOverride) -}}
+    {{- $secretList = append $secretList (.Values.sqs.secretNameOverride | default (include "mintel_common.defaultSqsSecretName" .)) -}}
     {{- end }}
 {{- end }}
 {{- range .Values.extraSecrets }}
 {{- if (or (ne (hasKey . "includeInMain") true) .includeInMain) }}
-{{- $secretList = append $secretList (default (printf "%s-%s" (include "mintel_common.fullname" $) .name) .nameOverride) -}}
+{{- $secretList = append $secretList (.nameOverride | default (printf "%s-%s" (include "mintel_common.fullname" $) .name) ) -}}
 {{- end }}
 {{- end }}
 {{- uniq $secretList | compact | sortAlpha | join "," -}}
@@ -336,7 +336,7 @@ Build comma separated list of configmaps
   value: {{ .Values.global.runtimeEnvironment }}
 {{- if .Values.kubelock.enabled }}
 - name: KUBELOCK_NAME
-  value: {{ default (include "mintel_common.fullname" .) .Values.kubelock.nameOverride }}
+  value: {{ .Values.kubelock.nameOverride | default (include "mintel_common.fullname" .) }}
 - name: KUBELOCK_NAMESPACE
   value: {{ .Release.Namespace }}
 {{- end }}
@@ -469,16 +469,16 @@ topologySpreadConstraints:
   {{- if (and .Values.topologySpreadConstraints.zone .Values.topologySpreadConstraints.zone.enabled) }}
   - labelSelector:
       matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 8 }}
-    maxSkew: {{ default 1 .Values.topologySpreadConstraints.zone.maxSkew }}
+    maxSkew: {{ .Values.topologySpreadConstraints.zone.maxSkew | default 1 }}
     topologyKey: topology.kubernetes.io/zone
-    whenUnsatisfiable: {{ default "DoNotSchedule" .Values.topologySpreadConstraints.zone.whenUnsatisfiable }}
+    whenUnsatisfiable: {{ .Values.topologySpreadConstraints.zone.whenUnsatisfiable | default "DoNotSchedule" }}
   {{- end }}
   {{- if or (and (not (kindIs "bool" .Values.topologySpreadConstraints.node.enabled)) (or (eq .Values.global.clusterEnv "logs") (eq .Values.global.clusterEnv "prod"))) (and .Values.topologySpreadConstraints.node .Values.topologySpreadConstraints.node.enabled) }}
   - labelSelector:
       matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 8 }}
-    maxSkew: {{ default 1 .Values.topologySpreadConstraints.node.maxSkew }}
+    maxSkew: {{ .Values.topologySpreadConstraints.node.maxSkew | default 1 }}
     topologyKey: kubernetes.io/hostname
-    whenUnsatisfiable: {{ default "DoNotSchedule" .Values.topologySpreadConstraints.node.whenUnsatisfiable }}
+    whenUnsatisfiable: {{ .Values.topologySpreadConstraints.node.whenUnsatisfiable | default "DoNotSchedule" }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -10,7 +10,7 @@ We truncate at 63 chars because sometimes Kubernetes name fields are limited to 
 {{- else if .component }}
 {{- printf "%s-%s" .Values.global.name .component | trimSuffix .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s" .Values.global.name | trunc 63 | trimSuffix "-" -}}
+{{- .Values.global.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 
@@ -129,11 +129,11 @@ Return the ImagePullPolicy
 */}}
 {{- define "mintel_common.imagePullPolicy" -}}
 {{- if .Values.image.pullPolicy }}
-{{- printf "%s" .Values.image.pullPolicy -}}
-{{- else if (eq .Values.image.tag "latest") }}
-{{- print "Always" -}}
-{{- else }}
-{{- print "IfNotPresent" -}}
+{{- .Values.image.pullPolicy -}}
+{{- else if (eq .Values.image.tag "latest") -}}
+Always
+{{- else -}}
+IfNotPresent
 {{- end }}
 {{- end -}}
 

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -55,7 +55,7 @@ app.mintel.com/owner: {{ .Values.global.owner }}
 {{- end }}
 app.mintel.com/env: {{ .Values.global.clusterEnv }}
 {{- if (eq .Values.global.clusterEnv "local") }}
-app.mintel.com/region: {{$.Values.global.clusterRegion | default "local" }}
+app.mintel.com/region: {{ $.Values.global.clusterRegion | default "local" }}
 {{- else }}
 app.mintel.com/region: {{ $.Values.global.clusterRegion | default "${CLUSTER_REGION}" }}
 {{- end }}
@@ -90,7 +90,7 @@ app.kubernetes.io/component: app
 {{- define "mintel_common.serviceLabels" -}}
 {{ include "mintel_common.labels" . }}
 {{- with .Values.service.labels }}
-{{- toYaml .}}
+{{- toYaml . }}
 {{- end }}
 {{- end -}}
 

--- a/charts/standard-application-stack/templates/_oauth-proxy.tpl
+++ b/charts/standard-application-stack/templates/_oauth-proxy.tpl
@@ -27,7 +27,7 @@
     - --profile-url={{ coalesce (printf "%s/userinfo/" .proxiedService.oauthProxy.issuerUrl) .proxiedService.oauthProxy.profileUrl "https://oauth.mintel.com/userinfo/" }}
     {{- end }}
     {{- with .proxiedService.oauthProxy.allowedGroups }}
-    - --allowed-group={{ join "," . }}
+    - --allowed-group={{ . | sortAlpha | uniq | compact | join "," }}
     {{- end }}
     - --oidc-issuer-url={{ .proxiedService.oauthProxy.issuerUrl | default "https://oauth.mintel.com" }}
     {{- if (eq .proxiedService.oauthProxy.type "portal") }}

--- a/charts/standard-application-stack/templates/_oauth-proxy.tpl
+++ b/charts/standard-application-stack/templates/_oauth-proxy.tpl
@@ -2,17 +2,17 @@
 {{- define "mintel_common.oauthProxySidecar" -}}
 {{- if (and .proxiedService.oauthProxy.enabled (ne .Values.global.clusterEnv "local")) }}
 - name: auth-proxy
-  image: {{ default "quay.io/oauth2-proxy/oauth2-proxy:v7.1.3" .proxiedService.oauthProxy.image }}
-  imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+  image: {{ .proxiedService.oauthProxy.image | default "quay.io/oauth2-proxy/oauth2-proxy:v7.1.3" }}
+  imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
   args:
-    - --redirect-url=https://{{ default .Values.ingress.defaultHost .proxiedService.oauthProxy.ingressHost }}/oauth2/callback
+    - --redirect-url=https://{{ .proxiedService.oauthProxy.ingressHost | default .Values.ingress.defaultHost }}/oauth2/callback
     - --upstream=http://localhost:{{ .proxiedService.port }}
     - --http-address=http://0.0.0.0:4180
     - --provider=oidc
     - --skip-auth-regex=^/ping$
-    - --skip-auth-regex=^{{ default "/healthz" .Values.liveness.path }}$
-    - --skip-auth-regex=^{{ default "/readiness" .Values.readiness.path }}$
-    - --skip-auth-regex=^{{ default "/external-health-check" .Values.ingress.blackbox.probePath }}$
+    - --skip-auth-regex=^{{ .Values.liveness.path | default "/healthz" }}$
+    - --skip-auth-regex=^{{ .Values.readiness.path | default "/readiness" }}$
+    - --skip-auth-regex=^{{ .Values.ingress.blackbox.probePath | default "/external-health-check" }}$
     {{- range .proxiedService.oauthProxy.skipAuthRegexes }}
     - --skip-auth-regex={{ if not (hasPrefix "^" . )}}^{{ end }}{{ . }}{{ if not (hasSuffix "$" . )}}${{ end }}
     {{- end }}
@@ -22,23 +22,23 @@
     - --ssl-upstream-insecure-skip-verify=true
     - --oidc-groups-claim=groups
     - --metrics-address=http://0.0.0.0:9090
-    - --email-domain={{ default "*" .proxiedService.oauthProxy.emailDomain }}
+    - --email-domain={{ .proxiedService.oauthProxy.emailDomain | default "*" }}
     {{- if .proxiedService.oauthProxy.emailDomain }}
-    - --profile-url={{ default "https://oauth.mintel.com/userinfo/" (printf "%s/userinfo/" .proxiedService.oauthProxy.issuerUrl) .proxiedService.oauthProxy.profileUrl }}
+    - --profile-url={{ coalesce (printf "%s/userinfo/" .proxiedService.oauthProxy.issuerUrl) .proxiedService.oauthProxy.profileUrl "https://oauth.mintel.com/userinfo/" }}
     {{- end }}
     {{- with .proxiedService.oauthProxy.allowedGroups }}
     - --allowed-group={{ join "," . }}
     {{- end }}
-    - --oidc-issuer-url={{ default "https://oauth.mintel.com" .proxiedService.oauthProxy.issuerUrl }}
+    - --oidc-issuer-url={{ .proxiedService.oauthProxy.issuerUrl | default "https://oauth.mintel.com" }}
     {{- if (eq .proxiedService.oauthProxy.type "portal") }}
     - --insecure-oidc-allow-unverified-email=true
     - --cookie-secure=false
     {{- if .proxiedService.oauthProxy.emailDomain }}
-    - --user-id-claim={{ default "email" .proxiedService.oauthProxy.userIdClaim }}
+    - --user-id-claim={{ .proxiedService.oauthProxy.userIdClaim | default "email" }}
     {{- else }}
-    - --user-id-claim={{ default "sub" .proxiedService.oauthProxy.userIdClaim }}
+    - --user-id-claim={{ .proxiedService.oauthProxy.userIdClaim | default "sub" }}
     {{- end }}
-    - --scope={{ default "openid profile email" .proxiedService.oauthProxy.scope }}
+    - --scope={{ .proxiedService.oauthProxy.scope | default "openid profile email" }}
     {{- end }}
   env:
     {{- with .proxiedService.oauthProxy.env }}

--- a/charts/standard-application-stack/templates/cronjobs.yaml
+++ b/charts/standard-application-stack/templates/cronjobs.yaml
@@ -11,8 +11,8 @@ metadata:
     helm.sh/chart: {{ include "mintel_common.chart" $ }}
   namespace: {{ $.Release.Namespace }}
 spec:
-  concurrencyPolicy: {{ coalesce .concurrencyPolicy $.Values.cronjobs.defaults.concurrencyPolicy }}
-  {{- if (coalesce .suspend $.Values.cronjobs.defaults.suspend) }}
+  concurrencyPolicy: {{ .concurrencyPolicy | default $.Values.cronjobs.defaults.concurrencyPolicy }}
+  {{- if (.suspend | default $.Values.cronjobs.defaults.suspend) }}
   suspend: true
   {{- else }}
   suspend: false
@@ -34,9 +34,9 @@ spec:
           securityContext: {{ toYaml . | nindent 12 }}
           {{- end }}
           {{- if (and $.Values.serviceAccount (or $.Values.serviceAccount.create $.Values.serviceAccount.name)) }}
-          serviceAccountName: {{ default (include "mintel_common.fullname" $) $.Values.serviceAccount.name }}
+          serviceAccountName: {{ $.Values.serviceAccount.name | default (include "mintel_common.fullname" $) }}
           {{- end }}
-          restartPolicy: {{ coalesce .restartPolicy $.Values.cronjobs.defaults.restartPolicy }}
+          restartPolicy: {{ .restartPolicy | default $.Values.cronjobs.defaults.restartPolicy }}
           {{- with .extraInitContainers }}
           initContainers:
           {{- toYaml . | nindent 12 }}
@@ -47,7 +47,7 @@ spec:
           {{- end }}
           containers:
             - name: main
-              image: {{ coalesce .image (include "mintel_common.image" $) }}
+              image: {{ .image | default (include "mintel_common.image" $) }}
               imagePullPolicy: {{ include "mintel_common.imagePullPolicy" $ }}
               {{- with .command }}
               command: {{ toYaml . | nindent 16 }}
@@ -93,7 +93,7 @@ spec:
                 {{- if (or (ne $.Values.global.clusterEnv "local") (and (eq $.Values.global.clusterEnv "local") $.Values.externalSecret.localValues)) }}
                 {{- if .includeAppSecret }}
                 - secretRef:
-                    name: {{ default (include "mintel_common.defaultAppSecretName" $) $.Values.externalSecret.nameOverride }}
+                    name: {{ $.Values.externalSecret.nameOverride | default (include "mintel_common.defaultAppSecretName" $) }}
                 {{- end }}
                 {{- end }}
                 {{- end }}
@@ -108,43 +108,43 @@ spec:
                 {{- if (and $.Values.mariadb $.Values.mariadb.enabled) }}
                 {{- if .includeMariadbSecret }}
                 - secretRef:
-                    name: {{ default (include "mintel_common.defaultMariadbSecretName" $) $.Values.mariadb.secretNameOverride }}
+                    name: {{ $.Values.mariadb.secretNameOverride | default (include "mintel_common.defaultMariadbSecretName" $) }}
                 {{- end }}
                 {{- end }}
                 {{- if (and $.Values.dynamodb $.Values.dynamodb.enabled) }}
                 {{- if .includeDynamodbSecret }}
                 - secretRef:
-                    name: {{ default (include "mintel_common.defaultDynamodbSecretName" $) $.Values.dynamodb.secretNameOverride }}
+                    name: {{ $.Values.dynamodb.secretNameOverride | default (include "mintel_common.defaultDynamodbSecretName" $) }}
                 {{- end }}
                 {{- end }}
                 {{- if (and $.Values.postgresql $.Values.postgresql.enabled) }}
                 {{- if .includePostgesqlSecret }}
                 - secretRef:
-                    name: {{ default (include "mintel_common.defaultPostgresqlSecretName" $) $.Values.postgresql.secretNameOverride }}
+                    name: {{ $.Values.postgresql.secretNameOverride | default (include "mintel_common.defaultPostgresqlSecretName" $) }}
                 {{- end }}
                 {{- end }}
                 {{- if (and $.Values.redis $.Values.redis.enabled) }}
                 {{- if .includeRedisSecret }}
                 - secretRef:
-                    name: {{ default (include "mintel_common.defaultRedisSecretName" $) $.Values.redis.secretNameOverride }}
+                    name: {{ $.Values.redis.secretNameOverride | default (include "mintel_common.defaultRedisSecretName" $) }}
                 {{- end }}
                 {{- end }}
                 {{- if (and $.Values.s3 $.Values.s3.enabled) }}
                 {{- if .includeS3Secret }}
                 - secretRef:
-                    name: {{ default (include "mintel_common.defaultS3SecretName" $) $.Values.s3.secretNameOverride }}
+                    name: {{ $.Values.s3.secretNameOverride | default (include "mintel_common.defaultS3SecretName" $) }}
                 {{- end }}
                 {{- end }}
                 {{- if (and $.Values.elasticsearch $.Values.elasticsearch.enabled) }}
                 {{- if .includeElasticsearchSecret }}
                 - secretRef:
-                    name: {{ default (include "mintel_common.defaultElasticsearchSecretName" $) $.Values.elasticsearch.secretNameOverride }}
+                    name: {{ $.Values.elasticsearch.secretNameOverride | default (include "mintel_common.defaultElasticsearchSecretName" $) }}
                 {{- end }}
                 {{- end }}
                 {{- if (and $.Values.opensearch $.Values.opensearch.enabled) }}
                 {{- if .includeOpensearchSecret }}
                 - secretRef:
-                    name: {{ default (include "mintel_common.defaultOpensearchSecretName" $) $.Values.opensearch.secretNameOverride }}
+                    name: {{ $.Values.opensearch.secretNameOverride | default (include "mintel_common.defaultOpensearchSecretName" $) }}
                 {{- end }}
                 {{- end }}
                 {{- end }}

--- a/charts/standard-application-stack/templates/deployment-aws-es-proxy.yaml
+++ b/charts/standard-application-stack/templates/deployment-aws-es-proxy.yaml
@@ -8,13 +8,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
-    secret.reloader.stakater.com/reload: {{ default (include "mintel_common.defaultOpensearchSecretName" .) .Values.opensearch.secretNameOverride }}
+    secret.reloader.stakater.com/reload: {{ .Values.opensearch.secretNameOverride | default (include "mintel_common.defaultOpensearchSecretName" .) }}
     app.mintel.com/opa-allow-single-replica: "true"
     app.mintel.com/opa-skip-readiness-probe-check.main: "true"
     app.mintel.com/opa-skip-security-context-check: "true"
   labels: {{ include "mintel_common.labels" $data | nindent 4 }}
 spec:
-  replicas: {{ default 2 .Values.opensearch.awsEsProxy.replicas }}
+  replicas: {{ .Values.opensearch.awsEsProxy.replicas | default 2 }}
   selector:
     matchLabels: {{ include "mintel_common.selectorLabels" $data | nindent 6 }}
   strategy:
@@ -25,13 +25,13 @@ spec:
     spec:
       {{- include "mintel_common.imagePullSecrets" . | nindent 6 }}
       {{- if (and .Values.serviceAccount (or .Values.serviceAccount.create .Values.serviceAccount.name)) }}
-      serviceAccountName: {{ default (include "mintel_common.fullname" .) .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
       {{- end }}
       {{- include "mintel_common.topologySpreadConstraints" $data | nindent 6 }}
       containers:
         - name: main
           image: index.docker.io/mintel/aws-es-proxy:v1.3.0_mintel.0.1.0
-          imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           args:
             - -listen=0.0.0.0:9200
             - -endpoint=$(OPENSEARCH_HOST)
@@ -45,7 +45,7 @@ spec:
                   fieldPath: metadata.namespace
           envFrom:
             - secretRef:
-                name: {{ default (include "mintel_common.defaultOpensearchSecretName" .) .Values.opensearch.secretNameOverride }}
+                name: {{ .Values.opensearch.secretNameOverride | default (include "mintel_common.defaultOpensearchSecretName" .) }}
           ports:
             - containerPort: 9200
               name: http

--- a/charts/standard-application-stack/templates/deployment-celery-beat.yaml
+++ b/charts/standard-application-stack/templates/deployment-celery-beat.yaml
@@ -42,16 +42,16 @@ spec:
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- if (and .Values.serviceAccount (or .Values.serviceAccount.create .Values.serviceAccount.name)) }}
-      serviceAccountName: {{ default (include "mintel_common.fullname" .) .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
       {{- end }}
       containers:
         - name: main
-          image: {{ coalesce .Values.celeryBeat.image (include "mintel_common.image" .) }}
+          image: {{ .Values.celeryBeat.image | default (include "mintel_common.image" .) }}
           imagePullPolicy: {{ include "mintel_common.imagePullPolicy" . }}
-          {{- with (coalesce .Values.celeryBeat.command .Values.command) }}
+          {{- with .Values.celeryBeat.command | default .Values.command }}
           command: {{ toYaml . | nindent 12 }}
           {{- end }}
-          {{- with (coalesce .Values.celeryBeat.args .Values.args) }}
+          {{- with .Values.celeryBeat.args | default .Values.args }}
           args: {{ toYaml . | nindent 12 }}
           {{- end }}
           env:
@@ -77,7 +77,7 @@ spec:
             {{- if (and .Values.externalSecret .Values.externalSecret.enabled) }}
             {{- if (or (ne .Values.global.clusterEnv "local") (and (eq .Values.global.clusterEnv "local") .Values.externalSecret.localValues)) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultAppSecretName" .) .Values.externalSecret.nameOverride }}
+                name: {{ .Values.externalSecret.nameOverride | default (include "mintel_common.defaultAppSecretName" .) }}
             {{- end }}
             {{- end }}
             {{- if .Values.global.terraform.externalSecrets }}
@@ -90,27 +90,27 @@ spec:
             {{- else }}
             {{- if (and .Values.mariadb .Values.mariadb.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultMariadbSecretName" .) .Values.mariadb.secretNameOverride }}
+                name: {{ .Values.mariadb.secretNameOverride | default (include "mintel_common.defaultMariadbSecretName" .) }}
             {{- end }}
             {{- if (and .Values.postgresql .Values.postgresql.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultPostgresqlSecretName" .) .Values.postgresql.secretNameOverride }}
+                name: {{ .Values.postgresql.secretNameOverride | default (include "mintel_common.defaultPostgresqlSecretName" .) }}
             {{- end }}
             {{- if (and .Values.redis .Values.redis.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultRedisSecretName" .) .Values.redis.secretNameOverride }}
+                name: {{ .Values.redis.secretNameOverride | default (include "mintel_common.defaultRedisSecretName" .) }}
             {{- end }}
             {{- if (and .Values.elasticsearch .Values.elasticsearch.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultElasticsearchSecretName" .) .Values.elasticsearch.secretNameOverride }}
+                name: {{ .Values.elasticsearch.secretNameOverride | default (include "mintel_common.defaultElasticsearchSecretName" .) }}
             {{- end }}
             {{- if (and .Values.opensearch .Values.opensearch.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultOpensearchSecretName" .) .Values.opensearch.secretNameOverride }}
+                name: {{ .Values.opensearch.secretNameOverride | default (include "mintel_common.defaultOpensearchSecretName" .) }}
             {{- end }}
             {{- if (and .Values.s3 .Values.s3.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultS3SecretName" .) .Values.s3.secretNameOverride }}
+                name: {{ .Values.s3.secretNameOverride | default (include "mintel_common.defaultS3SecretName" .) }}
             {{- end }}
             {{- end }}
             {{- with .Values.envFrom }}
@@ -125,21 +125,21 @@ spec:
             {{- toYaml .Values.celeryBeat.liveness.methodOverride | nindent 12 }}
             {{- else }}
             httpGet:
-              path: {{ default "/healthz" .Values.liveness.path }}
-              port: {{ default "http" .Values.liveness.port }}
-              scheme: {{ default "HTTP" .Values.liveness.scheme }}
+              path: {{ .Values.liveness.path | default "/healthz" }}
+              port: {{ .Values.liveness.port | default "http" }}
+              scheme: {{ .Values.liveness.scheme | default "HTTP" }}
             {{- end }}
-            initialDelaySeconds: {{ default 0 .Values.celeryBeat.liveness.initialDelaySeconds }}
-            timeoutSeconds: {{ default 1 .Values.celeryBeat.liveness.timeoutSeconds }}
-            periodSeconds: {{ default 10 .Values.celeryBeat.liveness.periodSeconds }}
+            initialDelaySeconds: {{ .Values.celeryBeat.liveness.initialDelaySeconds | default 0 }}
+            timeoutSeconds: {{ .Values.celeryBeat.liveness.timeoutSeconds | default 1 }}
+            periodSeconds: {{ .Values.celeryBeat.liveness.periodSeconds | default 10 }}
           startupProbe:
             {{- if .Values.celeryBeat.liveness.methodOverride }}
             {{- toYaml .Values.celeryBeat.liveness.methodOverride | nindent 12 }}
             {{- else }}
             httpGet:
-              path: {{ default "/healthz" .Values.liveness.path }}
-              port: {{ default "http" .Values.liveness.port }}
-              scheme: {{ default "HTTP" .Values.liveness.scheme }}
+              path: {{ .Values.liveness.path | default "/healthz" }}
+              port: {{ .Values.liveness.port | default "http" }}
+              scheme: {{ .Values.liveness.scheme | default "HTTP" }}
             {{- end }}
             {{- if .Values.celeryBeat.liveness.startup }}
             {{- if .Values.celeryBeat.liveness.startup.failureThreshold }}
@@ -163,13 +163,13 @@ spec:
             {{- toYaml .Values.celeryBeat.readiness.methodOverride | nindent 12 }}
             {{- else }}
             httpGet:
-              path: {{ default "/readiness" .Values.readiness.path }}
-              port: {{ default "http" .Values.readiness.port }}
-              scheme: {{ default "HTTP" .Values.readiness.scheme }}
+              path: {{ .Values.readiness.path | default "/readiness" }}
+              port: {{ .Values.readiness.port | default "http" }}
+              scheme: {{ .Values.readiness.scheme | default "HTTP" }}
             {{- end }}
-            initialDelaySeconds: {{ default 0 .Values.celeryBeat.readiness.initialDelaySeconds }}
-            timeoutSeconds: {{ default 1 .Values.celeryBeat.readiness.timeoutSeconds }}
-            periodSeconds: {{ default 10 .Values.celeryBeat.readiness.periodSeconds }}
+            initialDelaySeconds: {{ .Values.celeryBeat.readiness.initialDelaySeconds | default 0 }}
+            timeoutSeconds: {{ .Values.celeryBeat.readiness.timeoutSeconds | default 1 }}
+            periodSeconds: {{ .Values.celeryBeat.readiness.periodSeconds | default 10 }}
           {{- end }}
           {{- with .Values.securityContext }}
           securityContext: {{ toYaml . | nindent 12 }}

--- a/charts/standard-application-stack/templates/deployment-celery-exporter.yaml
+++ b/charts/standard-application-stack/templates/deployment-celery-exporter.yaml
@@ -25,12 +25,12 @@ spec:
     spec:
       {{- include "mintel_common.imagePullSecrets" . | nindent 6 }}
       {{- if (and .Values.serviceAccount (or .Values.serviceAccount.create .Values.serviceAccount.name)) }}
-      serviceAccountName: {{ default (include "mintel_common.fullname" .) .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
       {{- end }}
       containers:
         - name: main
-          image: {{ default "index.docker.io/ovalmoney/celery-exporter:1.5.1" .Values.celery.metrics.image }}
-          imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+          image: {{ .Values.celery.metrics.image | default "index.docker.io/ovalmoney/celery-exporter:1.5.1"}}
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           args:
             - --transport-options
             - '{"master_name":"mymaster"}'
@@ -52,7 +52,7 @@ spec:
               value: {{ .Release.Namespace }}
           envFrom:
             - secretRef:
-                name: {{ default (include "mintel_common.defaultRedisSecretName" .) .Values.redis.secretNameOverride }}
+                name: {{ .Values.redis.secretNameOverride | default (include "mintel_common.defaultRedisSecretName" .)}}
           ports:
             - containerPort: 9540
               name: metrics

--- a/charts/standard-application-stack/templates/deployment-celery.yaml
+++ b/charts/standard-application-stack/templates/deployment-celery.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ include "mintel_common.fullname" $data }}
   namespace: {{ .Release.Namespace }}
   annotations:
-    {{- include "mintel_common.commonAnnotations" . | nindent 4}}
+    {{- include "mintel_common.commonAnnotations" . | nindent 4 }}
     {{- if (and .Values.celery.liveness (not .Values.celery.liveness.enabled)) }}
     app.mintel.com/opa-skip-liveness-probe-check.main: "true"
     {{- end }}

--- a/charts/standard-application-stack/templates/deployment-celery.yaml
+++ b/charts/standard-application-stack/templates/deployment-celery.yaml
@@ -48,7 +48,7 @@ spec:
       maxUnavailable: {{ . }}
       {{- end }}
     {{- end }}
-    type: {{ default "RollingUpdate" .type }}
+    type: {{ .type | default "RollingUpdate"}}
     {{- else }}
     type: RollingUpdate
     {{- end }}
@@ -65,7 +65,7 @@ spec:
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- if (and .Values.serviceAccount (or .Values.serviceAccount.create .Values.serviceAccount.name)) }}
-      serviceAccountName: {{ default (include "mintel_common.fullname" .) .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
       {{- end }}
       {{- if (ne .Values.global.clusterEnv "local") }}
       {{- with .Values.priorityClassName }}
@@ -103,14 +103,14 @@ spec:
                 labelSelector:
                   matchLabels: {{ include "mintel_common.selectorLabels" $data | nindent 20 }}
                 topologyKey: topology.kubernetes.io/zone
-              weight: {{ default 100 .Values.affinity.podAntiAffinity.weight }}
+              weight: {{ .Values.affinity.podAntiAffinity.weight | default 100 }}
             {{- end }}
             {{- if (eq .Values.affinity.podAntiAffinity.node "soft") }}
             - podAffinityTerm:
                 labelSelector:
                   matchLabels: {{ include "mintel_common.selectorLabels" $data | nindent 20 }}
                 topologyKey: kubernetes.io/hostname
-              weight: {{ default 100 .Values.affinity.podAntiAffinity.weight }}
+              weight: {{ .Values.affinity.podAntiAffinity.weight | default 100 }}
             {{- end }}
         {{- end }}
         {{- end }}
@@ -119,12 +119,12 @@ spec:
       {{- end }}
       containers:
         - name: main
-          image: {{ coalesce .Values.celery.image (include "mintel_common.image" .) }}
+          image: {{ .Values.celery.image | default (include "mintel_common.image" .) }}
           imagePullPolicy: {{ include "mintel_common.imagePullPolicy" . }}
-          {{- with (coalesce .Values.celery.command .Values.command) }}
+          {{- with .Values.celery.command | default .Values.command }}
           command: {{ toYaml . | nindent 12 }}
           {{- end }}
-          {{- with (coalesce .Values.celery.args .Values.args) }}
+          {{- with .Values.celery.args | default .Values.args }}
           args: {{ toYaml . | nindent 12 }}
           {{- end }}
           env:
@@ -150,7 +150,7 @@ spec:
             {{- if (and .Values.externalSecret .Values.externalSecret.enabled) }}
             {{- if (or (ne .Values.global.clusterEnv "local") (and (eq .Values.global.clusterEnv "local") .Values.externalSecret.localValues)) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultAppSecretName" .) .Values.externalSecret.nameOverride }}
+                name: {{ .Values.externalSecret.nameOverride | default (include "mintel_common.defaultAppSecretName" .) }}
             {{- end }}
             {{- end }}
             {{- if .Values.global.terraform.externalSecrets }}
@@ -163,27 +163,27 @@ spec:
             {{- else }}
             {{- if (and .Values.mariadb .Values.mariadb.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultMariadbSecretName" .) .Values.mariadb.secretNameOverride }}
+                name: {{ .Values.mariadb.secretNameOverride | default (include "mintel_common.defaultMariadbSecretName" .) }}
             {{- end }}
             {{- if (and .Values.postgresql .Values.postgresql.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultPostgresqlSecretName" .) .Values.postgresql.secretNameOverride }}
+                name: {{ .Values.postgresql.secretNameOverride | default (include "mintel_common.defaultPostgresqlSecretName" .) }}
             {{- end }}
             {{- if (and .Values.redis .Values.redis.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultRedisSecretName" .) .Values.redis.secretNameOverride }}
+                name: {{ .Values.redis.secretNameOverride | default (include "mintel_common.defaultRedisSecretName" .) }}
             {{- end }}
             {{- if (and .Values.elasticsearch .Values.elasticsearch.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultElasticsearchSecretName" .) .Values.elasticsearch.secretNameOverride }}
+                name: {{ .Values.elasticsearch.secretNameOverride | default (include "mintel_common.defaultElasticsearchSecretName" .) }}
             {{- end }}
             {{- if (and .Values.opensearch .Values.opensearch.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultOpensearchSecretName" .) .Values.opensearch.secretNameOverride }}
+                name: {{ .Values.opensearch.secretNameOverride | default (include "mintel_common.defaultOpensearchSecretName" .) }}
             {{- end }}
             {{- if (and .Values.s3 .Values.s3.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultS3SecretName" .) .Values.s3.secretNameOverride }}
+                name: {{ .Values.s3.secretNameOverride | default (include "mintel_common.defaultS3SecretName" .) }}
             {{- end }}
             {{- end }}
             {{- with .Values.envFrom }}
@@ -203,9 +203,9 @@ spec:
               - '-c'
               - 'celery inspect ping -d celery@$(hostname)'
             {{- end }}
-            initialDelaySeconds: {{ default 0 .Values.celery.liveness.initialDelaySeconds }}
-            timeoutSeconds: {{ default 2 .Values.celery.liveness.timeoutSeconds }}
-            periodSeconds: {{ default 10 .Values.celery.liveness.periodSeconds }}
+            initialDelaySeconds: {{ .Values.celery.liveness.initialDelaySeconds | default 0 }}
+            timeoutSeconds: {{ .Values.celery.liveness.timeoutSeconds | default 2 }}
+            periodSeconds: {{ .Values.celery.liveness.periodSeconds | default 10 }}
           startupProbe:
             {{- if (and .Values.celery.startup .Values.celery.startup.methodOverride) }}
             {{- toYaml .Values.celery.startup.methodOverride | nindent 12 }}
@@ -216,9 +216,9 @@ spec:
               - '-c'
               - 'celery inspect ping -d celery@$(hostname)'
             {{- end }}
-            failureThreshold: {{ default 60 .Values.celery.startup.failureThreshold }}
-            timeoutSeconds: {{ default 1 .Values.celery.liveness.timeoutSeconds .Values.celery.startup.timeoutSeconds }}
-            periodSeconds: {{ default 5 .Values.celery.liveness.periodSeconds .Values.celery.startup.periodSeconds }}
+            failureThreshold: {{ .Values.celery.startup.failureThreshold | default 60 }}
+            timeoutSeconds: {{ coalesce .Values.celery.startup.timeoutSeconds .Values.celery.liveness.timeoutSeconds 1 }}
+            periodSeconds: {{ coalesce .Values.celery.startup.periodSeconds .Values.celery.liveness.periodSeconds 5 }}
           {{- end }}
           {{- if (and .Values.celery.readiness .Values.celery.readiness.enabled) }}
           readinessProbe:
@@ -226,13 +226,13 @@ spec:
             {{- toYaml .Values.celery.readiness.methodOverride | nindent 12 }}
             {{- else }}
             httpGet:
-              path: {{ default "/readiness" .Values.readiness.path }}
-              port: {{ default "http" .Values.readiness.port }}
-              scheme: {{ default "HTTP" .Values.readiness.scheme }}
+              path: {{ .Values.readiness.path | default "/readiness" }}
+              port: {{ .Values.readiness.port | default "http" }}
+              scheme: {{ .Values.readiness.scheme | default "HTTP" }}
             {{- end }}
-            initialDelaySeconds: {{ default 0 .Values.celery.readiness.initialDelaySeconds }}
-            timeoutSeconds: {{ default 1 .Values.celery.readiness.timeoutSeconds }}
-            periodSeconds: {{ default 10 .Values.celery.readiness.periodSeconds }}
+            initialDelaySeconds: {{ .Values.celery.readiness.initialDelaySeconds | default 0 }}
+            timeoutSeconds: {{ .Values.celery.readiness.timeoutSeconds | default 1 }}
+            periodSeconds: {{ .Values.celery.readiness.periodSeconds | default 10 }}
           {{- end }}
           {{- with .Values.securityContext }}
           securityContext: {{ toYaml . | nindent 12 }}
@@ -269,11 +269,11 @@ spec:
           envFrom:
             {{- if (and .Values.elasticsearch .Values.elasticsearch.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultElasticsearchSecretName" .) .Values.elasticsearch.secretNameOverride }}
+                name: {{ .Values.elasticsearch.secretNameOverride | default (include "mintel_common.defaultElasticsearchSecretName" .) }}
             {{- end }}
             {{- if (and .Values.opensearch .Values.opensearch.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultOpensearchSecretName" .) .Values.opensearch.secretNameOverride }}
+                name: {{ .Values.opensearch.secretNameOverride | default (include "mintel_common.defaultOpensearchSecretName" .) }}
             {{- end }}
           livenessProbe:
             tcpSocket:

--- a/charts/standard-application-stack/templates/deployment-mysqlclient.yaml
+++ b/charts/standard-application-stack/templates/deployment-mysqlclient.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
-    secret.reloader.stakater.com/reload: {{ default (include "mintel_common.defaultMariadbSecretName" .) .Values.mariadb.secretNameOverride }}
+    secret.reloader.stakater.com/reload: {{ .Values.mariadb.secretNameOverride | default (include "mintel_common.defaultMariadbSecretName" .) }}
     app.mintel.com/opa-allow-single-replica: "true"
     app.mintel.com/opa-skip-liveness-probe-check.main: "true"
     app.mintel.com/opa-skip-readiness-probe-check.main: "true"
@@ -27,12 +27,12 @@ spec:
       securityContext:
         runAsUser: 1000
       {{- if (and .Values.serviceAccount (or .Values.serviceAccount.create .Values.serviceAccount.name)) }}
-      serviceAccountName: {{ default (include "mintel_common.fullname" .) .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
       {{- end }}
       containers:
         - name: main
-          image: {{ default "index.docker.io/mintel/k8s-mysqlclient:0.5.1" .Values.mariadb.client.image }}
-          imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+          image: {{ .Values.mariadb.client.image | default "index.docker.io/mintel/k8s-mysqlclient:0.5.1" }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           env:
             - name: KUBERNETES_POD_NAMESPACE
               valueFrom:
@@ -40,7 +40,7 @@ spec:
                   fieldPath: metadata.namespace
           envFrom:
             - secretRef:
-                name: {{ default (include "mintel_common.defaultMariadbSecretName" .) .Values.mariadb.secretNameOverride }}
+                name: {{ .Values.mariadb.secretNameOverride | default (include "mintel_common.defaultMariadbSecretName" .) }}
           ports:
             - containerPort: 3306
               name: mysql

--- a/charts/standard-application-stack/templates/deployment-mysqldexporter.yaml
+++ b/charts/standard-application-stack/templates/deployment-mysqldexporter.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
-    secret.reloader.stakater.com/reload: {{ default (include "mintel_common.defaultMariadbSecretName" .) .Values.mariadb.secretNameOverride }}
+    secret.reloader.stakater.com/reload: {{ .Values.mariadb.secretNameOverride | default (include "mintel_common.defaultMariadbSecretName" .) }}
     app.mintel.com/opa-allow-single-replica: "true"
   labels: {{ include "mintel_common.labels" $data | nindent 4 }}
 spec:
@@ -25,12 +25,12 @@ spec:
     spec:
       {{- include "mintel_common.imagePullSecrets" . | nindent 6 }}
       {{- if (and .Values.serviceAccount (or .Values.serviceAccount.create .Values.serviceAccount.name)) }}
-      serviceAccountName: {{ default (include "mintel_common.fullname" .) .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
       {{- end }}
       containers:
         - name: main
-          image: {{ default "index.docker.io/mintel/k8s-mysqld-exporter:v0.13.0_mintel.0.3.0" .Values.mariadb.metrics.imageOverride }}
-          imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+          image: {{ .Values.mariadb.metrics.imageOverride | default "index.docker.io/mintel/k8s-mysqld-exporter:v0.13.0_mintel.0.3.0" }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           args:
             - /bin/mysqld_exporter
             - --collect.auto_increment.columns
@@ -49,7 +49,7 @@ spec:
                   fieldPath: metadata.namespace
           envFrom:
             - secretRef:
-                name: {{ default (include "mintel_common.defaultMariadbSecretName" .) .Values.mariadb.secretNameOverride }}
+                name: {{ .Values.mariadb.secretNameOverride | default (include "mintel_common.defaultMariadbSecretName" .) }}
           ports:
             - containerPort: 9104
               name: metrics

--- a/charts/standard-application-stack/templates/deployment-postgresqlclient.yaml
+++ b/charts/standard-application-stack/templates/deployment-postgresqlclient.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
-    secret.reloader.stakater.com/reload: {{ default (include "mintel_common.defaultPostgresqlSecretName" .) .Values.postgresql.secretNameOverride }}
+    secret.reloader.stakater.com/reload: {{ .Values.postgresql.secretNameOverride | default (include "mintel_common.defaultPostgresqlSecretName" .) }}
     app.mintel.com/opa-allow-single-replica: "true"
     app.mintel.com/opa-skip-liveness-probe-check.main: "true"
     app.mintel.com/opa-skip-readiness-probe-check.main: "true"
@@ -27,12 +27,12 @@ spec:
       securityContext:
         runAsUser: 1000
       {{- if (and .Values.serviceAccount (or .Values.serviceAccount.create .Values.serviceAccount.name)) }}
-      serviceAccountName: {{ default (include "mintel_common.fullname" .) .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
       {{- end }}
       containers:
         - name: main
-          image: {{ default "index.docker.io/mintel/k8s-postgresclient:0.1.1" .Values.postgresql.client.image }}
-          imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+          image: {{ .Values.postgresql.client.image | default "index.docker.io/mintel/k8s-postgresclient:0.1.1" }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           env:
             - name: KUBERNETES_POD_NAMESPACE
               valueFrom:
@@ -50,7 +50,7 @@ spec:
               value: "$(DB_PORT)"
           envFrom:
             - secretRef:
-                name: {{ default (include "mintel_common.defaultPostgresqlSecretName" .) .Values.postgresql.secretNameOverride }}
+                name: {{ .Values.postgresql.secretNameOverride | default (include "mintel_common.defaultPostgresqlSecretName" .) }}
           ports:
             - containerPort: 5432
               name: postgresql

--- a/charts/standard-application-stack/templates/deployment-postgresqlexporter.yaml
+++ b/charts/standard-application-stack/templates/deployment-postgresqlexporter.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
-    secret.reloader.stakater.com/reload: {{ default (include "mintel_common.defaultPostgresqlSecretName" .) .Values.postgresql.secretNameOverride }}
+    secret.reloader.stakater.com/reload: {{ .Values.postgresql.secretNameOverride | default (include "mintel_common.defaultPostgresqlSecretName" .) }}
     app.mintel.com/opa-allow-single-replica: "true"
   labels: {{ include "mintel_common.labels" $data | nindent 4 }}
 spec:
@@ -25,12 +25,12 @@ spec:
     spec:
       {{- include "mintel_common.imagePullSecrets" . | nindent 6 }}
       {{- if (and .Values.serviceAccount (or .Values.serviceAccount.create .Values.serviceAccount.name)) }}
-      serviceAccountName: {{ default (include "mintel_common.fullname" .) .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
       {{- end }}
       containers:
         - name: main
-          image: {{ default "index.docker.io/bitnami/postgres-exporter:0.10.0-debian-10-r169" .Values.postgresql.metrics.imageOverride }}
-          imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
+          image: {{ .Values.postgresql.metrics.imageOverride | default "index.docker.io/bitnami/postgres-exporter:0.10.0-debian-10-r169" }}
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           env:
             - name: KUBERNETES_POD_NAMESPACE
               valueFrom:
@@ -46,7 +46,7 @@ spec:
               value: "$(DB_PASSWORD)"
           envFrom:
             - secretRef:
-                name: {{ default (include "mintel_common.defaultPostgresqlSecretName" .) .Values.postgresql.secretNameOverride }}
+                name: {{ .Values.postgresql.secretNameOverride | default (include "mintel_common.defaultPostgresqlSecretName" .) }}
           ports:
             - containerPort: 9187
               name: metrics

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
       maxUnavailable: {{ . }}
       {{- end }}
     {{- end }}
-    type: {{ default "RollingUpdate" .type }}
+    type: {{ .type | default "RollingUpdate" }}
     {{- else }}
     type: RollingUpdate
     {{- end }}
@@ -104,7 +104,7 @@ spec:
       securityContext: {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- if (and .Values.serviceAccount (or .Values.serviceAccount.create .Values.serviceAccount.name)) }}
-      serviceAccountName: {{ default (include "mintel_common.fullname" .) .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
       {{- end }}
       {{- if (ne .Values.global.clusterEnv "local") }}
       {{- with .Values.priorityClassName }}
@@ -112,7 +112,7 @@ spec:
       {{- end }}
       {{- end }}
       {{- include "mintel_common.topologySpreadConstraints" . | nindent 6 }}
-      terminationGracePeriodSeconds: {{ default 30 .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       {{- if (and (gt (.Values.replicas | int) 1) (and .Values.affinity .Values.affinity.enabled)) }}
       affinity:
         {{- if (and .Values.affinity .Values.affinity.specificYaml) }}
@@ -143,14 +143,14 @@ spec:
                 labelSelector:
                   matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 20 }}
                 topologyKey: topology.kubernetes.io/zone
-              weight: {{ default 100 .Values.affinity.podAntiAffinity.weight }}
+              weight: {{ .Values.affinity.podAntiAffinity.weight | default 100 }}
             {{- end }}
             {{- if (eq .Values.affinity.podAntiAffinity.node "soft") }}
             - podAffinityTerm:
                 labelSelector:
                   matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 20 }}
                 topologyKey: kubernetes.io/hostname
-              weight: {{ default 100 .Values.affinity.podAntiAffinity.weight }}
+              weight: {{ .Values.affinity.podAntiAffinity.weight | default 100 }}
             {{- end }}
         {{- end }}
         {{- end }}
@@ -192,7 +192,7 @@ spec:
             {{- if (and .Values.externalSecret .Values.externalSecret.enabled) }}
             {{- if (or (ne .Values.global.clusterEnv "local") (and (eq .Values.global.clusterEnv "local") .Values.externalSecret.localValues)) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultAppSecretName" .) .Values.externalSecret.nameOverride }}
+                name: {{ .Values.externalSecret.nameOverride | default (include "mintel_common.defaultAppSecretName" .) }}
             {{- end }}
             {{- end }}
             {{- if (and (ne .Values.global.clusterEnv "local") .Values.global.terraform.externalSecrets) }}
@@ -205,41 +205,41 @@ spec:
             {{- else }}
               {{- if (and .Values.mariadb .Values.mariadb.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultMariadbSecretName" .) .Values.mariadb.secretNameOverride }}
+                name: {{ .Values.mariadb.secretNameOverride | default (include "mintel_common.defaultMariadbSecretName" .) }}
               {{- end }}
               {{- if (and .Values.postgresql .Values.postgresql.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultPostgresqlSecretName" .) .Values.postgresql.secretNameOverride }}
+                name: {{ .Values.postgresql.secretNameOverride | default (include "mintel_common.defaultPostgresqlSecretName" .) }}
               {{- end }}
               {{- if (and .Values.dynamodb .Values.dynamodb.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultDynamodbSecretName" .) .Values.dynamodb.secretNameOverride }}
+                name: {{ .Values.dynamodb.secretNameOverride | default (include "mintel_common.defaultDynamodbSecretName" .) }}
               {{- end }}
               {{- if (and .Values.redis .Values.redis.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultRedisSecretName" .) .Values.redis.secretNameOverride }}
+                name: {{ .Values.redis.secretNameOverride | default (include "mintel_common.defaultRedisSecretName" .) }}
               {{- end }}
               {{- if (and .Values.s3 .Values.s3.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultS3SecretName" .) .Values.s3.secretNameOverride }}
+                name: {{ .Values.s3.secretNameOverride | default (include "mintel_common.defaultS3SecretName" .) }}
               {{- end }}
               {{- if (and .Values.sqs .Values.sqs.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultSqsSecretName" .) .Values.sqs.secretNameOverride }}
+                name: {{ .Values.sqs.secretNameOverride | default (include "mintel_common.defaultSqsSecretName" .) }}
               {{- end }}
               {{- if (and .Values.elasticsearch .Values.elasticsearch.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultElasticsearchSecretName" .) .Values.elasticsearch.secretNameOverride }}
+                name: {{ .Values.elasticsearch.secretNameOverride | default (include "mintel_common.defaultElasticsearchSecretName" .) }}
               {{- end }}
               {{- if (and .Values.opensearch .Values.opensearch.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultOpensearchSecretName" .) .Values.opensearch.secretNameOverride }}
+                name: {{ .Values.opensearch.secretNameOverride | default (include "mintel_common.defaultOpensearchSecretName" .) }}
               {{- end }}
             {{- end }}
             {{- range .Values.extraSecrets }}
             {{- if (or (ne (hasKey . "includeInMain") true) .includeInMain) }}
             - secretRef:
-                name: {{ default (printf "%s-%s" (include "mintel_common.fullname" $) .name) .nameOverride }}
+                name: {{ .nameOverride | default (printf "%s-%s" (include "mintel_common.fullname" $) .name) }}
             {{- end }}
             {{- end }}
             {{- with .Values.envFrom }}
@@ -250,9 +250,9 @@ spec:
             - containerPort: {{ .Values.port }}
               name: http
             {{- if .Values.hybridCloud.enabled }}
-            - containerPort: {{ default "20200" .Values.hybridCloud.metrics.port }}
+            - containerPort: {{ .Values.hybridCloud.metrics.port | default "20200" }}
               name: consul-metrics
-            - containerPort: {{ default "20000" .Values.hybridCloud.proxyPort }}
+            - containerPort: {{ .Values.hybridCloud.proxyPort | default "20000" }}
               name: consul-proxy
             {{- end }}
             {{- with .Values.extraPorts }}
@@ -265,21 +265,21 @@ spec:
             {{- toYaml .Values.liveness.methodOverride | nindent 12 }}
             {{- else }}
             httpGet:
-              path: {{ default "/healthz" .Values.liveness.path }}
-              port: {{ default "http" .Values.liveness.port }}
-              scheme: {{ default "HTTP" .Values.liveness.scheme }}
+              path: {{ .Values.liveness.path | default "/healthz" }}
+              port: {{ .Values.liveness.port | default "http" }}
+              scheme: {{ .Values.liveness.scheme | default "HTTP" }}
             {{- end }}
-            initialDelaySeconds: {{ default 0 .Values.liveness.initialDelaySeconds }}
-            timeoutSeconds: {{ default 1 .Values.liveness.timeoutSeconds }}
-            periodSeconds: {{ default 10 .Values.liveness.periodSeconds }}
+            initialDelaySeconds: {{ .Values.liveness.initialDelaySeconds | default 0 }}
+            timeoutSeconds: {{ .Values.liveness.timeoutSeconds | default 1 }}
+            periodSeconds: {{ .Values.liveness.periodSeconds | default 10 }}
           startupProbe:
             {{- if .Values.liveness.methodOverride }}
             {{- toYaml .Values.liveness.methodOverride | nindent 12 }}
             {{- else }}
             httpGet:
-              path: {{ default "/healthz" .Values.liveness.path }}
-              port: {{ default "http" .Values.liveness.port }}
-              scheme: {{ default "HTTP" .Values.liveness.scheme }}
+              path: {{ .Values.liveness.path | default "/healthz" }}
+              port: {{ .Values.liveness.port | default "http" }}
+              scheme: {{ .Values.liveness.scheme | default "HTTP" }}
             {{- end }}
             {{- if .Values.liveness.startup }}
             {{- if .Values.liveness.startup.failureThreshold }}
@@ -303,13 +303,13 @@ spec:
             {{- toYaml .Values.readiness.methodOverride | nindent 12 }}
             {{- else }}
             httpGet:
-              path: {{ default "/readiness" .Values.readiness.path }}
-              port: {{ default "http" .Values.readiness.port }}
-              scheme: {{ default "HTTP" .Values.readiness.scheme }}
+              path: {{ .Values.readiness.path | default "/readiness" }}
+              port: {{ .Values.readiness.port | default "http" }}
+              scheme: {{ .Values.readiness.scheme | default "HTTP" }}
             {{- end }}
-            initialDelaySeconds: {{ default 0 .Values.readiness.initialDelaySeconds }}
-            timeoutSeconds: {{ default 1 .Values.readiness.timeoutSeconds }}
-            periodSeconds: {{ default 10 .Values.readiness.periodSeconds }}
+            initialDelaySeconds: {{ .Values.readiness.initialDelaySeconds | default 0 }}
+            timeoutSeconds: {{ .Values.readiness.timeoutSeconds | default 1 }}
+            periodSeconds: {{ .Values.readiness.periodSeconds | default 10 }}
           {{- end }}
           {{- with .Values.securityContext }}
           securityContext: {{ toYaml . | nindent 12 }}
@@ -342,11 +342,11 @@ spec:
           envFrom:
             {{- if (and .Values.elasticsearch .Values.elasticsearch.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultElasticsearchSecretName" .) .Values.opensearch.secretNameOverride }}
+                name: {{ .Values.opensearch.secretNameOverride | default (include "mintel_common.defaultElasticsearchSecretName" .) }}
             {{- end }}
             {{- if (and .Values.opensearch .Values.opensearch.enabled) }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultOpensearchSecretName" .) .Values.opensearch.secretNameOverride }}
+                name: {{ .Values.opensearch.secretNameOverride | default (include "mintel_common.defaultOpensearchSecretName" .) }}
             {{- end }}
           livenessProbe:
             tcpSocket:

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
       annotations:
         'consul.hashicorp.com/connect-inject': 'true'
         {{- if .Values.hybridCloud.upstreamServices }}
-        'consul.hashicorp.com/connect-service-upstreams': {{ join "," .Values.hybridCloud.upstreamServices }}
+        'consul.hashicorp.com/connect-service-upstreams': {{ .Values.hybridCloud.upstreamServices | sortAlpha | uniq | compact | join "," }}
         {{- end }}
       {{- end }}
       labels: {{ include "mintel_common.labels" . | nindent 8 }}

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -245,7 +245,7 @@ spec:
             {{- with .Values.envFrom }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- if .Values.port}}
+          {{- if .Values.port }}
           ports:
             - containerPort: {{ .Values.port }}
               name: http
@@ -258,7 +258,7 @@ spec:
             {{- with .Values.extraPorts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- end}}
+          {{- end }}
           {{- if (and .Values.liveness .Values.liveness.enabled) }}
           livenessProbe:
             {{- if .Values.liveness.methodOverride }}
@@ -378,7 +378,7 @@ spec:
         {{- end }}
         {{- if (and .Values.oauthProxy .Values.oauthProxy.enabled) }}
         {{- $oauthProxyData := dict "Release" .Release "Chart" .Chart "Values" .Values "proxiedService" .Values }}
-        {{- include "mintel_common.oauthProxySidecar" $oauthProxyData | nindent 8}}
+        {{- include "mintel_common.oauthProxySidecar" $oauthProxyData | nindent 8 }}
         {{- end }}
 
         {{- if (and .Values.gitSyncSidecar .Values.gitSyncSidecar.enabled) }}

--- a/charts/standard-application-stack/templates/helpers/_ingress.yaml
+++ b/charts/standard-application-stack/templates/helpers/_ingress.yaml
@@ -35,27 +35,27 @@
 {{/* Set default ALB healthcheck success-codes */}}
 {{- define "mintel_common.ingress.alb.healthcheck.successCodes" -}}
 {{- if eq .backendProtocolVersion "GRPC"}}
-{{- default "0,12" .healthcheck.successCodes }}
+{{- .healthcheck.successCodes | default "0,12" }}
 {{- else }}
-{{- default "200" .healthcheck.successCodes }}
+{{- .healthcheck.successCodes | default "200" }}
 {{- end }}
 {{- end }}
 
 {{/* Set default ALB healthcheck path */}}
 {{- define "mintel_common.ingress.alb.healthcheck.path" -}}
 {{- if eq .backendProtocolVersion "GRPC"}}
-{{- default "/grpc.health.v1.Health/Check" .healthcheck.path }}
+{{- .healthcheck.path | default "/grpc.health.v1.Health/Check" }}
 {{- else }}
-{{- default "/readiness" .healthcheck.path }}
+{{- .healthcheck.path | default "/readiness" }}
 {{- end }}
 {{- end }}
 
 {{/* Set default ALB healthcheck port */}}
 {{- define "mintel_common.ingress.alb.healthcheck.port" -}}
 {{- if .Values.oauthProxy.enabled }}
-{{- default 4180 .Values.ingress.alb.healthcheck.port }}
+{{- .Values.ingress.alb.healthcheck.port | default 4180 }}
 {{- else }}
-{{- default .Values.port .Values.ingress.alb.healthcheck.port }}
+{{- .Values.ingress.alb.healthcheck.port | default .Values.port }}
 {{- end }}
 {{- end }}
 
@@ -69,7 +69,7 @@
 {{- end }}
 
 {{- define "mintel_common.ingress.haproxy_annotations" -}}
-{{- with (coalesce .ingress.serverTimeoutSeconds .Values.ingress.serverTimeoutSeconds) }}
+{{- with .ingress.serverTimeoutSeconds | default .Values.ingress.serverTimeoutSeconds }}
 ingress.kubernetes.io/timeout-server: {{ . }}s
 {{- end }}
 ingress.kubernetes.io/rewrite-target: /
@@ -95,7 +95,7 @@ ingress.kubernetes.io/config-backend: |
 {{- define "mintel_common.ingress.alb_annotations" -}}
 alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
 alb.ingress.kubernetes.io/ssl-redirect: "443"
-alb.ingress.kubernetes.io/target-group-attributes: "deregistration_delay.timeout_seconds={{ default 10 .alb.deregistrationDelay.timeoutSeconds }}"
+alb.ingress.kubernetes.io/target-group-attributes: "deregistration_delay.timeout_seconds={{ .alb.deregistrationDelay.timeoutSeconds | default 10 }}"
 alb.ingress.kubernetes.io/target-type: "ip"
 external-dns.alpha.kubernetes.io/ttl: "60"
 external-dns.alpha.kubernetes.io/hostname: {{ .defaultHost }}
@@ -103,40 +103,40 @@ alb.ingress.kubernetes.io/backend-protocol: {{ include "mintel_common.ingress.al
 alb.ingress.kubernetes.io/backend-protocol-version: {{ include "mintel_common.ingress.alb.backendProtocolVersion" .alb }}
 alb.ingress.kubernetes.io/success-codes: "{{ include "mintel_common.ingress.alb.healthcheck.successCodes" .alb }}"
 alb.ingress.kubernetes.io/healthcheck-path: {{ include "mintel_common.ingress.alb.healthcheck.path" .alb }}
-alb.ingress.kubernetes.io/healthcheck-interval-seconds: "{{ default 15 .alb.healthcheck.intervalSeconds }}"
+alb.ingress.kubernetes.io/healthcheck-interval-seconds: "{{ .alb.healthcheck.intervalSeconds | default 15 }}"
 alb.ingress.kubernetes.io/healthcheck-port: "{{ include "mintel_common.ingress.alb.healthcheck.port" $ }}"
 alb.ingress.kubernetes.io/healthcheck-protocol: {{ include "mintel_common.ingress.alb.healthcheck.protocol" .alb }}
-alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "{{ default 5 .alb.healthcheck.timeoutSeconds }}"
-alb.ingress.kubernetes.io/healthy-threshold-count: "{{ default 2 .alb.healthcheck.healthyThresholdCount }}"
-alb.ingress.kubernetes.io/unhealthy-threshold-count: "{{ default 2 .alb.healthcheck.unhealthyThresholdCount }}"
+alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "{{ .alb.healthcheck.timeoutSeconds | default 5 }}"
+alb.ingress.kubernetes.io/healthy-threshold-count: "{{ .alb.healthcheck.healthyThresholdCount | default 2 }}"
+alb.ingress.kubernetes.io/unhealthy-threshold-count: "{{ .alb.healthcheck.unhealthyThresholdCount | default 2 }}"
 {{- end -}}
 
 {{- define "mintel_common.ingress.ingressPath" -}}
-- path: {{ default "/" .path }}
-  pathType: {{ default "Prefix" .pathType }}
+- path: {{ .path | default "/" }}
+  pathType: {{ .pathType | default "Prefix" }}
   backend:
     service:
-      name: {{ default (include "mintel_common.fullname" .) .targetService }}
+      name: {{ .targetService | default (include "mintel_common.fullname" .) }}
       port:
         {{- if (and .Values.oauthProxy .Values.oauthProxy.enabled) }}
         number: 4180
         {{- else }}
-        number: {{ default .Values.port .targetPort }}
+        number: {{ .targetPort | default .Values.port }}
         {{- end }}
 {{- end -}}
 
 {{/* Outputs space separated list of endpoints to deny at ingress */}}
 {{- define "mintel_common.ingressDenyEndpoints" -}}
 {{- $endpoints := list }}
-{{- $endpoints = append $endpoints (default "/metrics" .Values.metrics.path) }}
+{{- $endpoints = append $endpoints ( .Values.metrics.path | default "/metrics" ) }}
 {{- if (ne .Values.ingress.allowLivenessUrl true) }}
-{{- $livenessEndpoint := (coalesce .Values.liveness.path "/healthz") }}
+{{- $livenessEndpoint := .Values.liveness.path | default "/healthz" }}
 {{- if (ne $livenessEndpoint .Values.ingress.blackbox.probePath) }}
 {{- $endpoints = append $endpoints $livenessEndpoint }}
 {{- end }}
 {{- end }}
 {{- if (ne .Values.ingress.allowReadinessUrl true) }}
-{{- $readinessEndpoint := (coalesce .Values.readiness.path "/readiness") }}
+{{- $readinessEndpoint := .Values.readiness.path | default "/readiness" }}
 {{- if (ne $readinessEndpoint .Values.ingress.blackbox.probePath) }}
 {{- $endpoints = append $endpoints $readinessEndpoint }}
 {{- end }}

--- a/charts/standard-application-stack/templates/helpers/_ingress.yaml
+++ b/charts/standard-application-stack/templates/helpers/_ingress.yaml
@@ -2,35 +2,34 @@
 
 {{/* Output ingressClassName */}}
 {{- define "mintel_common.ingress.className" -}}
-{{- if (and .Values.ingress.alb .Values.ingress.alb.enabled) }}
-{{- if eq .Values.ingress.alb.scheme "internet-facing" }}
-{{- print "alb-public-apps-default" -}}
-{{- end }}
-{{- if eq .Values.ingress.alb.scheme "internal" }}
-{{- print "alb-internal-apps-default" -}}
-{{- end }}
-{{- else }}
-{{- print "haproxy" -}}
-{{- end }}
+{{- if (and .Values.ingress.alb .Values.ingress.alb.enabled) -}}
+  {{- if eq .Values.ingress.alb.scheme "internet-facing" -}}
+  alb-public-apps-default
+  {{- else if eq .Values.ingress.alb.scheme "internal" -}}
+  alb-internal-apps-default
+  {{- end -}}
+{{- else -}}
+haproxy
+{{- end -}}
 {{- end -}}
 
 {{/* Validate ALB BackendProtocol and default to HTTP */}}
 {{- define "mintel_common.ingress.alb.backendProtocol" -}}
-{{- if has .backendProtocol (list "HTTP" "HTTPS" ) }}
-{{- .backendProtocol }}
-{{- else }}
-{{- "HTTP" }}
-{{- end }}
-{{- end }}
+{{- if (list "HTTP" "HTTPS") | has .backendProtocol -}}
+{{- .backendProtocol -}}
+{{- else -}}
+HTTP"
+{{- end -}}
+{{- end -}}
 
 {{/* Validate ALB BackendProtocolVersion and default to HTTP1 */}}
 {{- define "mintel_common.ingress.alb.backendProtocolVersion" -}}
-{{- if has .backendProtocolVersion (list "HTTP1" "HTTP2" "GRPC" ) }}
-{{- .backendProtocolVersion }}
-{{- else }}
-{{- "HTTP1" }}
-{{- end }}
-{{- end }}
+{{- if (list "HTTP1" "HTTP2" "GRPC") | has .backendProtocolVersion -}}
+{{- .backendProtocolVersion -}}
+{{- else -}}
+HTTP1
+{{- end -}}
+{{- end -}}
 
 {{/* Set default ALB healthcheck success-codes */}}
 {{- define "mintel_common.ingress.alb.healthcheck.successCodes" -}}
@@ -43,7 +42,7 @@
 
 {{/* Set default ALB healthcheck path */}}
 {{- define "mintel_common.ingress.alb.healthcheck.path" -}}
-{{- if eq .backendProtocolVersion "GRPC"}}
+{{- if eq .backendProtocolVersion "GRPC" }}
 {{- .healthcheck.path | default "/grpc.health.v1.Health/Check" }}
 {{- else }}
 {{- .healthcheck.path | default "/readiness" }}
@@ -61,19 +60,19 @@
 
 {{/* Set default ALB healthcheck protocol */}}
 {{- define "mintel_common.ingress.alb.healthcheck.protocol" -}}
-{{- if has .healthcheck.protocol (list "HTTP" "HTTPS" ) }}
-{{- .healthcheck.protocol}}
-{{- else }}
-{{- "HTTP" }}
-{{- end }}
-{{- end }}
+{{- if (list "HTTP" "HTTPS") | has .healthcheck.protocol -}}
+{{- .healthcheck.protocol -}}
+{{- else -}}
+HTTP
+{{- end -}}
+{{- end -}}
 
 {{- define "mintel_common.ingress.haproxy_annotations" -}}
 {{- with .ingress.serverTimeoutSeconds | default .Values.ingress.serverTimeoutSeconds }}
 ingress.kubernetes.io/timeout-server: {{ . }}s
 {{- end }}
 ingress.kubernetes.io/rewrite-target: /
-{{- if (or (or (and .Values.metrics .Values.metrics.enabled) (or .Values.ingress.setXForwardedForHeaders .ingress.setXForwardedForHeaders)) (or .Values.ingress.setNoCacheHeaders .ingress.setNoCacheHeaders)) }}
+{{- if or (and .Values.metrics .Values.metrics.enabled) .Values.ingress.setXForwardedForHeaders .ingress.setXForwardedForHeaders .Values.ingress.setNoCacheHeaders .ingress.setNoCacheHeaders }}
 ingress.kubernetes.io/config-backend: |
 {{- end }}
 {{- if (and .Values.metrics .Values.metrics.enabled) }}
@@ -141,7 +140,7 @@ alb.ingress.kubernetes.io/unhealthy-threshold-count: "{{ .alb.healthcheck.unheal
 {{- $endpoints = append $endpoints $readinessEndpoint }}
 {{- end }}
 {{- end }}
-{{- print (join " " $endpoints) }}
+{{- join " " $endpoints }}
 {{- end -}}
 
 {{/* Create a fully qualified app name, but with ability to override it for ingress */}}
@@ -149,7 +148,7 @@ alb.ingress.kubernetes.io/unhealthy-threshold-count: "{{ .alb.healthcheck.unheal
 {{- if .ingress.ingressNameSuffix }}
 {{- printf "%s-%s" (coalesce .ingress.ingressNameOverride $.Values.ingress.ingressNameOverride (include "mintel_common.fullname" .)) .ingress.ingressNameSuffix -}}
 {{- else -}}
-{{- printf "%s" (coalesce .ingress.ingressNameOverride $.Values.ingress.ingressNameOverride (include "mintel_common.fullname" .)) -}}
+{{- coalesce .ingress.ingressNameOverride $.Values.ingress.ingressNameOverride (include "mintel_common.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/standard-application-stack/templates/helpers/_ingress.yaml
+++ b/charts/standard-application-stack/templates/helpers/_ingress.yaml
@@ -140,7 +140,7 @@ alb.ingress.kubernetes.io/unhealthy-threshold-count: "{{ .alb.healthcheck.unheal
 {{- $endpoints = append $endpoints $readinessEndpoint }}
 {{- end }}
 {{- end }}
-{{- join " " $endpoints }}
+{{- $endpoints | sortAlpha | uniq | compact | join " " }}
 {{- end -}}
 
 {{/* Create a fully qualified app name, but with ability to override it for ingress */}}

--- a/charts/standard-application-stack/templates/helpers/_keda.yaml
+++ b/charts/standard-application-stack/templates/helpers/_keda.yaml
@@ -29,5 +29,5 @@ Helpers for Keda objects
 
 # pollingInterval must be >= 10
 {{- define "mintel_common.keda.scaledObject.pollingInterval" -}}
-  {{- max 10 .pollingInterval}}
+  {{- max 10 .pollingInterval }}
 {{- end }}

--- a/charts/standard-application-stack/templates/helpers/_nlb.yaml
+++ b/charts/standard-application-stack/templates/helpers/_nlb.yaml
@@ -34,9 +34,9 @@ service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold: "{
 
 {{/* Set default NLB healthcheck protocol */}}
 {{- define "mintel_common.nlb.healthcheck.protocol" -}}
-{{- if has .healthcheck.protocol (list "HTTP" "HTTPS" "TCP" ) }}
-{{- .healthcheck.protocol}}
-{{- else }}
-{{- "TCP" }}
-{{- end }}
-{{- end }}
+{{- if (list "HTTP" "HTTPS" "TCP") | has .healthcheck.protocol -}}
+{{- .healthcheck.protocol -}}
+{{- else -}}
+TCP
+{{- end -}}
+{{- end -}}

--- a/charts/standard-application-stack/templates/helpers/_nlb.yaml
+++ b/charts/standard-application-stack/templates/helpers/_nlb.yaml
@@ -12,23 +12,23 @@ service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: {{ .Values.nlb.tar
 service.beta.kubernetes.io/healthcheck-path: {{ include "mintel_common.nlb.healthcheck.path" .Values.nlb }}
 service.beta.kubernetes.io/healthcheck-port: "{{ include "mintel_common.nlb.healthcheck.port" . }}"
 service.beta.kubernetes.io/healthcheck-protocol: {{ include "mintel_common.nlb.healthcheck.protocol" .Values.nlb }}
-service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout: "{{ default 5 .Values.nlb.healthcheck.timeoutSeconds }}"
-service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval: "{{ default 10 .Values.nlb.healthcheck.intervalSeconds }}"
-service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold: "{{ default 2 .Values.nlb.healthcheck.healthyThresholdCount }}"
-service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold: "{{ default 2 .Values.nlb.healthcheck.unhealthyThresholdCount }}"
+service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout: "{{ .Values.nlb.healthcheck.timeoutSeconds | default 5 }}"
+service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval: "{{ .Values.nlb.healthcheck.intervalSeconds | default 10 }}"
+service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold: "{{ .Values.nlb.healthcheck.healthyThresholdCount | default 2 }}"
+service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold: "{{ .Values.nlb.healthcheck.unhealthyThresholdCount | default 2 }}"
 {{- end }}
 
 {{/* Set default NLB healthcheck path */}}
 {{- define "mintel_common.nlb.healthcheck.path" -}}
-{{- default "/" .healthcheck.path }}
+{{- .healthcheck.path | default "/" }}
 {{- end }}
 
 {{/* Set default NLB healthcheck port */}}
 {{- define "mintel_common.nlb.healthcheck.port" -}}
 {{- if .Values.oauthProxy.enabled }}
-{{- default 4180 .Values.nlb.healthcheck.port }}
+{{- .Values.nlb.healthcheck.port | default 4180 }}
 {{- else }}
-{{- default .Values.port .Values.nlb.healthcheck.port }}
+{{- .Values.nlb.healthcheck.port | default .Values.port }}
 {{- end }}
 {{- end }}
 

--- a/charts/standard-application-stack/templates/ingress.yaml
+++ b/charts/standard-application-stack/templates/ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
     {{- if .Values.ingress.extraAnnotations }}
     {{- toYaml .Values.ingress.extraAnnotations | nindent 4 }}
-    {{- end}}
+    {{- end }}
     ingress.kubernetes.io/ssl-redirect: "false"
 spec:
   rules:
@@ -45,7 +45,7 @@ metadata:
     {{ include "mintel_common.commonAnnotations" $ingressData | nindent 4 }}
     {{- if (or $.Values.ingress.extraAnnotations $ingressData.ingress.extraAnnotations) }}
     {{- $ingressData.extraAnnotations | default $.Values.ingress.extraAnnotations | toYaml | nindent 4 }}
-    {{- end}}
+    {{- end }}
 
     {{- if (eq (include "mintel_common.ingress.className" $ingressData) "haproxy" ) }}
     {{- include "mintel_common.ingress.haproxy_annotations" $ingressData | nindent 4 }}

--- a/charts/standard-application-stack/templates/ingress.yaml
+++ b/charts/standard-application-stack/templates/ingress.yaml
@@ -44,7 +44,7 @@ metadata:
   annotations:
     {{ include "mintel_common.commonAnnotations" $ingressData | nindent 4 }}
     {{- if (or $.Values.ingress.extraAnnotations $ingressData.ingress.extraAnnotations) }}
-    {{- toYaml (default $.Values.ingress.extraAnnotations $ingressData.extraAnnotations) | nindent 4 }}
+    {{- $ingressData.extraAnnotations | default $.Values.ingress.extraAnnotations | toYaml | nindent 4 }}
     {{- end}}
 
     {{- if (eq (include "mintel_common.ingress.className" $ingressData) "haproxy" ) }}

--- a/charts/standard-application-stack/templates/jobs.yaml
+++ b/charts/standard-application-stack/templates/jobs.yaml
@@ -34,16 +34,16 @@ spec:
       securityContext: {{ toYaml . | nindent 12 }}
       {{- end }}
       {{- if (and $.Values.serviceAccount (or $.Values.serviceAccount.create $.Values.serviceAccount.name)) }}
-      serviceAccountName: {{ default (include "mintel_common.fullname" $) $.Values.serviceAccount.name }}
+      serviceAccountName: {{ $.Values.serviceAccount.name | default (include "mintel_common.fullname" $)}}
       {{- end }}
-      restartPolicy: {{ coalesce .restartPolicy "Never" }}
+      restartPolicy: {{ .restartPolicy | default "Never" }}
       {{- with .extraInitContainers }}
       initContainers:
       {{- toYaml . | nindent 12 }}
       {{- end }}
       containers:
         - name: main
-          image: {{ coalesce .image (include "mintel_common.image" $) }}
+          image: {{ .image | default (include "mintel_common.image" $) }}
           imagePullPolicy: {{ include "mintel_common.imagePullPolicy" $ }}
           {{- with .command }}
           command: {{ toYaml . | nindent 16 }}
@@ -71,7 +71,7 @@ spec:
             {{- if (or (ne $.Values.global.clusterEnv "local") (and (eq $.Values.global.clusterEnv "local") $.Values.externalSecret.localValues)) }}
             {{- if .includeAppSecret }}
             - secretRef:
-                name: {{ default (include "mintel_common.defaultAppSecretName" $) $.Values.externalSecret.nameOverride }}
+                name: {{ $.Values.externalSecret.nameOverride | default (include "mintel_common.defaultAppSecretName" $) }}
             {{- end }}
             {{- end }}
             {{- end }}

--- a/charts/standard-application-stack/templates/kubelock-role-binding.yaml
+++ b/charts/standard-application-stack/templates/kubelock-role-binding.yaml
@@ -7,7 +7,7 @@ kind: RoleBinding
 metadata:
   name: {{ include "mintel_common.fullname" . }}
   namespace: {{ .Release.Namespace }}
-  labels: {{ include "mintel_common.labels" . | nindent 4}}
+  labels: {{ include "mintel_common.labels" . | nindent 4 }}
   annotations: {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/standard-application-stack/templates/kubelock-role-binding.yaml
+++ b/charts/standard-application-stack/templates/kubelock-role-binding.yaml
@@ -15,7 +15,7 @@ roleRef:
   name: {{ include "mintel_common.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ default (include "mintel_common.fullname" .) .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
 

--- a/charts/standard-application-stack/templates/kubelock-role.yaml
+++ b/charts/standard-application-stack/templates/kubelock-role.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ include "mintel_common.fullname" .  }}
   namespace: {{ .Release.Namespace }}
   annotations: {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
-  labels: {{ include "mintel_common.labels" . | nindent 4}}
+  labels: {{ include "mintel_common.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - coordination.k8s.io

--- a/charts/standard-application-stack/templates/network-policy.yaml
+++ b/charts/standard-application-stack/templates/network-policy.yaml
@@ -96,7 +96,7 @@ spec:
       {{ if .Values.ingress.alb.healthcheck.port }}
       {{ $ports = append $ports .Values.ingress.alb.healthcheck.port }}
       {{- end }}
-      {{ $ports := sortAlpha $ports | uniq }}
+      {{ $ports := $ports | sortAlpha | uniq | compact }}
       {{- range $ports }}
         - port: {{ . }}
           protocol: TCP
@@ -144,7 +144,7 @@ spec:
       ports:
       {{ $ports := list }}
       {{ $ports = append $ports .Values.port}}
-      {{ $ports := sortAlpha $ports | uniq }}
+      {{ $ports := $ports | sortAlpha | uniq | compact }}
       {{- range $ports }}
         - port: {{ . }}
           protocol: TCP

--- a/charts/standard-application-stack/templates/network-policy.yaml
+++ b/charts/standard-application-stack/templates/network-policy.yaml
@@ -23,13 +23,13 @@ spec:
 kind: NetworkPolicy
 apiVersion: {{ include "common.capabilities.networkpolicy.apiVersion" . }}
 metadata:
-  name: {{ printf "%s-to-%s" .fromName (default $.Values.global.name .toName) }}
+  name: {{ printf "%s-to-%s" .fromName (.toName | default $.Values.global.name) }}
   namespace: {{ $.Release.Namespace }}
   annotations: {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}
 spec:
   podSelector:
     matchLabels:
-      app.kubernetes.io/name: {{ default $.Values.global.name .toName }}
+      app.kubernetes.io/name: {{ .toName | default $.Values.global.name }}
   ingress:
     - from:
       - podSelector:

--- a/charts/standard-application-stack/templates/network-policy.yaml
+++ b/charts/standard-application-stack/templates/network-policy.yaml
@@ -91,7 +91,7 @@ spec:
       {{- if .Values.oauthProxy.enabled }}
       {{ $ports = append $ports 4180 }}
       {{- else }}
-      {{ $ports = append $ports .Values.port}}
+      {{ $ports = append $ports .Values.port }}
       {{- end }}
       {{ if .Values.ingress.alb.healthcheck.port }}
       {{ $ports = append $ports .Values.ingress.alb.healthcheck.port }}
@@ -143,7 +143,7 @@ spec:
       {{- end }}
       ports:
       {{ $ports := list }}
-      {{ $ports = append $ports .Values.port}}
+      {{ $ports = append $ports .Values.port }}
       {{ $ports := $ports | sortAlpha | uniq | compact }}
       {{- range $ports }}
         - port: {{ . }}

--- a/charts/standard-application-stack/templates/pod-monitor-celery-exporter.yaml
+++ b/charts/standard-application-stack/templates/pod-monitor-celery-exporter.yaml
@@ -14,8 +14,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   podMetricsEndpoints:
-    - interval: {{ default "30s" .Values.celery.metrics.interval }}
-      path: {{ default "/metrics" .Values.celery.metrics.path }}
+    - interval: {{ .Values.celery.metrics.interval | default "30s" }}
+      path: {{ .Values.celery.metrics.path | default "/metrics" }}
       port: metrics
       relabelings:
         - separator: /
@@ -23,8 +23,8 @@ spec:
             - __meta_kubernetes_namespace
             - __meta_kubernetes_pod_label_app_kubernetes_io_name
           targetLabel: job
-      scheme: {{ default "http" .Values.celery.metrics.scheme }}
-      scrapeTimeout: {{ default "10s" .Values.celery.metrics.timeout }}
+      scheme: {{ .Values.celery.metrics.scheme | default "http" }}
+      scrapeTimeout: {{ .Values.celery.metrics.timeout | default "10s" }}
       tlsConfig:
         insecureSkipVerify: true
   selector:

--- a/charts/standard-application-stack/templates/pod-monitor-celery.yaml
+++ b/charts/standard-application-stack/templates/pod-monitor-celery.yaml
@@ -16,8 +16,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   podMetricsEndpoints:
-    - interval: {{ default "30s" .Values.filebeatSidecar.metrics.interval }}
-      path: {{ default "/metrics" .Values.filebeatSidecar.metrics.path }}
+    - interval: {{ .Values.filebeatSidecar.metrics.interval | default "30s" }}
+      path: {{ .Values.filebeatSidecar.metrics.path | default "/metrics" }}
       port: beat-exporter-metrics
       relabelings:
         - separator: /
@@ -25,8 +25,8 @@ spec:
             - __meta_kubernetes_namespace
             - __meta_kubernetes_pod_label_app_kubernetes_io_name
           targetLabel: job
-      scheme: {{ default "http" .Values.filebeatSidecar.metrics.scheme }}
-      scrapeTimeout: {{ default "10s" .Values.filebeatSidecar.metrics.timeout }}
+      scheme: {{ .Values.filebeatSidecar.metrics.scheme | default "http" }}
+      scrapeTimeout: {{ .Values.filebeatSidecar.metrics.timeout | default "10s" }}
       tlsConfig:
         insecureSkipVerify: true
   selector:

--- a/charts/standard-application-stack/templates/pod-monitor-hybrid-consul.yaml
+++ b/charts/standard-application-stack/templates/pod-monitor-hybrid-consul.yaml
@@ -14,8 +14,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   podMetricsEndpoints:
-    - interval: {{ default "30s" .Values.hybridCloud.metrics.interval }}
-      path: {{ default "/metrics" .Values.hybridCloud.metrics.path }}
+    - interval: {{ .Values.hybridCloud.metrics.interval | default "30s" }}
+      path: {{ .Values.hybridCloud.metrics.path | default "/metrics" }}
       port: consul-metrics
       relabelings:
         - separator: /
@@ -23,8 +23,8 @@ spec:
             - __meta_kubernetes_namespace
             - __meta_kubernetes_pod_label_app_kubernetes_io_name
           targetLabel: job
-      scheme: {{ default "http" .Values.hybridCloud.metrics.scheme }}
-      scrapeTimeout: {{ default "10s" .Values.hybridCloud.metrics.timeout }}
+      scheme: {{ .Values.hybridCloud.metrics.scheme | default "http" }}
+      scrapeTimeout: {{ .Values.hybridCloud.metrics.timeout | default "10s" }}
       tlsConfig:
         insecureSkipVerify: true
   selector:

--- a/charts/standard-application-stack/templates/pod-monitor-hybrid-consul.yaml
+++ b/charts/standard-application-stack/templates/pod-monitor-hybrid-consul.yaml
@@ -8,7 +8,7 @@ kind: PodMonitor
 metadata:
   name: {{ include "mintel_common.fullname" $monitorData }}
   namespace: {{ .Release.Namespace }}
-  labels: {{ include "mintel_common.labels" $monitorData | nindent 4}}
+  labels: {{ include "mintel_common.labels" $monitorData | nindent 4 }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/charts/standard-application-stack/templates/pod-monitor-mysqldexporter.yaml
+++ b/charts/standard-application-stack/templates/pod-monitor-mysqldexporter.yaml
@@ -13,8 +13,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   podMetricsEndpoints:
-    - interval: {{ default "30s" .Values.mariadb.metrics.interval }}
-      path: {{ default "/metrics" .Values.mariadb.metrics.path }}
+    - interval: {{ .Values.mariadb.metrics.interval | default "30s" }}
+      path: {{ .Values.mariadb.metrics.path | default "/metrics" }}
       port: metrics
       relabelings:
         - separator: /
@@ -22,8 +22,8 @@ spec:
             - __meta_kubernetes_namespace
             - __meta_kubernetes_pod_label_app_kubernetes_io_name
           targetLabel: job
-      scheme: {{ default "http" .Values.mariadb.metrics.scheme }}
-      scrapeTimeout: {{ default "10s" .Values.mariadb.metrics.timeout }}
+      scheme: {{ .Values.mariadb.metrics.scheme | default "http" }}
+      scrapeTimeout: {{ .Values.mariadb.metrics.timeout | default "10s" }}
       tlsConfig:
         insecureSkipVerify: true
   selector:

--- a/charts/standard-application-stack/templates/pod-monitor-postgresqlexporter.yaml
+++ b/charts/standard-application-stack/templates/pod-monitor-postgresqlexporter.yaml
@@ -13,8 +13,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   podMetricsEndpoints:
-    - interval: {{ default "30s" .Values.postgresql.metrics.interval }}
-      path: {{ default "/metrics" .Values.postgresql.metrics.path }}
+    - interval: {{ .Values.postgresql.metrics.interval | default "30s" }}
+      path: {{ .Values.postgresql.metrics.path | default "/metrics" }}
       port: metrics
       relabelings:
         - separator: /
@@ -22,8 +22,8 @@ spec:
             - __meta_kubernetes_namespace
             - __meta_kubernetes_pod_label_app_kubernetes_io_name
           targetLabel: job
-      scheme: {{ default "http" .Values.postgresql.metrics.scheme }}
-      scrapeTimeout: {{ default "10s" .Values.postgresql.metrics.timeout }}
+      scheme: {{ .Values.postgresql.metrics.scheme | default "http" }}
+      scrapeTimeout: {{ .Values.postgresql.metrics.timeout | default "10s" }}
       tlsConfig:
         insecureSkipVerify: true
   selector:

--- a/charts/standard-application-stack/templates/pod-monitor.yaml
+++ b/charts/standard-application-stack/templates/pod-monitor.yaml
@@ -14,9 +14,9 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   podMetricsEndpoints:
-    - interval: {{ default "30s" .Values.metrics.interval }}
-      path: {{ default "/metrics" .Values.metrics.path }}
-      port: {{ default "http" .Values.metrics.port }}
+    - interval: {{ .Values.metrics.interval | default "30s" }}
+      path: {{ .Values.metrics.path | default "/metrics" }}
+      port: {{ .Values.metrics.port | default "http" }}
       {{- if .Values.metrics.basicAuth }}
       {{- if .Values.metrics.basicAuth.enabled }}
       basicAuth:
@@ -34,8 +34,8 @@ spec:
             - __meta_kubernetes_namespace
             - __meta_kubernetes_pod_label_app_kubernetes_io_name
           targetLabel: job
-      scheme: {{ default "http" .Values.metrics.scheme }}
-      scrapeTimeout: {{ default "10s" .Values.metrics.timeout }}
+      scheme: {{ .Values.metrics.scheme | default "http" }}
+      scrapeTimeout: {{ .Values.metrics.timeout | default "10s" }}
       tlsConfig:
         insecureSkipVerify: true
   selector:
@@ -57,9 +57,9 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   podMetricsEndpoints:
-    - interval: {{ default "30s" .interval $.Values.metrics.interval }}
-      path: {{ default "/metrics" .path $.Values.metrics.path }}
-      port: {{ default "http" .port $.Values.metrics.port }}
+    - interval: {{ coalesce .interval $.Values.metrics.interval "30s" }}
+      path: {{ coalesce .path $.Values.metrics.path "/metrics" }}
+      port: {{ coalesce .port $.Values.metrics.port "http" }}
       {{- if .basicAuth }}
       {{- if .basicAuth.enabled }}
       basicAuth:
@@ -77,8 +77,8 @@ spec:
             - __meta_kubernetes_namespace
             - __meta_kubernetes_pod_label_app_kubernetes_io_name
           targetLabel: job
-      scheme: {{ default "http" .scheme $.Values.metrics.scheme }}
-      scrapeTimeout: {{ default "10s" .timeout $.Values.metrics.timeout }}
+      scheme: {{ coalesce .scheme $.Values.metrics.scheme "http" }}
+      scrapeTimeout: {{ coalesce .timeout $.Values.metrics.timeout "10s" }}
       tlsConfig:
         insecureSkipVerify: true
   selector:
@@ -102,7 +102,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   podMetricsEndpoints:
-    - interval: {{ default "30s" .Values.metrics.interval }}
+    - interval: {{ .Values.metrics.interval | default "30s" }}
       path: /metrics
       port: auth-proxy-metrics
       relabelings:
@@ -135,8 +135,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   podMetricsEndpoints:
-    - interval: {{ default "30s" .Values.filebeatSidecar.metrics.interval }}
-      path: {{ default "/metrics" .Values.filebeatSidecar.metrics.path }}
+    - interval: {{ .Values.filebeatSidecar.metrics.interval | default "30s" }}
+      path: {{ .Values.filebeatSidecar.metrics.path | default "/metrics" }}
       port: beat-exporter-metrics
       relabelings:
         - separator: /
@@ -144,8 +144,8 @@ spec:
             - __meta_kubernetes_namespace
             - __meta_kubernetes_pod_label_app_kubernetes_io_name
           targetLabel: job
-      scheme: {{ default "http" .Values.filebeatSidecar.metrics.scheme }}
-      scrapeTimeout: {{ default "10s" .Values.filebeatSidecar.metrics.timeout }}
+      scheme: {{ .Values.filebeatSidecar.metrics.scheme | default "http" }}
+      scrapeTimeout: {{ .Values.filebeatSidecar.metrics.timeout | default "10s" }}
       tlsConfig:
         insecureSkipVerify: true
   selector:

--- a/charts/standard-application-stack/templates/pod-monitor.yaml
+++ b/charts/standard-application-stack/templates/pod-monitor.yaml
@@ -129,7 +129,7 @@ kind: PodMonitor
 metadata:
   name: {{ include "mintel_common.fullname" $filebeatData }}
   namespace: {{ .Release.Namespace }}
-  labels: {{ include "mintel_common.labels" $filebeatData | nindent 4}}
+  labels: {{ include "mintel_common.labels" $filebeatData | nindent 4 }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/charts/standard-application-stack/templates/pvcs.yaml
+++ b/charts/standard-application-stack/templates/pvcs.yaml
@@ -6,7 +6,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ include "mintel_common.fullname" $pvcData  }}
   namespace: {{ $.Release.Namespace }}
-  labels: {{ include "mintel_common.labels" $pvcData | nindent 4}}
+  labels: {{ include "mintel_common.labels" $pvcData | nindent 4 }}
   annotations: {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}
 spec:
   accessModes:

--- a/charts/standard-application-stack/templates/pvcs.yaml
+++ b/charts/standard-application-stack/templates/pvcs.yaml
@@ -10,7 +10,7 @@ metadata:
   annotations: {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}
 spec:
   accessModes:
-    - {{ default "ReadWriteOnce" .mode }}
+    - {{ .mode | default "ReadWriteOnce" }}
   resources:
     requests:
       storage: {{ .size }}

--- a/charts/standard-application-stack/templates/secrets.yaml
+++ b/charts/standard-application-stack/templates/secrets.yaml
@@ -135,7 +135,7 @@ data:
   mariadb-password: {{ .Values.mariadb.auth.password | b64enc }}
 {{- end }}
 {{- end }}
-{{- end}}
+{{- end }}
 
 {{- if not .Values.global.terraform.externalSecrets }}
 {{- if (and .Values.dynamodb .Values.dynamodb.enabled) }}
@@ -177,7 +177,7 @@ data:
   DYNAMODB_TABLE_NAME: {{ printf "%s-dynamodb" (include "mintel_common.fullname" .) | b64enc }}
 {{- end }}
 {{- end }}
-{{- end}}
+{{- end }}
 
 {{- if not .Values.global.terraform.externalSecrets }}
 {{- if (and .Values.redis .Values.redis.enabled) }}
@@ -216,7 +216,7 @@ data:
   REDIS_AUTH_TOKEN: {{ .Values.redis.auth.password | default "test" | b64enc }}
 {{- end }}
 {{- end }}
-{{- end}}
+{{- end }}
 
 {{- if not .Values.global.terraform.externalSecrets }}
 {{- if (and .Values.s3 .Values.s3.enabled) }}
@@ -258,7 +258,7 @@ data:
   BUCKET_NAME: {{ printf "%s-s3" (include "mintel_common.fullname" .) | b64enc }}
 {{- end }}
 {{- end }}
-{{- end}}
+{{- end }}
 
 {{- if (and .Values.elasticsearch .Values.elasticsearch.enabled) }}
 {{- if (ne .Values.global.clusterEnv "local") }}
@@ -356,7 +356,7 @@ data:
   OPENSEARCH_DASHBOARD_HOST: {{ printf "%s-opensearch-dashboards" (include "mintel_common.fullname" .) | b64enc }}
 {{- end }}
 {{- end }}
-{{- end}}
+{{- end }}
 
 {{- if not .Values.global.terraform.externalSecrets }}
 {{- if (and .Values.postgresql .Values.postgresql.enabled) }}
@@ -420,7 +420,7 @@ data:
   postgresql-password: {{ .Values.postgresql.auth.password | b64enc }}
 {{- end }}
 {{- end }}
-{{- end}}
+{{- end }}
 
 {{- if (and .Values.oauthProxy .Values.oauthProxy.enabled) }}
 {{- if (ne .Values.global.clusterEnv "local") }}

--- a/charts/standard-application-stack/templates/secrets.yaml
+++ b/charts/standard-application-stack/templates/secrets.yaml
@@ -28,10 +28,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ coalesce .Values.externalSecret.pathOverride (printf "%s/%s/app" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
-  refreshInterval: {{ default "5m0s" .Values.externalSecret.secretRefreshIntervalOverride }}
+    - key: {{ .Values.externalSecret.pathOverride | default (printf "%s/%s/app" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
+  refreshInterval: {{ .Values.externalSecret.secretRefreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
-    name: {{ default "aws-secrets-manager-default" .Values.externalSecret.secretStoreRefOverride }}
+    name: {{ .Values.externalSecret.secretStoreRefOverride | default "aws-secrets-manager-default" }}
     kind: SecretStore
   target:
     creationPolicy: Owner
@@ -68,10 +68,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ coalesce .pathOverride (printf "%s/%s/%s" $.Release.Namespace (include "mintel_common.fullname" $) .name) }}
-  refreshInterval: {{ default "5m0s" .refreshIntervalOverride }}
+    - key: {{ .pathOverride | default (printf "%s/%s/%s" $.Release.Namespace (include "mintel_common.fullname" $) .name) }}
+  refreshInterval: {{ .refreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
-    name: {{ default "aws-secrets-manager-default" .secretStoreRefOverride }}
+    name: {{ .secretStoreRefOverride | default "aws-secrets-manager-default" }}
     kind: SecretStore
   target:
     creationPolicy: Owner
@@ -93,7 +93,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   data:
-    {{- $dataKey := ( coalesce .Values.mariadb.secretPathOverride (printf "%s/%s/mariadb" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
+    {{- $dataKey := ( .Values.mariadb.secretPathOverride | default (printf "%s/%s/mariadb" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
     - secretKey: DB_HOST
       remoteRef:
         key: {{ $dataKey }}
@@ -110,9 +110,9 @@ spec:
       remoteRef:
         key: {{ $dataKey }}
         property: password
-  refreshInterval: {{ default "5m0s" .Values.mariadb.secretRefreshIntervalOverride }}
+  refreshInterval: {{ .Values.mariadb.secretRefreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
-    name: {{ default "aws-secrets-manager-default" .Values.mariadb.secretStoreRefOverride }}
+    name: {{ .Values.mariadb.secretStoreRefOverride | default "aws-secrets-manager-default" }}
     kind: SecretStore
   target:
     creationPolicy: Owner
@@ -152,14 +152,14 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   data:
-    {{- $dataKey := ( coalesce .Values.dynamodb.secretPathOverride (printf "%s/%s/dynamodb" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
+    {{- $dataKey := ( .Values.dynamodb.secretPathOverride | default (printf "%s/%s/dynamodb" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
     - secretKey: DYNAMODB_TABLE_NAME
       remoteRef:
         key: {{ $dataKey }}
         property: DYNAMODB_TABLE_NAME
-  refreshInterval: {{ default "5m0s" .Values.dynamodb.secretRefreshIntervalOverride }}
+  refreshInterval: {{ .Values.dynamodb.secretRefreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
-    name: {{ default "aws-secrets-manager-default" .Values.dynamodb.secretStoreRefOverride }}
+    name: {{ .Values.dynamodb.secretStoreRefOverride | default "aws-secrets-manager-default" }}
     kind: SecretStore
   target:
     creationPolicy: Owner
@@ -194,10 +194,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ coalesce .Values.redis.secretPathOverride (printf "%s/%s/redis" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
-  refreshInterval: {{ default "5m0s" .Values.redis.secretRefreshIntervalOverride }}
+    - key: {{ .Values.redis.secretPathOverride | default (printf "%s/%s/redis" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
+  refreshInterval: {{ .Values.redis.secretRefreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
-    name: {{ default "aws-secrets-manager-default" .Values.redis.secretStoreRefOverride }}
+    name: {{ .Values.redis.secretStoreRefOverride | default "aws-secrets-manager-default" }}
     kind: SecretStore
   target:
     creationPolicy: Owner
@@ -213,7 +213,7 @@ metadata:
 type: Opaque
 data:
   REDIS_PRIMARY_ENDPOINT: {{ printf "%s-redis-headless:6379" (include "mintel_common.fullname" .) | b64enc }}
-  REDIS_AUTH_TOKEN: {{ (default "test" .Values.redis.auth.password) | b64enc }}
+  REDIS_AUTH_TOKEN: {{ .Values.redis.auth.password | default "test" | b64enc }}
 {{- end }}
 {{- end }}
 {{- end}}
@@ -233,14 +233,14 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   data:
-    {{- $dataKey := ( coalesce .Values.s3.secretPathOverride (printf "%s/%s/s3" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
+    {{- $dataKey := ( .Values.s3.secretPathOverride | default (printf "%s/%s/s3" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
     - secretKey: BUCKET_NAME
       remoteRef:
         key: {{ $dataKey }}
         property: BUCKET_NAME
-  refreshInterval: {{ default "5m0s" .Values.s3.secretRefreshIntervalOverride }}
+  refreshInterval: {{ .Values.s3.secretRefreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
-    name: {{ default "aws-secrets-manager-default" .Values.s3.secretStoreRefOverride }}
+    name: {{ .Values.s3.secretStoreRefOverride | default "aws-secrets-manager-default" }}
     kind: SecretStore
   target:
     creationPolicy: Owner
@@ -274,16 +274,16 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ coalesce .Values.elasticsearch.secretPathOverride (printf "%s/%s/elasticsearch" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
+    - key: {{ .Values.elasticsearch.secretPathOverride | default (printf "%s/%s/elasticsearch" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
   data:
-    {{- $dataKey := ( coalesce .Values.elasticsearch.secretPathOverride (printf "%s/%s/elasticsearch" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
+    {{- $dataKey := ( .Values.elasticsearch.secretPathOverride | default (printf "%s/%s/elasticsearch" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
     - secretKey: ES_HOSTS
       remoteRef:
         key: {{ $dataKey }}
         property: ELASTICSEARCH_HOST
-  refreshInterval: {{ default "5m0s" .Values.elasticsearch.secretRefreshIntervalOverride }}
+  refreshInterval: {{ .Values.elasticsearch.secretRefreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
-    name: {{ default "aws-secrets-manager-default" .Values.elasticsearch.secretStoreRefOverride }}
+    name: {{ .Values.elasticsearch.secretStoreRefOverride | default "aws-secrets-manager-default" }}
     kind: SecretStore
   target:
     creationPolicy: Owner
@@ -318,9 +318,9 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ coalesce .Values.opensearch.secretPathOverride (printf "%s/%s/opensearch" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
+    - key: {{ .Values.opensearch.secretPathOverride | default (printf "%s/%s/opensearch" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
   data:
-    {{- $dataKey := ( coalesce .Values.opensearch.secretPathOverride (printf "%s/%s/opensearch" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
+    {{- $dataKey := ( .Values.opensearch.secretPathOverride | default (printf "%s/%s/opensearch" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
     {{- if (not .Values.opensearch.awsEsProxy.enabled) }}
     - secretKey: ES_HOSTS
       remoteRef:
@@ -331,9 +331,9 @@ spec:
       remoteRef:
         key: {{ $dataKey }}
         property: OPENSEARCH_HOST
-  refreshInterval: {{ default "5m0s" .Values.opensearch.secretRefreshIntervalOverride }}
+  refreshInterval: {{ .Values.opensearch.secretRefreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
-    name: {{ default "aws-secrets-manager-default" .Values.opensearch.secretStoreRefOverride }}
+    name: {{ .Values.opensearch.secretStoreRefOverride | default "aws-secrets-manager-default" }}
     kind: SecretStore
   target:
     creationPolicy: Owner
@@ -373,7 +373,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   data:
-    {{- $dataKey := ( coalesce .Values.postgresql.secretPathOverride (printf "%s/%s/postgres" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
+    {{- $dataKey := ( .Values.postgresql.secretPathOverride | default (printf "%s/%s/postgres" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
     - secretKey: DB_HOST
       remoteRef:
         key: {{ $dataKey }}
@@ -394,9 +394,9 @@ spec:
       remoteRef:
         key: {{ $dataKey }}
         property: port
-  refreshInterval: {{ default "5m0s" .Values.postgresql.secretRefreshIntervalOverride }}
+  refreshInterval: {{ .Values.postgresql.secretRefreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
-    name: {{ default "aws-secrets-manager-default" .Values.postgresql.secretStoreRefOverride }}
+    name: {{ .Values.postgresql.secretStoreRefOverride | default "aws-secrets-manager-default" }}
     kind: SecretStore
   target:
     creationPolicy: Owner
@@ -415,7 +415,7 @@ data:
   DB_NAME: {{ .Values.postgresql.auth.database | b64enc }}
   DB_USER: {{ .Values.postgresql.auth.username | b64enc }}
   DB_PASSWORD: {{ .Values.postgresql.auth.password | b64enc }}
-  DB_PORT: {{ ( default "5432" .Values.postgresql.auth.port ) | b64enc }}
+  DB_PORT: {{ .Values.postgresql.auth.port | default "5432" | b64enc }}
   postgresql-postgres-password: {{ .Values.postgresql.auth.password | b64enc }}
   postgresql-password: {{ .Values.postgresql.auth.password | b64enc }}
 {{- end }}
@@ -442,10 +442,10 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ coalesce .Values.oauthProxy.secretPathOverride (printf "%s/%s/oauth" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
-  refreshInterval: {{ default "5m0s" .Values.oauthProxy.secretRefreshIntervalOverride }}
+    - key: {{ .Values.oauthProxy.secretPathOverride | default (printf "%s/%s/oauth" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
+  refreshInterval: {{ .Values.oauthProxy.secretRefreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
-    name: {{ default "aws-secrets-manager-default" .Values.oauthProxy.secretStoreRefOverride }}
+    name: {{ .Values.oauthProxy.secretStoreRefOverride | default "aws-secrets-manager-default" }}
     kind: SecretStore
   target:
     creationPolicy: Owner

--- a/charts/standard-application-stack/templates/service-account-cluster-role-bindings.yaml
+++ b/charts/standard-application-stack/templates/service-account-cluster-role-bindings.yaml
@@ -16,7 +16,7 @@ roleRef:
   name: {{ include "mintel_common.fullname" $roleData }}
 subjects:
   - kind: ServiceAccount
-    name: {{ default (include "mintel_common.fullname" $) $.Values.serviceAccount.name }}
+    name: {{ $.Values.serviceAccount.name | default (include "mintel_common.fullname" $) }}
     apiGroup: ""
     namespace: {{ $.Release.Namespace }}
   {{- end }}

--- a/charts/standard-application-stack/templates/service-account-cluster-role-bindings.yaml
+++ b/charts/standard-application-stack/templates/service-account-cluster-role-bindings.yaml
@@ -8,7 +8,7 @@ kind: ClusterRoleBinding
 metadata:
   name: {{ include "mintel_common.fullname" $roleData }}
   namespace: {{ $.Release.Namespace }}
-  labels: {{ include "mintel_common.labels" $roleData | nindent 4}}
+  labels: {{ include "mintel_common.labels" $roleData | nindent 4 }}
   annotations: {{ include "mintel_common.commonAnnotations" $roleData | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/standard-application-stack/templates/service-account-role-bindings.yaml
+++ b/charts/standard-application-stack/templates/service-account-role-bindings.yaml
@@ -16,7 +16,7 @@ roleRef:
   name: {{ include "mintel_common.fullname" $roleData }}
 subjects:
   - kind: ServiceAccount
-    name: {{ default (include "mintel_common.fullname" $) $.Values.serviceAccount.name }}
+    name: {{ $.Values.serviceAccount.name | default (include "mintel_common.fullname" $) }}
     namespace: {{ $.Release.Namespace }}
 {{- end }}
 

--- a/charts/standard-application-stack/templates/service-account-role-bindings.yaml
+++ b/charts/standard-application-stack/templates/service-account-role-bindings.yaml
@@ -8,7 +8,7 @@ kind: RoleBinding
 metadata:
   name: {{ include "mintel_common.fullname" $roleData }}
   namespace: {{ $.Release.Namespace }}
-  labels: {{ include "mintel_common.labels" $roleData | nindent 4}}
+  labels: {{ include "mintel_common.labels" $roleData | nindent 4 }}
   annotations: {{ include "mintel_common.commonAnnotations" $roleData | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/standard-application-stack/templates/service-accounts.yaml
+++ b/charts/standard-application-stack/templates/service-accounts.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
   namespace: {{ .Release.Namespace }}
-  labels: {{ include "mintel_common.labels" . | nindent 4}}
+  labels: {{ include "mintel_common.labels" . | nindent 4 }}
   {{- if (or .Values.serviceAccount.annotations (and .Values.serviceAccount.irsa.enabled (ne .Values.global.clusterEnv "local"))) }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}

--- a/charts/standard-application-stack/templates/service-accounts.yaml
+++ b/charts/standard-application-stack/templates/service-accounts.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "common.capabilities.serviceaccount.apiVersion" . }}
 kind: ServiceAccount
 metadata:
-  name: {{ default (include "mintel_common.fullname" .) .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "mintel_common.labels" . | nindent 4}}
   {{- if (or .Values.serviceAccount.annotations (and .Values.serviceAccount.irsa.enabled (ne .Values.global.clusterEnv "local"))) }}

--- a/charts/standard-application-stack/templates/service-monitor.yaml
+++ b/charts/standard-application-stack/templates/service-monitor.yaml
@@ -133,7 +133,7 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "mintel_common.fullname" $filebeatData }}
   namespace: {{ .Release.Namespace }}
-  labels: {{ include "mintel_common.labels" $filebeatData | nindent 4}}
+  labels: {{ include "mintel_common.labels" $filebeatData | nindent 4 }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/charts/standard-application-stack/templates/service-monitor.yaml
+++ b/charts/standard-application-stack/templates/service-monitor.yaml
@@ -15,9 +15,9 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   endpoints:
-    - interval: {{ default "30s" .Values.metrics.interval }}
-      path: {{ default "/metrics" .Values.metrics.path }}
-      port: main-{{ default "http" .Values.metrics.port }}
+    - interval: {{ .Values.metrics.interval | default "30s" }}
+      path: {{ .Values.metrics.path | default "/metrics" }}
+      port: main-{{ .Values.metrics.port | default "http" }}
       {{- if .Values.metrics.basicAuth }}
       {{- if .Values.metrics.basicAuth.enabled }}
       basicAuth:
@@ -35,8 +35,8 @@ spec:
             - __meta_kubernetes_namespace
             - __meta_kubernetes_pod_label_app_kubernetes_io_name
           targetLabel: job
-      scheme: {{ default "http" .Values.metrics.scheme }}
-      scrapeTimeout: {{ default "10s" .Values.metrics.timeout }}
+      scheme: {{ .Values.metrics.scheme | default "http" }}
+      scrapeTimeout: {{ .Values.metrics.timeout | default "10s" }}
       tlsConfig:
         insecureSkipVerify: true
   selector:
@@ -59,8 +59,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   endpoints:
-    - interval: {{ default "30s" .interval $.Values.metrics.interval }}
-      path: {{ default "/metrics" .path $.Values.metrics.path }}
+    - interval: {{ coalesce .interval $.Values.metrics.interval "30s" }}
+      path: {{ coalesce .path $.Values.metrics.path "/metrics" }}
       port: main-{{ .name }}
       {{- if .basicAuth }}
       {{- if .basicAuth.enabled }}
@@ -79,8 +79,8 @@ spec:
             - __meta_kubernetes_namespace
             - __meta_kubernetes_pod_label_app_kubernetes_io_name
           targetLabel: job
-      scheme: {{ default "http" .scheme $.Values.metrics.scheme }}
-      scrapeTimeout: {{ default "10s" .timeout $.Values.metrics.timeout }}
+      scheme: {{ coalesce .scheme $.Values.metrics.scheme "http" }}
+      scrapeTimeout: {{ coalesce .timeout $.Values.metrics.timeout "10s" }}
       tlsConfig:
         insecureSkipVerify: true
   selector:
@@ -105,7 +105,7 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   endpoints:
-    - interval: {{ default "30s" .Values.metrics.interval }}
+    - interval: {{ .Values.metrics.interval | default "30s" }}
       path: /metrics
       port: auth-proxy-metrics
       relabelings:
@@ -139,8 +139,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   endpoints:
-    - interval: {{ default "30s" .Values.filebeatSidecar.metrics.interval }}
-      path: {{ default "/metrics" .Values.filebeatSidecar.metrics.path }}
+    - interval: {{ .Values.filebeatSidecar.metrics.interval | default "30s" }}
+      path: {{ .Values.filebeatSidecar.metrics.path | default "/metrics" }}
       port: beat-exporter-metrics
       relabelings:
         - separator: /
@@ -148,8 +148,8 @@ spec:
             - __meta_kubernetes_namespace
             - __meta_kubernetes_pod_label_app_kubernetes_io_name
           targetLabel: job
-      scheme: {{ default "http" .Values.filebeatSidecar.metrics.scheme }}
-      scrapeTimeout: {{ default "10s" .Values.filebeatSidecar.metrics.timeout }}
+      scheme: {{ .Values.filebeatSidecar.metrics.scheme | default "http" }}
+      scrapeTimeout: {{ .Values.filebeatSidecar.metrics.timeout | default "10s" }}
       tlsConfig:
         insecureSkipVerify: true
   selector:

--- a/charts/standard-application-stack/templates/service.yaml
+++ b/charts/standard-application-stack/templates/service.yaml
@@ -12,7 +12,7 @@ metadata:
     {{ toYaml .Values.service.annotations | nindent 4 }}
     {{- end }}
     {{- if (and .Values.global.owner (and .Values.ingress.enabled .Values.ingress.alb.enabled)) }}
-    'alb.ingress.kubernetes.io/tags': 'Owner={{.Values.global.owner}}'
+    'alb.ingress.kubernetes.io/tags': 'Owner={{ .Values.global.owner }}'
     {{- end }}
     {{- if .Values.nlb.enabled }}
     {{ include "mintel_common.nlb.annotations" . | nindent 4 }}

--- a/charts/standard-application-stack/templates/service.yaml
+++ b/charts/standard-application-stack/templates/service.yaml
@@ -41,7 +41,7 @@ spec:
     {{- end }}
     {{- end }}
     {{- range .Values.extraPorts }}
-    - name: {{ default "main" .containerName }}-{{ .name }}
+    - name: {{ .containerName | default "main" }}-{{ .name }}
       port: {{ .containerPort }}
       targetPort: {{ .containerPort }}
     {{- end }}

--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove pointless `print` and `printf` function calls
 - Make concatenated lists sorted and unique
 
+### Fixed
+- Make spacing inside `{{ }}` consistent
+
 ## [v0.30.0] - 2022-12-13
 ### Changed
 - Bump version of S3 Terraform module to allow option to create cloudfront distribution

--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Refactor use of the `default` template function (sometimes use `coalesce`)
+
 ## [v0.30.0] - 2022-12-13
 ### Changed
 - Bump version of S3 Terraform module to allow option to create cloudfront distribution

--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Refactor use of the `default` template function (sometimes use `coalesce`)
+- Remove pointless `print` and `printf` function calls
 
 ## [v0.30.0] - 2022-12-13
 ### Changed

--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Refactor use of the `default` template function (sometimes use `coalesce`)
 - Remove pointless `print` and `printf` function calls
+- Make concatenated lists sorted and unique
 
 ## [v0.30.0] - 2022-12-13
 ### Changed

--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [v0.30.1] - 2022-12-29
 ### Changed
 - Refactor use of the `default` template function (sometimes use `coalesce`)
 - Remove pointless `print` and `printf` function calls

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.30.0
+version: 0.30.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 0.30.0](https://img.shields.io/badge/Version-0.30.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.30.1](https://img.shields.io/badge/Version-0.30.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 

--- a/charts/terraform-cloud/templates/_helpers.tpl
+++ b/charts/terraform-cloud/templates/_helpers.tpl
@@ -1,13 +1,13 @@
 {{/* Supported resources */}}
 {{- define "mintel_common.terraformCloudResources" -}}
 {{- $terraformCloudResources := (list "memcached" "opensearch" "postgresql" "redis" "s3" "mariadb" "dynamodb" "sns" "sqs" "staticWebsite" "stepFunctionEks" "activeMQ" "auroraMySql" "auroraPostgresql" "sshKeyPairSecret") -}}
-{{ join "," $terraformCloudResources }}
+{{ $terraformCloudResources | sortAlpha | uniq | compact | join "," }}
 {{- end -}}
 
 {{/* Supported resources that require IRSA */}}
 {{- define "mintel_common.terraformCloudIRSAResources" -}}
 {{- $terraformCloudIRSAResources := (list "opensearch" "s3" "dynamodb" "sns" "sqs") -}}
-{{ join "," $terraformCloudIRSAResources }}
+{{ $terraformCloudIRSAResources | sortAlpha | uniq | compact | join "," }}
 {{- end -}}
 
 {{- define "mintel_common.terraform_cloud.irsaRequired"}}

--- a/charts/terraform-cloud/templates/_helpers.tpl
+++ b/charts/terraform-cloud/templates/_helpers.tpl
@@ -18,7 +18,7 @@
     {{- $irsaRequired = "true" }}
   {{- end }}
 {{- end }}
-{{$irsaRequired}}
+{{ $irsaRequired }}
 {{- end -}}
 
 {{/*
@@ -80,12 +80,12 @@ app.mintel.com/region: {{ .Values.global.clusterRegion }}
 {{/* ternary and hasKey functions are used instead of defaults below due to https://github.com/helm/helm/issues/3308 */}}
 app.mintel.com/terraform-allow-destroy: {{ hasKey .InstanceCfg "workspaceAllowDestroy" | ternary .InstanceCfg.workspaceAllowDestroy (include "mintel_common.terraform_cloud.allow_destroy_default" .) | quote }}
 app.mintel.com/terraform-owner: {{ .InstanceCfg.workspaceOwner | default .Global.owner }}
-app.mintel.com/terraform-cloud-tags: {{ .InstanceCfg.workspaceTags | default (include "mintel_common.terraform_cloud.tags" .) | quote}}
+app.mintel.com/terraform-cloud-tags: {{ .InstanceCfg.workspaceTags | default (include "mintel_common.terraform_cloud.tags" .) | quote }}
 {{- end -}}
 
 {{/* Set variable values depending on environment */}}
 {{- define "mintel_common.terraform_cloud.defaultVarValues" -}}
-{{- $defaults := dict}}
+{{- $defaults := dict }}
 {{/* rds and rds-aurora */}}
 {{- if ( has .ResourceType (list "postgresql" "mariadb" "auroraMySql" "auroraPostgresql"))}}
     {{/* deletion_protection */}}

--- a/charts/terraform-cloud/templates/_helpers.tpl
+++ b/charts/terraform-cloud/templates/_helpers.tpl
@@ -79,8 +79,8 @@ app.mintel.com/region: {{ .Values.global.clusterRegion }}
 {{- define "mintel_common.terraform_cloud.operatorAnnotations" -}}
 {{/* ternary and hasKey functions are used instead of defaults below due to https://github.com/helm/helm/issues/3308 */}}
 app.mintel.com/terraform-allow-destroy: {{ hasKey .InstanceCfg "workspaceAllowDestroy" | ternary .InstanceCfg.workspaceAllowDestroy (include "mintel_common.terraform_cloud.allow_destroy_default" .) | quote }}
-app.mintel.com/terraform-owner: {{ default .Global.owner .InstanceCfg.workspaceOwner }}
-app.mintel.com/terraform-cloud-tags: {{ default (include "mintel_common.terraform_cloud.tags" .) .InstanceCfg.workspaceTags | quote}}
+app.mintel.com/terraform-owner: {{ .InstanceCfg.workspaceOwner | default .Global.owner }}
+app.mintel.com/terraform-cloud-tags: {{ .InstanceCfg.workspaceTags | default (include "mintel_common.terraform_cloud.tags" .) | quote}}
 {{- end -}}
 
 {{/* Set variable values depending on environment */}}

--- a/charts/terraform-cloud/templates/helpers/_workspace.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace.yaml
@@ -4,8 +4,8 @@
 {{- $resourceType := index . 3 }}
 {{- $moduleSource := index . 4 }}
 {{- $moduleVersion := index . 5 }}
-{{- $tfVersion := index . 6}}
-{{- $resourceCfg := index . 7}}
+{{- $tfVersion := index . 6 }}
+{{- $resourceCfg := index . 7 }}
 {{- $global := $.Values.global }}
 {{- $workspaceDict := dict "Global" $global "Release" $.Release "InstanceCfg" $instanceCfg "ResourceType" $resourceType }}
 {{- with index . 1 }}
@@ -27,7 +27,7 @@ metadata:
     {{- else }}
     app.mintel.com/altManifestFileSuffix: "{{ $instanceCfg.name }}-{{ $resourceType | kebabcase }}"
     argocd.argoproj.io/sync-wave: "{{ coalesce $instanceCfg.syncWave $resourceCfg.syncWave -40 }}"
-    {{- end}}
+    {{- end }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   agentPoolID: {{ $global.terraform.agentPoolID | quote }}
@@ -41,8 +41,8 @@ spec:
   terraformVersion: {{ $tfVersion | default $global.terraform.terraformVersion | quote }}
   {{- if (eq $resourceType "irsa") }}
   runTriggers:
-  {{include "mintel_common.terraform_cloud.irsaRunTriggers" .| indent 4}}
-  {{- end}}
+  {{ include "mintel_common.terraform_cloud.irsaRunTriggers" .| indent 4 }}
+  {{- end }}
   variables:
   {{- $_ := unset $instanceCfg "workspaceNameOverride" }}
   {{- $_ := unset $instanceCfg "workspaceAllowDestroy" }}
@@ -51,7 +51,7 @@ spec:
   {{- $_ := unset $instanceCfg "outputSecretMap" }}
   {{- $_ := unset $instanceCfg "syncWave" }}
   {{- range $varKey, $varVal := $instanceCfg }}
-    {{- if kindIs "map" $varVal}}
+    {{- if kindIs "map" $varVal }}
       {{- include "mintel_common.terraform_cloud.tfVar" (merge (dict "key" $varKey) $varVal) | indent 2 }}
     {{- else }}
       {{- include "mintel_common.terraform_cloud.tfVar" (dict "key" $varKey "value" $varVal) | indent 2 }}
@@ -63,13 +63,13 @@ spec:
 {{- define "mintel_common.terraform_cloud.tfVar" }}
 - key: {{ .key | quote }}
   value: {{ .value | quote }}
-  environmentVariable: {{ .environmentVariable | default false}}
+  environmentVariable: {{ .environmentVariable | default false }}
   hcl: {{ .hcl | default false }}
-  sensitive: {{ .sensitive | default false}}
+  sensitive: {{ .sensitive | default false }}
 {{- end }}
 
 {{- define "mintel_common.terraform_cloud.workspaceName"}}
-{{printf "%s-%s-%s-%s-%s-%s" .Global.clusterEnv .Global.clusterRegion .Global.clusterName .Release.Namespace (.InstanceCfg.name | kebabcase) (.ResourceType | kebabcase) }}
+{{ printf "%s-%s-%s-%s-%s-%s" .Global.clusterEnv .Global.clusterRegion .Global.clusterName .Release.Namespace (.InstanceCfg.name | kebabcase) (.ResourceType | kebabcase) }}
 {{- end -}}
 
 
@@ -87,5 +87,5 @@ spec:
 - sourceableName: {{ $instanceCfg.workspaceNameOverride | default (include "mintel_common.terraform_cloud.workspaceName" $workspaceDict) | trim | quote }}
   {{- end }}
   {{- end }}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/terraform-cloud/templates/helpers/_workspace.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace.yaml
@@ -12,7 +12,7 @@
 apiVersion: app.terraform.io/v1alpha1
 kind: Workspace
 metadata:
-  name: {{ default (include "mintel_common.terraform_cloud.workspaceName" $workspaceDict | trim | quote) $instanceCfg.workspaceNameOverride }}
+  name: {{ $instanceCfg.workspaceNameOverride | default (include "mintel_common.terraform_cloud.workspaceName" $workspaceDict) | trim | quote }}
   namespace: {{ $.Release.Namespace | quote }}
   labels:
     {{ include "mintel_common.labels" $ | nindent 4 }}
@@ -23,10 +23,10 @@ metadata:
     {{ include "mintel_common.terraform_cloud.operatorAnnotations" $workspaceDict | nindent 4 }}
     {{- if (eq $resourceType "irsa") }}
     app.mintel.com/altManifestFileSuffix: "{{ $global.name }}-{{ $resourceType | kebabcase }}"
-    argocd.argoproj.io/sync-wave: "{{ default -20 (default $resourceCfg.syncWave $instanceCfg.syncWave) }}"
+    argocd.argoproj.io/sync-wave: "{{ coalesce $instanceCfg.syncWave $resourceCfg.syncWave -20 }}"
     {{- else }}
     app.mintel.com/altManifestFileSuffix: "{{ $instanceCfg.name }}-{{ $resourceType | kebabcase }}"
-    argocd.argoproj.io/sync-wave: "{{ default -40 (default $resourceCfg.syncWave $instanceCfg.syncWave) }}"
+    argocd.argoproj.io/sync-wave: "{{ coalesce $instanceCfg.syncWave $resourceCfg.syncWave -40 }}"
     {{- end}}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
@@ -38,7 +38,7 @@ spec:
   organization: {{ $global.terraform.organization | quote }}
   secretsMountPath: {{ $global.terraform.secretsMountPath | quote }}
   sshKeyID: "mintel-ssh"
-  terraformVersion: {{ (default $global.terraform.terraformVersion $tfVersion) | quote }}
+  terraformVersion: {{ $tfVersion | default $global.terraform.terraformVersion | quote }}
   {{- if (eq $resourceType "irsa") }}
   runTriggers:
   {{include "mintel_common.terraform_cloud.irsaRunTriggers" .| indent 4}}
@@ -79,12 +79,12 @@ spec:
   {{- $resourceType := . }}
   {{- $resourceConfig := (get $.Values .) }}
   {{- if (and $resourceConfig.enabled (has $resourceType (list "opensearch" "s3" "dynamodb" "sns" "sqs")))}}
-  {{- range $instanceName, $instanceCfg := default ( dict "default" dict ) $resourceConfig.terraform.instances }}
+  {{- range $instanceName, $instanceCfg := $resourceConfig.terraform.instances | default ( dict "default" dict ) }}
       # Set instance.name via helper
       {{- $instanceDict := dict "Global" $global "InstanceCfg" $instanceCfg "InstanceName" $instanceName "ResourceType" $resourceType }}
       {{- $_ := set $instanceCfg "name" (include "mintel_common.terraform_cloud.instanceConfigName" $instanceDict | trim)}}
 {{- $workspaceDict := dict "Global" $global "Release" $.Release "InstanceCfg" $instanceCfg "ResourceType" $resourceType }}
-- sourceableName: {{ default (include "mintel_common.terraform_cloud.workspaceName" $workspaceDict | trim | quote) $instanceCfg.workspaceNameOverride }}
+- sourceableName: {{ $instanceCfg.workspaceNameOverride | default (include "mintel_common.terraform_cloud.workspaceName" $workspaceDict) | trim | quote }}
   {{- end }}
   {{- end }}
 {{- end}}

--- a/charts/terraform-cloud/templates/irsa-workspace.yaml
+++ b/charts/terraform-cloud/templates/irsa-workspace.yaml
@@ -7,7 +7,7 @@
   {{- $moduleSource := $irsa.terraform.module.source }}
   {{- $moduleVersion := $irsa.terraform.module.version }}
   {{- $tfVersion := $irsa.terraform.terraformVersion }}
-  {{- $irsaConfig := $irsa.terraform.vars}}
+  {{- $irsaConfig := $irsa.terraform.vars }}
   {{- if not (hasKey $irsaConfig "name") }}
     {{- $_ := set $irsaConfig "name" (.Values.irsa.nameOverride | default $global.name) }}
   {{- end }}

--- a/charts/terraform-cloud/templates/irsa-workspace.yaml
+++ b/charts/terraform-cloud/templates/irsa-workspace.yaml
@@ -9,7 +9,7 @@
   {{- $tfVersion := $irsa.terraform.terraformVersion }}
   {{- $irsaConfig := $irsa.terraform.vars}}
   {{- if not (hasKey $irsaConfig "name") }}
-    {{- $_ := set $irsaConfig "name" (printf "%s" (coalesce .Values.irsa.nameOverride $global.name)) }}
+    {{- $_ := set $irsaConfig "name" (.Values.irsa.nameOverride | default $global.name) }}
   {{- end }}
   {{- if not (hasKey $irsaConfig "aws_account_name") }}
     {{- $_ := set $irsaConfig "aws_account_name" $global.clusterEnv }}

--- a/charts/terraform-cloud/templates/workspace-output-secret.yaml
+++ b/charts/terraform-cloud/templates/workspace-output-secret.yaml
@@ -4,7 +4,7 @@
     {{- $resourceType := . }}
     {{- $resourceConfig := (get $.Values .) }}
     {{- if ( and $resourceConfig.enabled $resourceConfig.outputSecret) }}
-      {{- range $instanceName, $instanceConfig := default ( dict "default" dict ) $resourceConfig.terraform.instances }}
+      {{- range $instanceName, $instanceConfig := $resourceConfig.terraform.instances | default ( dict "default" dict ) }}
         # Set instance.name via helper
         {{- $instanceDict := dict "Global" $global "InstanceCfg" $instanceConfig "InstanceName" $instanceName "ResourceType" $resourceType }}
         {{- $_ := set $instanceConfig "name" (include "mintel_common.terraform_cloud.instanceConfigName" $instanceDict | trim)}}

--- a/charts/terraform-cloud/templates/workspace.yaml
+++ b/charts/terraform-cloud/templates/workspace.yaml
@@ -10,7 +10,7 @@
   {{- if $resourceConfig.enabled }}
     # Loop through the instances configured in memcached.terraform.instances (create an empty dict with a "default"
     # instance if it hasn't been specified)
-    {{- range $instanceName, $instanceConfig := default ( dict "default" dict ) $resourceConfig.terraform.instances }}
+    {{- range $instanceName, $instanceConfig := $resourceConfig.terraform.instances | default ( dict "default" dict ) }}
       {{- $moduleSource := $resourceConfig.terraform.module.source }}
       {{- $moduleVersion := $resourceConfig.terraform.module.version }}
       {{- $tfVersion := $resourceConfig.terraform.terraformVersion}}

--- a/charts/terraform-cloud/templates/workspace.yaml
+++ b/charts/terraform-cloud/templates/workspace.yaml
@@ -13,7 +13,7 @@
     {{- range $instanceName, $instanceConfig := $resourceConfig.terraform.instances | default ( dict "default" dict ) }}
       {{- $moduleSource := $resourceConfig.terraform.module.source }}
       {{- $moduleVersion := $resourceConfig.terraform.module.version }}
-      {{- $tfVersion := $resourceConfig.terraform.terraformVersion}}
+      {{- $tfVersion := $resourceConfig.terraform.terraformVersion }}
       # Set instance.name via helper
       {{- $instanceDict := dict "Global" $global "InstanceCfg" $instanceConfig "InstanceName" $instanceName "ResourceType" $resourceType }}
       {{- $_ := set $instanceConfig "name" (include "mintel_common.terraform_cloud.instanceConfigName" $instanceDict | trim)}}


### PR DESCRIPTION
JIRA: INFRA-28410

## Refactor use of `default` template function
We have some instances of:
```    
{{ default A B C }}
```
which is invalid. Replace those with:
```
{{ coalesce A B C }}
```

We also have a lot of uses of the `default` template function like:
```    
{{ default A B }}
```
which is a little non-obvious that A is the default value. Replace these with:
```    
{{ B | default A }}
```

We also have some instances of:
```
{{ coalesce A B }}
```
For consistency's sake, replace those with:
```
{{ A | default B }}
```

## Remove pointless print and printf function calls
We have a lot of print and printf calls like:
```
{{- define "common.capabilities.policy.apiVersion" -}}
{{- print "policy/v1" -}}
{{- end -}}

{{ printf "%s" .Values.foo }}
```
Replace those with
```
{{- define "common.capabilities.policy.apiVersion" -}}
policy/v1
{{- end -}}

{{ .Values.foo }}
```

## Make concatenated lists sorted and unique

We have a few places where we assemble a list, and then concatenated it:
```
{{ $aList := list }}
// Add stuff to the list
{{ join "," $aList }}
```
In most cases we want the values in that list to be unique. Also, having the list be sorted will produce more consistent diffs in the manifests. Therefore, change to:
```
{{ $aList | sortAlpha | compact | uniq | join "," }}
```
Make sure to do sortAlpha first so all the values are converted to strings. Otherwise, `5432` and `"5432"` would be considered two, separate unique values.

## Spacing around `{{ }}`

Make spacing consistent according to https://github.com/giantswarm/fmt/blob/master/helm/formatting_guidelines.md#templating