### PR TITLE
Allow using host network on main deployment

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.58.0] - 2023-01-25
+### Added
+- Ability to use host network for the main deployment
+
 ## [v3.57.0] - 2023-01-25
 ### Changed
 - Bump version of mysqlclient docker image

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.57.0
+version: 3.58.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.57.0](https://img.shields.io/badge/Version-3.57.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.58.0](https://img.shields.io/badge/Version-3.58.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -311,6 +311,7 @@ A generic chart to support most common application requirements
 | topologySpreadConstraints.specificYaml | string | `nil` | Specify custom topologySpreadConstraints yaml |
 | topologySpreadConstraints.zone.enabled | bool | `true` |  |
 | topologySpreadConstraints.zone.maxSkew | int | `1` |  |
+| useHostNetwork | bool | `false` | If true, use the host network for the main deployment. |
 | verticalPodAutoscaler | object | `{"enabled":true}` | Configuration for creating a VerticalPodAutoscaler for this app. Currently only supports recommendations-only mode. |
 | verticalPodAutoscaler.enabled | bool | `true` | Set to true to create a VerticalPodAutoscaler. |
 | volumeMounts | list | `[]` | A list of volume mounts to be added to the pod |

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -161,6 +161,9 @@ spec:
       initContainers:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.useHostNetwork }}
+      hostNetwork: true
+      {{- end }}
       containers:
         - name: main
           image: {{ include "mintel_common.image" . }}

--- a/charts/standard-application-stack/tests/deployment_host_network_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_host_network_test.yaml
@@ -1,0 +1,22 @@
+suite: Test Deployment with Host Networking
+templates:
+  - deployment.yaml
+release:
+  namespace: test-namespace
+tests:
+  - it: Has a pod template that uses the host network
+    set:
+      global.clusterEnv: qa
+      global.name: test-app
+      useHostNetwork: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: true

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -527,6 +527,9 @@ ingress:
       # -- Success threshold
       healthyThresholdCount: 2
 
+# -- If true, use the host network for the main deployment.
+useHostNetwork: false
+
 # -- Define a default NetworkPolicy for allowing apps in the same 'app.kubernetes.io/part-of' group to communicate
 # with eachother.
 # ref: https://kubernetes.io/docs/concepts/services-networking/network-policies/


### PR DESCRIPTION
A limitation with the AWS VPC CNI is that we have to put a webhook pod on the host's network to allow the EKS control plane to communicate with it.

This commit allows the pods of the main deployment to run on the host network so we can deploy webhooks with the standard-application-stack chart.