### PR TITLE
add okta auth config to ingress and opensearch awsEsProxy ingress

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.56.0] - 2023-01-24
+### Added
+- Added `ingress.alb.okta` values used for Okta ALB authentication
+- Added `opensearch.awsEsProxy.ingress` values to allow placing opensearch behind an ingress
+
 ## [v3.55.2] - 2023-01-17
 ### Fixed
 - Use `deepCopy` function when creating new dict from values

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.55.2
+version: 3.56.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.55.2](https://img.shields.io/badge/Version-3.55.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.56.0](https://img.shields.io/badge/Version-3.56.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -124,7 +124,7 @@ A generic chart to support most common application requirements
 | image.repository | string | `"test"` | Docker repository |
 | image.tag | string | `"auto-replaced"` | Container image tag |
 | imagePullSecrets | list | `[]` | Optional array of imagePullSecrets ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
-| ingress | object | `{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","deregistrationDelay":{"timeoutSeconds":5},"enabled":true,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"preStopDelay":{"delaySeconds":15,"enabled":true},"scheme":"internet-facing"},"allowFrontendAccess":false,"allowLivenessUrl":false,"allowReadinessUrl":false,"blackbox":{"enabled":true,"probePath":"/external-health-check"},"enabled":false,"extraAnnotations":{},"extraHosts":[],"extraIngresses":[],"setNoCacheHeaders":false,"setXForwardedForHeaders":false,"specificRulesHostsYaml":{},"specificTlsHostsYaml":{},"tls":true}` | Configure the ingress resource that allows you to access the application from public-internet ref: http://kubernetes.io/docs/user-guide/ingress/ |
+| ingress | object | `{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","deregistrationDelay":{"timeoutSeconds":5},"enabled":true,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"okta":{"authOnUnauthenticated":"authenticate","enabled":false,"groups":"","ingressName":"","redirectPath":"","users":""},"preStopDelay":{"delaySeconds":15,"enabled":true},"scheme":"internet-facing"},"allowFrontendAccess":false,"allowLivenessUrl":false,"allowReadinessUrl":false,"blackbox":{"enabled":true,"probePath":"/external-health-check"},"enabled":false,"extraAnnotations":{},"extraHosts":[],"extraIngresses":[],"setNoCacheHeaders":false,"setXForwardedForHeaders":false,"specificRulesHostsYaml":{},"specificTlsHostsYaml":{},"tls":true}` | Configure the ingress resource that allows you to access the application from public-internet ref: http://kubernetes.io/docs/user-guide/ingress/ |
 | ingress.alb.backendProtocol | string | `"HTTP"` | Application Version (HTTP / HTTPS) |
 | ingress.alb.backendProtocolVersion | string | `"HTTP1"` | Application Protocol Version (HTTP1 / HTTP2 / GRPC) |
 | ingress.alb.healthcheck.healthyThresholdCount | int | `2` | Success threshold |
@@ -132,6 +132,12 @@ A generic chart to support most common application requirements
 | ingress.alb.healthcheck.protocol | string | `"HTTP"` | Healthcheck protocol |
 | ingress.alb.healthcheck.timeoutSeconds | int | `5` | Timeout seconds |
 | ingress.alb.healthcheck.unhealthyThresholdCount | int | `2` | Failure threshold |
+| ingress.alb.okta | object | `{"authOnUnauthenticated":"authenticate","enabled":false,"groups":"","ingressName":"","redirectPath":"","users":""}` | Enable and configure authentication using okta aws-load-balancer-controller must be installed on the cluster for Okta integration to work |
+| ingress.alb.okta.authOnUnauthenticated | string | `"authenticate"` | Specifies the behavior if the user is not authenticated.    Possible values are 'authenticate' (defalt value, and used in most cases), 'allow', or 'deny' |
+| ingress.alb.okta.groups | string | `""` | Comma separated list of Okta Groups that have access to the Ingress URI. e.g. 'group1,group2,group3' |
+| ingress.alb.okta.ingressName | string | `""` | (required) Name of the ingress |
+| ingress.alb.okta.redirectPath | string | `""` | The path that is appended onto the Ingress URI for Oauth authentication on the Ingress URI. Defaults to '/oauth2/idpresponse/' |
+| ingress.alb.okta.users | string | `""` | Comma separated list of Okta Users that have access to the Ingress URI. e.g. 'user1,user2,user3' |
 | ingress.alb.preStopDelay.delaySeconds | int | `15` | The delay (sleep) to wait for. IMPORTANT: The terminationGracePeriodSeconds must be greater than this. |
 | ingress.alb.preStopDelay.enabled | bool | `true` | Enable an additional delay when the container is shutdown of delaySeconds. This allows ALB to fully de-register the pod (allows zero-downtime rollouts) |
 | ingress.alb.scheme | string | `"internet-facing"` | Public or private alb (internet-facing / internal) |
@@ -215,9 +221,28 @@ A generic chart to support most common application requirements
 | oauthProxy.skipAuthRegexes | list | `[]` | Optional: list of URL endpoints to bypass oauth-proxy for Health check and readiness urls are skipped automatically |
 | oauthProxy.type | string | `"portal"` | Identifies oauth-proxy as auth'ing with a mintel portal instance |
 | oauthProxy.userIdClaim | string | `""` | Optional: Claim contains the user ID |
-| opensearch | object | `{"awsEsProxy":{"enabled":false,"port":9200,"resources":{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"64Mi"}}},"enabled":false,"outputSecret":true,"secretRefreshIntervalOverride":"","secretStoreRefOverride":""}` | Configures AWS Opensearch deployment/connections |
-| opensearch.awsEsProxy | object | `{"enabled":false,"port":9200,"resources":{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"64Mi"}}}` | Configures aws-es-proxy to enable external access to opensearch |
+| opensearch | object | `{"awsEsProxy":{"enabled":false,"ingress":{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","deregistrationDelay":{"timeoutSeconds":5},"enabled":true,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"path":"/_cluster/health","protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"okta":{"authOnUnauthenticated":"authenticate","enabled":false,"groups":"","ingressName":"","redirectPath":"","users":""},"preStopDelay":{"delaySeconds":15,"enabled":true},"scheme":"internet-facing"},"enabled":false,"extraAnnotations":{},"path":"/_dashboards"},"port":9200,"resources":{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"64Mi"}}},"enabled":false,"outputSecret":true,"secretRefreshIntervalOverride":"","secretStoreRefOverride":""}` | Configures AWS Opensearch deployment/connections |
+| opensearch.awsEsProxy | object | `{"enabled":false,"ingress":{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","deregistrationDelay":{"timeoutSeconds":5},"enabled":true,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"path":"/_cluster/health","protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"okta":{"authOnUnauthenticated":"authenticate","enabled":false,"groups":"","ingressName":"","redirectPath":"","users":""},"preStopDelay":{"delaySeconds":15,"enabled":true},"scheme":"internet-facing"},"enabled":false,"extraAnnotations":{},"path":"/_dashboards"},"port":9200,"resources":{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"64Mi"}}}` | Configures aws-es-proxy to enable external access to opensearch |
 | opensearch.awsEsProxy.enabled | bool | `false` | Set to true to add an aws-es-proxy deployment in front of opensearch |
+| opensearch.awsEsProxy.ingress | object | `{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","deregistrationDelay":{"timeoutSeconds":5},"enabled":true,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"path":"/_cluster/health","protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"okta":{"authOnUnauthenticated":"authenticate","enabled":false,"groups":"","ingressName":"","redirectPath":"","users":""},"preStopDelay":{"delaySeconds":15,"enabled":true},"scheme":"internet-facing"},"enabled":false,"extraAnnotations":{},"path":"/_dashboards"}` | Ingress for aws-es-proxy |
+| opensearch.awsEsProxy.ingress.alb.backendProtocol | string | `"HTTP"` | Application Version (HTTP / HTTPS) |
+| opensearch.awsEsProxy.ingress.alb.backendProtocolVersion | string | `"HTTP1"` | Application Protocol Version (HTTP1 / HTTP2 / GRPC) |
+| opensearch.awsEsProxy.ingress.alb.healthcheck.healthyThresholdCount | int | `2` | Success threshold |
+| opensearch.awsEsProxy.ingress.alb.healthcheck.intervalSeconds | int | `15` | Period seconds |
+| opensearch.awsEsProxy.ingress.alb.healthcheck.path | string | `"/_cluster/health"` | Healthcheck Request path |
+| opensearch.awsEsProxy.ingress.alb.healthcheck.protocol | string | `"HTTP"` | Healthcheck protocol |
+| opensearch.awsEsProxy.ingress.alb.healthcheck.timeoutSeconds | int | `5` | Timeout seconds |
+| opensearch.awsEsProxy.ingress.alb.healthcheck.unhealthyThresholdCount | int | `2` | Failure threshold |
+| opensearch.awsEsProxy.ingress.alb.okta | object | `{"authOnUnauthenticated":"authenticate","enabled":false,"groups":"","ingressName":"","redirectPath":"","users":""}` | Enable and configure authentication using okta aws-load-balancer-controller must be installed on the cluster for Okta integration to work |
+| opensearch.awsEsProxy.ingress.alb.okta.authOnUnauthenticated | string | `"authenticate"` | Specifies the behavior if the user is not authenticated.    Possible values are 'authenticate' (defalt value, and used in most cases), 'allow', or 'deny' |
+| opensearch.awsEsProxy.ingress.alb.okta.groups | string | `""` | Comma separated list of Okta Groups that have access to the Ingress URI. e.g. 'group1,group2,group3' |
+| opensearch.awsEsProxy.ingress.alb.okta.ingressName | string | `""` | (required) Name of the ingress |
+| opensearch.awsEsProxy.ingress.alb.okta.redirectPath | string | `""` | The path that is appended onto the Ingress URI for Oauth authentication on the Ingress URI. Defaults to '/oauth2/idpresponse/' |
+| opensearch.awsEsProxy.ingress.alb.okta.users | string | `""` | Comma separated list of Okta Users that have access to the Ingress URI. e.g. 'user1,user2,user3' |
+| opensearch.awsEsProxy.ingress.alb.preStopDelay.delaySeconds | int | `15` | The delay (sleep) to wait for. IMPORTANT: The terminationGracePeriodSeconds must be greater than this. |
+| opensearch.awsEsProxy.ingress.alb.preStopDelay.enabled | bool | `true` | Enable an additional delay when the container is shutdown of delaySeconds. This allows ALB to fully de-register the pod (allows zero-downtime rollouts) |
+| opensearch.awsEsProxy.ingress.alb.scheme | string | `"internet-facing"` | Public or private alb (internet-facing / internal) |
+| opensearch.awsEsProxy.ingress.path | string | `"/_dashboards"` | Path for the Ingress |
 | opensearch.awsEsProxy.port | int | `9200` | Port for aws-es-proxy to listen on |
 | opensearch.awsEsProxy.resources | object | `{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Container resource requests and limits for aws-es-proxy sidecar ref: http://kubernetes.io/docs/user-guide/compute-resources |
 | opensearch.enabled | bool | `false` | Set to true if deployment makes use of AWS opensearch |

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -534,3 +534,9 @@ topologySpreadConstraints:
 {{- end }}
 {{- $tfSecretList | sortAlpha | uniq | compact | join "," -}}
 {{- end -}}
+
+{{/* Return the name of the role used by the AWS Load Balancer Controller to read Okta secrets */}}
+{{- define "mintel_common.okta.alb_controller_role_name" -}}
+{{- $name := include "mintel_common.fullname" . }}
+{{- print $name "-alb-controller-role" -}}
+{{- end -}}

--- a/charts/standard-application-stack/templates/helpers/_ingress.yaml
+++ b/charts/standard-application-stack/templates/helpers/_ingress.yaml
@@ -54,7 +54,11 @@ HTTP1
 {{- if .Values.oauthProxy.enabled }}
 {{- .Values.ingress.alb.healthcheck.port | default 4180 }}
 {{- else }}
+{{- if (and .Values.opensearch.awsEsProxy.ingress .Values.opensearch.awsEsProxy.ingress.enabled) }}
+{{- .Values.opensearch.awsEsProxy.ingress.alb.healthcheck.port | default .Values.opensearch.awsEsProxy.port }}
+{{- else }}
 {{- .Values.ingress.alb.healthcheck.port | default .Values.port }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/standard-application-stack/templates/ingress-aws-es-proxy.yaml
+++ b/charts/standard-application-stack/templates/ingress-aws-es-proxy.yaml
@@ -1,0 +1,39 @@
+{{- if (and .Values.opensearch .Values.opensearch.enabled) }}
+{{- if (and .Values.opensearch.awsEsProxy .Values.opensearch.awsEsProxy.enabled) }}
+{{- if (and .Values.opensearch.awsEsProxy.ingress .Values.opensearch.awsEsProxy.ingress.enabled) }}
+{{- $data := dict "Release" .Release "Chart" .Chart "Values" .Values "component" "aws-es-proxy" }}
+{{- $ingressData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "ingress" .Values.opensearch.awsEsProxy.ingress }}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" $ }}
+kind: Ingress
+metadata:
+  name: {{ include "mintel_common.fullname" $data }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{ include "mintel_common.labels" $data | nindent 4 }}
+  annotations:
+    {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
+    # alb annotations
+    {{- if (and $.Values.opensearch.awsEsProxy.ingress.alb $.Values.opensearch.awsEsProxy.ingress.alb.enabled) }}
+    {{- $albData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "alb" $.Values.opensearch.awsEsProxy.ingress.alb "defaultHost" $.Values.opensearch.awsEsProxy.ingress.defaultHost }}
+    {{- include "mintel_common.ingress.alb_annotations" $albData | nindent 4 }}
+    {{- end }}
+    # extra annotations
+    {{- if .Values.opensearch.awsEsProxy.ingress.extraAnnotations }}
+    {{- toYaml .Values.opensearch.awsEsProxy.ingress.extraAnnotations | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ include "mintel_common.ingress.className" $ingressData }}
+  rules:
+  - host: {{ .Values.opensearch.awsEsProxy.ingress.defaultHost }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ include "mintel_common.fullname" $data }}
+            port:
+              number: {{ .Values.opensearch.awsEsProxy.port }}
+        path: {{ .Values.opensearch.awsEsProxy.ingress.path }}
+        pathType: Prefix
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/standard-application-stack/templates/network-policy-aws-es-proxy.yaml
+++ b/charts/standard-application-stack/templates/network-policy-aws-es-proxy.yaml
@@ -1,0 +1,62 @@
+{{- if (and .Values.opensearch .Values.opensearch.enabled) }}
+{{- if (and .Values.opensearch.awsEsProxy .Values.opensearch.awsEsProxy.enabled) }}
+{{- if (and .Values.opensearch.awsEsProxy.ingress .Values.opensearch.awsEsProxy.ingress.enabled) }}
+{{- if (and .Values.opensearch.awsEsProxy.ingress.alb .Values.opensearch.awsEsProxy.ingress.alb.enabled) }}
+# We generate this network policy if routing through the public or
+# internal ALB to allow Ingress traffic and healthchecks
+#
+# Healthchecks can be on a different port to the main application port, so
+# we allow this to be specified as well.
+kind: NetworkPolicy
+apiVersion: {{ include "common.capabilities.networkpolicy.apiVersion" . }}
+metadata:
+  {{- if eq .Values.ingress.alb.scheme "internet-facing" }}
+  name: {{ printf "allow-aws-alb-to-%s-opensearch" .Values.global.name }}
+  {{- else }}
+  # Assume internal facing
+  name: {{ printf "allow-aws-alb-internal-to-%s-opensearch" .Values.global.name }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "mintel_common.labels" . | nindent 4 }}
+  annotations: {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: {{ .Values.global.partOf }}
+  ingress:
+    - from:
+      {{- if eq .Values.ingress.alb.scheme "internet-facing" }}
+      - ipBlock:
+          cidr: "${AWS_PUBLIC_SUBNET_CIDR_BLOCKS_0}"
+      - ipBlock:
+          cidr: "${AWS_PUBLIC_SUBNET_CIDR_BLOCKS_1}"
+      - ipBlock:
+          cidr: "${AWS_PUBLIC_SUBNET_CIDR_BLOCKS_2}"
+      {{- else }}
+      # Assume internal facing
+      - ipBlock:
+          cidr: "${AWS_PRIVATE_APP_SUBNET_CIDR_BLOCKS_0}"
+      - ipBlock:
+          cidr: "${AWS_PRIVATE_APP_SUBNET_CIDR_BLOCKS_1}"
+      - ipBlock:
+          cidr: "${AWS_PRIVATE_APP_SUBNET_CIDR_BLOCKS_2}"
+      {{- end }}
+      ports:
+      {{ $ports := list }}
+      {{- if .Values.oauthProxy.enabled }}
+      {{ $ports = append $ports 4180 }}
+      {{- else }}
+      {{ $ports = append $ports .Values.opensearch.awsEsProxy.port }}
+      {{- end }}
+      {{ if .Values.opensearch.awsEsProxy.ingress.alb.healthcheck.port }}
+      {{ $ports = append $ports .Values.ingress.alb.healthcheck.port }}
+      {{- end }}
+      {{ $ports := $ports | sortAlpha | uniq | compact }}
+      {{- range $ports }}
+        - port: {{ . }}
+          protocol: TCP
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/standard-application-stack/templates/role-aws-load-balancer-controller-okta.yaml
+++ b/charts/standard-application-stack/templates/role-aws-load-balancer-controller-okta.yaml
@@ -1,0 +1,19 @@
+{{- if (or (and .Values.ingress.alb.okta .Values.ingress.alb.okta.enabled) (and .Values.opensearch.awsEsProxy.ingress.alb.okta .Values.opensearch.awsEsProxy.ingress.alb.okta.enabled)) }}
+{{- $roleData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "component" .name }}
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" $ }}
+kind: Role
+metadata:
+  name: {{ include "mintel_common.okta.alb_controller_role_name" $roleData }}
+  namespace: {{ $.Release.Namespace }}
+  annotations: {{ include "mintel_common.commonAnnotations" $roleData | nindent 4 }}
+  labels: {{ include "mintel_common.labels" $roleData | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}

--- a/charts/standard-application-stack/templates/role-binding-aws-load-balancer-controller-okta.yaml
+++ b/charts/standard-application-stack/templates/role-binding-aws-load-balancer-controller-okta.yaml
@@ -1,0 +1,18 @@
+{{- if (or (and .Values.ingress.alb.okta .Values.ingress.alb.okta.enabled) (and .Values.opensearch.awsEsProxy.ingress.alb.okta .Values.opensearch.awsEsProxy.ingress.alb.okta.enabled)) }}
+{{- $roleData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "component" .name }}
+apiVersion: {{ include "common.capabilities.rbac.apiVersion" $ }}
+kind: RoleBinding
+metadata:
+  name: {{ include "mintel_common.okta.alb_controller_role_name" $roleData }}
+  namespace: {{ $.Release.Namespace }}
+  labels: {{ include "mintel_common.labels" $roleData | nindent 4 }}
+  annotations: {{ include "mintel_common.commonAnnotations" $roleData | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "mintel_common.okta.alb_controller_role_name" $roleData }}
+subjects:
+  - kind: ServiceAccount
+    name: aws-load-balancer-controller
+    namespace: ingress-controller
+{{- end }}

--- a/charts/standard-application-stack/templates/service-aws-es-proxy.yaml
+++ b/charts/standard-application-stack/templates/service-aws-es-proxy.yaml
@@ -6,7 +6,11 @@ kind: Service
 metadata:
   name: {{ include "mintel_common.fullname" $data }}
   namespace: {{ .Release.Namespace }}
-  annotations: {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
+  annotations:
+    {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
+    {{- if (and .Values.global.owner (and .Values.opensearch.awsEsProxy.ingress.enabled .Values.opensearch.awsEsProxy.ingress.alb.enabled)) }}
+    'alb.ingress.kubernetes.io/tags': 'Owner={{ .Values.global.owner }}'
+    {{- end }}
   labels: {{ include "mintel_common.labels" $data | nindent 4 }}
 spec:
   ports:

--- a/charts/standard-application-stack/tests/opensearch_aws_es_proxy_test.yaml
+++ b/charts/standard-application-stack/tests/opensearch_aws_es_proxy_test.yaml
@@ -1,0 +1,139 @@
+suite: Test OpenSearch AWS ElasticSearch Proxy configuration
+templates:
+  - deployment-aws-es-proxy.yaml
+  - ingress-aws-es-proxy.yaml
+  - network-policy-aws-es-proxy.yaml
+  - role-aws-load-balancer-controller-okta.yaml
+  - role-binding-aws-load-balancer-controller-okta.yaml
+  - service-aws-es-proxy.yaml
+release:
+  namespace: test-namespace
+tests:
+  - it: Check awsEsProxy deployment is created if enabled
+    template: deployment-aws-es-proxy.yaml
+    set:
+      opensearch.enabled: true
+      opensearch.awsEsProxy.enabled: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: example-app-aws-es-proxy
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: index.docker.io/mintel/aws-es-proxy:.*
+
+  - it: Check awsEsProxy service is created if enabled
+    template: service-aws-es-proxy.yaml
+    set:
+      opensearch.enabled: true
+      opensearch.awsEsProxy.enabled: true
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: example-app-aws-es-proxy
+      - equal:
+          path: spec.selector.[app.kubernetes.io/name]
+          value: example-app-aws-es-proxy
+
+  - it: Check awsEsProxy Ingress is created if enabled
+    template: ingress-aws-es-proxy.yaml
+    set:
+      opensearch.enabled: true
+      opensearch.awsEsProxy.enabled: true
+      opensearch.awsEsProxy.ingress.enabled: true
+    asserts:
+      - isKind:
+          of: Ingress
+      - equal:
+          path: metadata.name
+          value: example-app-aws-es-proxy
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /_dashboards
+
+  - it: Check awsEsProxy NetworkPolicy is created if enabled
+    template: network-policy-aws-es-proxy.yaml
+    set:
+      opensearch.enabled: true
+      opensearch.awsEsProxy.enabled: true
+      opensearch.awsEsProxy.ingress.enabled: true
+    asserts:
+      - isKind:
+          of: NetworkPolicy
+      - equal:
+          path: metadata.name
+          value: allow-aws-alb-to-example-app-opensearch
+      - equal:
+          path: spec.ingress[0].from
+          value:
+            - ipBlock:
+                cidr: ${AWS_PUBLIC_SUBNET_CIDR_BLOCKS_0}
+            - ipBlock:
+                cidr: ${AWS_PUBLIC_SUBNET_CIDR_BLOCKS_1}
+            - ipBlock:
+                cidr: ${AWS_PUBLIC_SUBNET_CIDR_BLOCKS_2}
+
+  - it: Check awsEsProxy aws-load-balancer-controller okta role is created if enabled
+    template: role-aws-load-balancer-controller-okta.yaml
+    set:
+      global.clusterEnv: qa
+      opensearch.enabled: true
+      opensearch.awsEsProxy.enabled: true
+      opensearch.awsEsProxy.ingress.enabled: true
+      opensearch.awsEsProxy.ingress.alb.enabled: true
+      opensearch.awsEsProxy.ingress.alb.okta.enabled: true
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: example-app-alb-controller-role
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+              - ""
+              resources:
+              - secrets
+              verbs:
+              - get
+              - list
+              - watch
+
+  - it: Check awsEsProxy aws-load-balancer-controller okta role is created if enabled
+    template: role-binding-aws-load-balancer-controller-okta.yaml
+    set:
+      global.clusterEnv: qa
+      opensearch.enabled: true
+      opensearch.awsEsProxy.enabled: true
+      opensearch.awsEsProxy.ingress.enabled: true
+      opensearch.awsEsProxy.ingress.alb.enabled: true
+      opensearch.awsEsProxy.ingress.alb.okta.enabled: true
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.name
+          value: example-app-alb-controller-role
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: example-app-alb-controller-role
+      - equal:
+          path: subjects
+          value:
+            - kind: ServiceAccount
+              name: aws-load-balancer-controller
+              namespace: ingress-controller

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -482,6 +482,22 @@ ingress:
     # -- Application Protocol Version (HTTP1 / HTTP2 / GRPC)
     backendProtocolVersion: HTTP1
 
+    # -- Enable and configure authentication using okta
+    # aws-load-balancer-controller must be installed on the cluster for Okta integration to work
+    okta:
+      enabled: false
+      # -- (required) Name of the ingress
+      ingressName: ''
+      # -- Comma separated list of Okta Users that have access to the Ingress URI. e.g. 'user1,user2,user3'
+      users: ''
+      # -- Comma separated list of Okta Groups that have access to the Ingress URI. e.g. 'group1,group2,group3'
+      groups: ''
+      # -- The path that is appended onto the Ingress URI for Oauth authentication on the Ingress URI. Defaults to '/oauth2/idpresponse/'
+      redirectPath: ''
+      # -- Specifies the behavior if the user is not authenticated.
+      #    Possible values are 'authenticate' (defalt value, and used in most cases), 'allow', or 'deny'
+      authOnUnauthenticated: 'authenticate'
+
     deregistrationDelay:
       timeoutSeconds: 5
 
@@ -1076,6 +1092,65 @@ opensearch:
         memory: 64Mi
     # -- Port for aws-es-proxy to listen on
     port: 9200
+    # -- Ingress for aws-es-proxy
+    ingress:
+      enabled: false
+      # -- Path for the Ingress
+      path: /_dashboards
+      extraAnnotations: {}
+      alb:
+        enabled: true
+        # -- Public or private alb (internet-facing / internal)
+        scheme: internet-facing
+        # -- Application Version (HTTP / HTTPS)
+        backendProtocol: HTTP
+        # -- Application Protocol Version (HTTP1 / HTTP2 / GRPC)
+        backendProtocolVersion: HTTP1
+
+        # -- Enable and configure authentication using okta
+        # aws-load-balancer-controller must be installed on the cluster for Okta integration to work
+        okta:
+          enabled: false
+          # -- (required) Name of the ingress
+          ingressName: ''
+          # -- Comma separated list of Okta Users that have access to the Ingress URI. e.g. 'user1,user2,user3'
+          users: ''
+          # -- Comma separated list of Okta Groups that have access to the Ingress URI. e.g. 'group1,group2,group3'
+          groups: ''
+          # -- The path that is appended onto the Ingress URI for Oauth authentication on the Ingress URI. Defaults to '/oauth2/idpresponse/'
+          redirectPath: ''
+          # -- Specifies the behavior if the user is not authenticated.
+          #    Possible values are 'authenticate' (defalt value, and used in most cases), 'allow', or 'deny'
+          authOnUnauthenticated: 'authenticate'
+
+        deregistrationDelay:
+          timeoutSeconds: 5
+
+        preStopDelay:
+          # -- Enable an additional delay when the container is shutdown of delaySeconds.
+          # This allows ALB to fully de-register the pod (allows zero-downtime rollouts)
+          enabled: true
+          # -- The delay (sleep) to wait for.
+          # IMPORTANT: The terminationGracePeriodSeconds must be greater than this.
+          delaySeconds: 15
+
+        healthcheck:
+          # -- Healthcheck protocol
+          protocol: HTTP
+          # -- Healthcheck success codes
+          # successCodes: "200"
+          # -- Period seconds
+          intervalSeconds: 15
+          # -- Healthcheck Request path
+          path: /_cluster/health
+          # -- Port (defaults to port specified in Ingress used to direct traffic to service)
+          # port: "9200"
+          # -- Timeout seconds
+          timeoutSeconds: 5
+          # -- Failure threshold
+          unhealthyThresholdCount: 2
+          # -- Success threshold
+          healthyThresholdCount: 2
   # -- Optional: ExternalSecret refreshInterval override
   secretRefreshIntervalOverride: ""
   # -- Optional: override the SecretStoreRef of the ExternalSecret


### PR DESCRIPTION
## [v3.56.0] - 2023-01-24
### Added
- Added `ingress.alb.okta` values used for Okta ALB authentication
- Added `opensearch.awsEsProxy.ingress` values to allow placing opensearch behind an ingress