### PR TITLE
INFRA-28408: Validate extraPorts when generating deployment 

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.54.0] - 2023-01-09
+### Added
+- Added extra tests around Deployment `extraPorts`
+
+### Fixed
+- Validate usage of `extraPorts` when generating Deployment containerPort spec
+
 ## [v3.53.2] - 2022-12-29
 ### Changed
 - Refactor use of the `default` template function (sometimes use `coalesce`)

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.53.2
+version: 3.54.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.53.2](https://img.shields.io/badge/Version-3.53.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.54.0](https://img.shields.io/badge/Version-3.54.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -255,8 +255,12 @@ spec:
             - containerPort: {{ .Values.hybridCloud.proxyPort | default "20000" }}
               name: consul-proxy
             {{- end }}
-            {{- with .Values.extraPorts }}
-            {{- toYaml . | nindent 12 }}
+            {{- range .Values.extraPorts }}
+            - name: {{ .name }}
+              containerPort: {{ .containerPort }}
+              {{- if .protocol }}
+              protocol: {{ .protocol }}
+              {{- end }}
             {{- end }}
           {{- end }}
           {{- if (and .Values.liveness .Values.liveness.enabled) }}

--- a/charts/standard-application-stack/tests/deployment_ports_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_ports_test.yaml
@@ -1,0 +1,86 @@
+suite: Test Deployment Ports
+templates:
+  - deployment.yaml
+release:
+  namespace: test-namespace
+tests:
+  - it: Check default container main port
+    set:
+      global.clusterEnv: qa
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value:
+          - containerPort: 8000
+            name: http
+  - it: Check overidden container main port
+    set:
+      global.clusterEnv: qa
+      port: 9000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value:
+          - containerPort: 9000
+            name: http
+  - it: Check container extraPorts
+    set:
+      global.clusterEnv: qa
+      extraPorts:
+        - name: "extra-port-1"
+          containerPort: 8001
+        - name: "extra-port-2"
+          containerPort: 8002
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value:
+          - containerPort: 8000
+            name: http
+          - containerPort: 8001
+            name: extra-port-1
+          - containerPort: 8002
+            name: extra-port-2
+  - it: Check container extraPorts are validated
+    set:
+      global.clusterEnv: qa
+      extraPorts:
+        - name: "extra-port-1"
+          containerPort: 8001
+        - name: "extra-port-2"
+          containerPort: 8002
+        - name: "extra-port-3"
+          containerPort: 8003
+          shouldIgnoreThis: value
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value:
+          - containerPort: 8000
+            name: http
+          - containerPort: 8001
+            name: extra-port-1
+          - containerPort: 8002
+            name: extra-port-2
+          - containerPort: 8003
+            name: extra-port-3
+  - it: Check container extraPorts protocol
+    set:
+      global.clusterEnv: qa
+      extraPorts:
+        - name: "extra-port-1"
+          containerPort: 8001
+        - name: "extra-port-2"
+          containerPort: 8002
+          protocol: "UDP"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports
+          value:
+          - containerPort: 8000
+            name: http
+          - containerPort: 8001
+            name: extra-port-1
+          - containerPort: 8002
+            name: extra-port-2
+            protocol: "UDP"

--- a/charts/standard-application-stack/tests/pod_monitor_test.yaml
+++ b/charts/standard-application-stack/tests/pod_monitor_test.yaml
@@ -318,8 +318,6 @@ tests:
               name: http
             - containerPort: 9002
               name: metrics-2
-              targetPort: 9002
             - containerPort: 9003
               name: metrics-3
-              targetPort: 9003
         template: deployment.yaml

--- a/charts/standard-application-stack/tests/service_monitor_test.yaml
+++ b/charts/standard-application-stack/tests/service_monitor_test.yaml
@@ -272,10 +272,8 @@ tests:
       extraPorts:
         - name: metrics-2
           containerPort: 9002
-          targetPort: 9002
         - name: metrics-3
           containerPort: 9003
-          targetPort: 9003
     asserts:
       - isKind:
           of: Service
@@ -361,8 +359,6 @@ tests:
               name: http
             - containerPort: 9002
               name: metrics-2
-              targetPort: 9002
             - containerPort: 9003
               name: metrics-3
-              targetPort: 9003
         template: deployment.yaml

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -78,6 +78,7 @@ extraPorts: []
 # extraPorts:
 #   - name: ""
 #     containerPort: 1234
+#     protocol: "TCP"
 
 # -- Optional command to the container
 command:


### PR DESCRIPTION
Validates usage of `extraPorts` by pulling out known `containerPort` spec values and adds extra tests around this.

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#containerport-v1-core

Note, `hostIP` and `hostPort` are not supported as we shouldn't require these.