### PR TITLE
Add opentelemetry-operator Instrumentation custom resource

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.60.0] - 2023-02-07
+### Added
+- Add opentelemetry-operator Instrumentation custom resource
+
 ## [v3.59.1] - 2023-02-06
 ### Added
 - Add snapshot tests

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.59.1
+version: 3.60.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.59.1](https://img.shields.io/badge/Version-3.59.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.60.0](https://img.shields.io/badge/Version-3.60.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -99,10 +99,11 @@ A generic chart to support most common application requirements
 | filebeatSidecar.resources.requests.memory | string | `"100Mi"` |  |
 | gitSyncSidecar | object | `{"branch":"main","enabled":false,"resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"50m","memory":"50Mi"}},"root":"/data/git-sync"}` | Helper to sync a local directory with Git ref: https://github.com/kubernetes/git-sync |
 | gitSyncSidecar.branch | string | `"main"` | The git branch to check out |
-| global | object | `{"additionalLabels":{},"cloudProvider":{"accountId":""},"clusterDomain":"127.0.0.1.nip.io","clusterEnv":"local","clusterName":"","ingressTLSSecrets":{},"name":"example-app","owner":"","partOf":"","runtimeEnvironment":"kubernetes","terraform":{"externalSecrets":false,"irsa":false}}` | Global variables for us in all charts and sub charts |
+| global | object | `{"additionalLabels":{},"cloudProvider":{"accountId":"","region":""},"clusterDomain":"127.0.0.1.nip.io","clusterEnv":"local","clusterName":"","ingressTLSSecrets":{},"name":"example-app","owner":"","partOf":"","runtimeEnvironment":"kubernetes","terraform":{"externalSecrets":false,"irsa":false}}` | Global variables for us in all charts and sub charts |
 | global.additionalLabels | object | `{}` | Additional labels to apply to all resources |
-| global.cloudProvider | object | `{"accountId":""}` | Global variables relating to cloud provider |
-| global.cloudProvider.accountId | string | `""` | AWS ACcount Id |
+| global.cloudProvider | object | `{"accountId":"","region":""}` | Global variables relating to cloud provider |
+| global.cloudProvider.accountId | string | `""` | AWS Account Id |
+| global.cloudProvider.region | string | `""` | AWS region name |
 | global.clusterDomain | string | `"127.0.0.1.nip.io"` | Kubernetes cluster domain |
 | global.clusterEnv | string | `"local"` | Environment (local, dev, qa, prod) |
 | global.clusterName | string | `""` | Kubernetes cluster name |
@@ -251,6 +252,40 @@ A generic chart to support most common application requirements
 | opensearch.outputSecret | bool | `true` | set outputSecret to true to allow TF Cloud chart create ExternalSecrets |
 | opensearch.secretRefreshIntervalOverride | string | `""` | Optional: ExternalSecret refreshInterval override |
 | opensearch.secretStoreRefOverride | string | `""` | Optional: override the SecretStoreRef of the ExternalSecret |
+| otelInstrumentation | object | `{"annotations":{},"containerNames":[],"enabled":true,"env":[],"exporter":{"endpoint":"http://grafana-agent.monitoring.svc.cluster.local:4317"},"injectDotNet":{"enabled":false,"env":[],"image":null},"injectEnvVars":{"enabled":true},"injectJava":{"enabled":false,"env":[],"image":null},"injectNodeJS":{"enabled":false,"env":[],"image":null},"injectPython":{"enabled":false,"env":[{"name":"OTEL_EXPORTER_OTLP_ENDPOINT","value":"http://grafana-agent.monitoring.svc.cluster.local:4318"},{"name":"OTEL_PYTHON_EXCLUDED_URLS","value":"/health[zy]?,/ready[z]?,/readiness,/external-health-check,/metrics"}],"image":null},"labels":{},"propagators":["tracecontext","baggage","b3","jaeger","xray"],"resource":{"addK8sUIDAttributes":false,"resourceAttributes":{}},"sampler":{"argument":"","type":"parentbased_always_on"},"syncWave":-20}` | Enabled opentelemetry-operator Instrumentation ref: https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection |
+| otelInstrumentation.annotations | object | `{}` | Extra annotations to add to the Instrumentation resource. |
+| otelInstrumentation.containerNames | list | `[]` | If the pod has multiple containers, only inject instrumentation to containers with these names. |
+| otelInstrumentation.enabled | bool | `true` | If true, create opentelemetry-operator Instrumentation custom resource and add annotations to pods such that the OpenTelemetry config environment variables are automatically injected into pods. You can also optionally inject auto-instrumentation libraries for some languages. ref: https://github.com/open-telemetry/opentelemetry-operator/blob/v0.68.0/docs/api.md#instrumentation |
+| otelInstrumentation.env | list | `[]` | Common environment variables to inject regardless of language. The `valueFrom` field is supported.  Only var names beginning with "OTEL_" or "SPLUNK_" are allowed. ref: https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/ |
+| otelInstrumentation.exporter | object | `{"endpoint":"http://grafana-agent.monitoring.svc.cluster.local:4317"}` | Configure where the OpenTelemetry client exporters traces/spans. |
+| otelInstrumentation.exporter.endpoint | string | `"http://grafana-agent.monitoring.svc.cluster.local:4317"` | The endpoint to send traces/spans to. |
+| otelInstrumentation.injectDotNet | object | `{"enabled":false,"env":[],"image":null}` | Inject .NET auto-instrumentation. |
+| otelInstrumentation.injectDotNet.enabled | bool | `false` | Enable/disable injecting auto-instrumentation. Implies also injecting the OpenTelemetry config environment variables. |
+| otelInstrumentation.injectDotNet.env | list | `[]` | Additional environment variables to inject into the pod container(s). The `valueFrom` field is supported.  Only var names beginning with "OTEL_" or "SPLUNK_" are allowed. ref: https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/ |
+| otelInstrumentation.injectDotNet.image | string | `nil` | Use a custom auto-instrumentation image. |
+| otelInstrumentation.injectEnvVars | object | `{"enabled":true}` | Set an annotation on the pods to have opentelemetry-operator inject environment variables to configure OpenTelemetry client libraries. |
+| otelInstrumentation.injectEnvVars.enabled | bool | `true` | If true add the annotation to pods. |
+| otelInstrumentation.injectJava | object | `{"enabled":false,"env":[],"image":null}` | Inject Java auto-instrumentation. |
+| otelInstrumentation.injectJava.enabled | bool | `false` | Enable/disable injecting auto-instrumentation. Implies also injecting the OpenTelemetry config environment variables. |
+| otelInstrumentation.injectJava.env | list | `[]` | Additional environment variables to inject into the pod container(s). The `valueFrom` field is supported.  Only var names beginning with "OTEL_" or "SPLUNK_" are allowed. ref: https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/ |
+| otelInstrumentation.injectJava.image | string | `nil` | Use a custom auto-instrumentation image. |
+| otelInstrumentation.injectNodeJS | object | `{"enabled":false,"env":[],"image":null}` | Inject NodeJS auto-instrumentation. |
+| otelInstrumentation.injectNodeJS.enabled | bool | `false` | Enable/disable injecting auto-instrumentation. Implies also injecting the OpenTelemetry config environment variables. |
+| otelInstrumentation.injectNodeJS.env | list | `[]` | Additional environment variables to inject into the pod container(s). The `valueFrom` field is supported.  Only var names beginning with "OTEL_" or "SPLUNK_" are allowed. ref: https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/ |
+| otelInstrumentation.injectNodeJS.image | string | `nil` | Use a custom auto-instrumentation image. |
+| otelInstrumentation.injectPython | object | `{"enabled":false,"env":[{"name":"OTEL_EXPORTER_OTLP_ENDPOINT","value":"http://grafana-agent.monitoring.svc.cluster.local:4318"},{"name":"OTEL_PYTHON_EXCLUDED_URLS","value":"/health[zy]?,/ready[z]?,/readiness,/external-health-check,/metrics"}],"image":null}` | Inject Python auto-instrumentation. |
+| otelInstrumentation.injectPython.enabled | bool | `false` | Enable/disable injecting auto-instrumentation. Implies also injecting the OpenTelemetry config environment variables. |
+| otelInstrumentation.injectPython.env | list | `[{"name":"OTEL_EXPORTER_OTLP_ENDPOINT","value":"http://grafana-agent.monitoring.svc.cluster.local:4318"},{"name":"OTEL_PYTHON_EXCLUDED_URLS","value":"/health[zy]?,/ready[z]?,/readiness,/external-health-check,/metrics"}]` | Additional environment variables to inject into the pod container(s). The `valueFrom` field is supported.  Only var names beginning with "OTEL_" or "SPLUNK_" are allowed. ref: https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/ |
+| otelInstrumentation.injectPython.image | string | `nil` | Use a custom auto-instrumentation image. |
+| otelInstrumentation.labels | object | `{}` | Extra labels to add to the Instrumentation resource. |
+| otelInstrumentation.propagators | list | `["tracecontext","baggage","b3","jaeger","xray"]` | Enable OpenTelemetry propagators. Default to enabling all of the official list of propagators + AWS XRay. ref: https://opentelemetry.io/docs/reference/specification/context/api-propagators/ |
+| otelInstrumentation.resource | object | `{"addK8sUIDAttributes":false,"resourceAttributes":{}}` | Resource defines the configuration for the resource attributes, as defined by the OpenTelemetry specification. ref: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/overview.md#resources |
+| otelInstrumentation.resource.addK8sUIDAttributes | bool | `false` | If true, add deployment and pod UID attributes e.g. `k8s.deployment.uid`. |
+| otelInstrumentation.resource.resourceAttributes | object | `{}` | Key/value attributes that will be added to the trace spans exported by OpenTelemetry. The following attributes are added automatically, either by the opentelemetry-operator or by values from this chart: - `cloud.account.id` - `cloud.platform` - `cloud.provider` - `cloud.region` - `deployment.environment` - `k8s.cluster.name` - `k8s.container.name` - `k8s.deployment.name` - `k8s.namespace.name` - `k8s.node.name` - `k8s.pod.name` - `k8s.replicaset.name` - `service.name` - `service.namespace` ref: https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/ |
+| otelInstrumentation.sampler | object | `{"argument":"","type":"parentbased_always_on"}` | Set client side trace sampling. |
+| otelInstrumentation.sampler.argument | string | `""` | Optional argument to pass to the sampler. For example, for the `traceidratio` sampler you would use this to pass the ratio of traces to sample. |
+| otelInstrumentation.sampler.type | string | `"parentbased_always_on"` | The type of sampling to use. Valid values: - `always_on` - Sampler that always samples spans, regardless of the parent span’s sampling decision. - `always_off` - Sampler that never samples spans, regardless of the parent span’s sampling decision. - `traceidratio` - Sampler that samples probabilistically based on rate. - `parentbased_always_on` - (default) Sampler that respects its parent span’s sampling decision, but otherwise always samples. - `parentbased_always_off` - Sampler that respects its parent span’s sampling decision, but otherwise never samples. - `parentbased_traceidratio` - Sampler that respects its parent span’s sampling decision, but otherwise samples probabilistically based on rate. ref: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampling ref: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#built-in-samplers |
+| otelInstrumentation.syncWave | int | `-20` | The ArgoCD sync-wave to use for the Instrumentation CR. This needs to be lower than the sync-wave of any deployments/statefulsets that use it. ref: https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/ |
 | persistentVolumes | string | `nil` | A list of persistent volume claims to be added to the pod |
 | podAnnotations | object | `{}` | Additional annotations to apply to the pod |
 | podDisruptionBudget | object | `{"enabled":true,"minAvailable":"50%"}` | Pod Disruption Budget ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/ |

--- a/charts/standard-application-stack/templates/_capabilities.tpl
+++ b/charts/standard-application-stack/templates/_capabilities.tpl
@@ -120,3 +120,8 @@ This check is introduced as a regexMatch instead of {{ if .Capabilities.HelmVers
 {{- define "common.capabilities.verticalPodAutoscaler.apiVersion" -}}
 autoscaling.k8s.io/v1
 {{- end -}}
+
+{{/* Return the appropriate apiVersion for the opentelemetry-operator Instrumentation resource. */}}
+{{- define "common.capabilities.otelInstrumentation.apiVersion" -}}
+opentelemetry.io/v1alpha1
+{{- end -}}

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -87,14 +87,39 @@ spec:
   {{- end }}
   template:
     metadata:
-      {{- if (and .Values.hybridCloud .Values.hybridCloud.enabled) }}
       annotations:
-        'consul.hashicorp.com/connect-inject': 'true'
-        {{- if .Values.hybridCloud.upstreamServices }}
-        'consul.hashicorp.com/connect-service-upstreams': {{ .Values.hybridCloud.upstreamServices | sortAlpha | uniq | compact | join "," }}
+        {{- if (and .Values.hybridCloud .Values.hybridCloud.enabled) }}
+        consul.hashicorp.com/connect-inject: "true"
+          {{- with .Values.hybridCloud.upstreamServices }}
+        consul.hashicorp.com/connect-service-upstreams: {{ . | sortAlpha | uniq | compact | join "," | quote }}
+          {{- end }}
         {{- end }}
-      {{- end }}
-      labels: {{ include "mintel_common.labels" . | nindent 8 }}
+
+        {{- if .Values.otelInstrumentation.enabled }}
+          {{- with .Values.otelInstrumentation }}
+            {{- $instrumentationRef := printf "%s/%s" $.Release.Namespace (include "mintel_common.fullname" $) }}
+            {{- if .injectPython.enabled }}
+        instrumentation.opentelemetry.io/inject-python: {{ $instrumentationRef | quote }}
+            {{- end }}
+            {{- if .injectJava.enabled }}
+        instrumentation.opentelemetry.io/inject-java: {{ $instrumentationRef | quote }}
+            {{- end }}
+            {{- if .injectNodeJS.enabled }}
+        instrumentation.opentelemetry.io/inject-nodejs: {{ $instrumentationRef | quote }}
+            {{- end }}
+            {{- if .injectDotNet.enabled }}
+        instrumentation.opentelemetry.io/inject-dotnet: {{ $instrumentationRef | quote }}
+            {{- end }}
+            {{- if .injectEnvVars.enabled | and (not (or .injectPython.enabled .injectJava.enabled .injectNodeJS.enabled .injectDotNet.enabled)) }}
+        instrumentation.opentelemetry.io/inject-sdk: {{ $instrumentationRef | quote }}
+            {{- end }}
+            {{- with .containerNames }}
+        instrumentation.opentelemetry.io/container-names: {{ . | sortAlpha | uniq | compact | join "," | quote }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      labels:
+        {{- include "mintel_common.labels" . | nindent 8 }}
         {{- if (or (and .Values.ingress .Values.ingress.enabled) .Values.ingress.allowFrontendAccess) }}
         tier: frontend
         {{- end }}

--- a/charts/standard-application-stack/templates/instrumentation.yaml
+++ b/charts/standard-application-stack/templates/instrumentation.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.otelInstrumentation.enabled -}}
+{{- with dict "Release" $.Release "Chart" $.Chart "Values" $.Values "instrumentation" | merge .Values.otelInstrumentation }}
+apiVersion: {{ include "common.capabilities.otelInstrumentation.apiVersion" $ }}
+kind: Instrumentation
+metadata:
+  name: {{ include "mintel_common.fullname" . }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "mintel_common.labels" . | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- include "mintel_common.commonAnnotations" . | nindent 4 }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    argocd.argoproj.io/sync-options: 'SkipDryRunOnMissingResource=true'
+    argocd.argoproj.io/sync-wave: {{ .syncWave | quote }}
+spec:
+  exporter:
+    endpoint: {{ .exporter.endpoint | quote }}
+  {{- with .env }}
+  env:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- with .propagators }}
+  propagators:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+
+  {{- if .sampler.type }}
+  sampler:
+    type: {{ .sampler.type | quote }}
+    {{- if .sampler.argument }}
+    argument: {{ .sampler.argument | quote }}
+    {{- end }}
+  {{- end }}
+
+  resource:
+    resourceAttributes:
+      {{- with $.Values.global.cloudProvider.accountId }}
+      cloud.account.id: {{ . | quote }}
+      {{- end }}
+      cloud.platform: aws_eks
+      cloud.provider: aws
+      {{- with $.Values.global.cloudProvider.region }}
+      cloud.region: {{ . | quote }}
+      {{- end }}
+      {{- with $.Values.global.clusterEnv }}
+      deployment.environment: {{ . | quote }}
+      {{- end }}
+      {{- with $.Values.global.clusterName }}
+      k8s.cluster.name: {{ . | quote }}
+      {{- end }}
+      service.name: {{ include "mintel_common.fullname" . | quote }}
+      service.namespace: {{ $.Release.Namespace | quote }}
+      {{- with .resource.resourceAttributes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    {{- if .resource.addK8sUIDAttributes }}
+    addK8sUIDAttributes: true
+    {{- end }}
+
+  {{- if .injectPython.enabled | and (.injectPython.image | or .injectPython.env) }}
+  python:
+    {{- if .injectPython.image }}
+    image: {{ .injectPython.image | quote }}
+    {{- end }}
+    {{- with .injectPython.env }}
+    env:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+  {{- if .injectJava.enabled | and (.injectJava.image | or .injectJava.env) }}
+  java:
+    {{- if .injectJava.image }}
+    image: {{ .injectJava.image | quote }}
+    {{- end }}
+    {{- with .injectJava.env }}
+    env:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+  {{- if .injectNodeJS.enabled | and (.injectNodeJS.image | or .injectNodeJS.env) }}
+  nodejs:
+    {{- if .injectNodeJS.image }}
+    image: {{ .injectNodeJS.image | quote }}
+    {{- end }}
+    {{- with .injectNodeJS.env }}
+    env:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+  {{- if .injectDotNet.enabled | and (.injectDotNet.image | or .injectDotNet.env) }}
+  dotnet:
+    {{- if .injectDotNet.image }}
+    image: {{ .injectDotNet.image | quote }}
+    {{- end }}
+    {{- with .injectDotNet.env }}
+    env:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}
+
+{{- end -}}
+{{- end }}

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check DynamoDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -29,6 +29,8 @@ Check DynamoDB envfrom secretRef is present:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -106,7 +108,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -131,6 +133,8 @@ Check DynamoDB envfrom secretRef is present for local environment:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -206,7 +210,7 @@ Check DynamoDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app
@@ -231,6 +235,8 @@ Check DynamoDB secretName Override:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -4,7 +4,7 @@ Has a pod template that uses the host network:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -29,6 +29,8 @@ Has a pod template that uses the host network:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -4,7 +4,7 @@ Check AWS ALB lifecycle rule applied:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -30,6 +30,8 @@ Check AWS ALB lifecycle rule applied:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -119,7 +121,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -145,6 +147,8 @@ Check AWS ALB lifecycle rules applied with custom delay:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -234,7 +238,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -260,6 +264,8 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -342,7 +348,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -367,6 +373,8 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -444,7 +452,7 @@ Check lifecycle rules:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -469,6 +477,8 @@ Check lifecycle rules:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check MariaDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -29,6 +29,8 @@ Check MariaDB envfrom secretRef is present:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -106,7 +108,7 @@ Check MariaDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -131,6 +133,8 @@ Check MariaDB envfrom secretRef is present for local environment:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -206,7 +210,7 @@ Check MariaDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app
@@ -231,6 +235,8 @@ Check MariaDB secretName Override:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -4,7 +4,7 @@ Check container extraPorts:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -29,6 +29,8 @@ Check container extraPorts:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -110,7 +112,7 @@ Check container extraPorts are validated:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -135,6 +137,8 @@ Check container extraPorts are validated:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -218,7 +222,7 @@ Check container extraPorts protocol:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -243,6 +247,8 @@ Check container extraPorts protocol:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -325,7 +331,7 @@ Check container hybrid cloud ports:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -352,6 +358,7 @@ Check container hybrid cloud ports:
         metadata:
           annotations:
             consul.hashicorp.com/connect-inject: "true"
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -433,7 +440,7 @@ Check default container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -458,6 +465,8 @@ Check default container main port:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -535,7 +544,7 @@ Check overridden container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -560,6 +569,8 @@ Check overridden container main port:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -5,7 +5,7 @@ Check allowSingleReplica doesn't alter strategy:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -30,6 +30,8 @@ Check allowSingleReplica doesn't alter strategy:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -108,7 +110,7 @@ Check allowSingleReplica set annotations:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -133,6 +135,8 @@ Check allowSingleReplica set annotations:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -210,7 +214,7 @@ Check replicas unset when autoscaling is enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -234,6 +238,8 @@ Check replicas unset when autoscaling is enabled:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -312,7 +318,7 @@ Check singleReplicaOnly applied:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -334,6 +340,8 @@ Check singleReplicaOnly applied:
         type: Recreate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -412,7 +420,7 @@ Check singleReplicaOnly ignore replicas value:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -434,6 +442,8 @@ Check singleReplicaOnly ignore replicas value:
         type: Recreate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check S3 envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -29,6 +29,8 @@ Check S3 envfrom secretRef is present:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -106,7 +108,7 @@ Check S3 envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -131,6 +133,8 @@ Check S3 envfrom secretRef is present for local environment:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -206,7 +210,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3
       labels:
         app.kubernetes.io/component: app
@@ -234,6 +238,8 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -316,7 +322,7 @@ Check S3 secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app
@@ -341,6 +347,8 @@ Check S3 secretName Override:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -418,7 +426,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3,test-app-app,test-app-extra-secret-1
       labels:
         app.kubernetes.io/component: app
@@ -446,6 +454,8 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -326,7 +326,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -352,6 +352,8 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/instrumentation_test.yaml.snap
@@ -1,19 +1,57 @@
-Check default container args:
+adds the .NET injection annotation to the Deployment:
   1: |
+    apiVersion: opentelemetry.io/v1alpha1
+    kind: Instrumentation
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-20"
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app
+      name: example-app
+      namespace: test-namespace
+    spec:
+      dotnet:
+        env:
+          - name: OTEL_ENV_VAR
+            value: mock-env-var-value
+      exporter:
+        endpoint: http://grafana-agent.monitoring.svc.cluster.local:4317
+      propagators:
+        - tracecontext
+        - baggage
+        - b3
+        - jaeger
+        - xray
+      resource:
+        resourceAttributes:
+          cloud.platform: aws_eks
+          cloud.provider: aws
+          deployment.environment: qa
+          service.name: example-app
+          service.namespace: test-namespace
+      sampler:
+        type: parentbased_always_on
+  2: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
       annotations:
         helm.sh/chart: standard-application-stack-3.60.0
-        secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
+        secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
+        app.kubernetes.io/name: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
+        name: example-app
+      name: example-app
       namespace: test-namespace
     spec:
       minReadySeconds: 10
@@ -21,7 +59,7 @@ Check default container args:
       selector:
         matchLabels:
           app.kubernetes.io/component: app
-          app.kubernetes.io/name: test-app
+          app.kubernetes.io/name: example-app
       strategy:
         rollingUpdate:
           maxSurge: 15%
@@ -30,14 +68,14 @@ Check default container args:
       template:
         metadata:
           annotations:
-            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
+            instrumentation.opentelemetry.io/inject-dotnet: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: test-app
+            app.kubernetes.io/name: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
-            name: test-app
+            name: example-app
         spec:
           containers:
             - command:
@@ -53,7 +91,7 @@ Check default container args:
                   value: kubernetes
               envFrom:
                 - secretRef:
-                    name: test-app-app
+                    name: example-app-app
               image: registry.gitlab.com/test:auto-replaced
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -86,88 +124,76 @@ Check default container args:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-            - args:
-                - --redirect-url=https:///oauth2/callback
-                - --upstream=http://localhost:8000
-                - --http-address=http://0.0.0.0:4180
-                - --provider=oidc
-                - --skip-auth-regex=^/ping$
-                - --skip-auth-regex=^/healthz$
-                - --skip-auth-regex=^/readiness$
-                - --skip-auth-regex=^/external-health-check$
-                - --skip-provider-button=true
-                - --skip-jwt-bearer-tokens=true
-                - --ssl-insecure-skip-verify=true
-                - --ssl-upstream-insecure-skip-verify=true
-                - --oidc-groups-claim=groups
-                - --metrics-address=http://0.0.0.0:9090
-                - --email-domain=*
-                - --oidc-issuer-url=https://oauth.mintel.com
-                - --insecure-oidc-allow-unverified-email=true
-                - --cookie-secure=false
-                - --user-id-claim=sub
-                - --scope=openid profile email
-              env: null
-              envFrom:
-                - secretRef:
-                    name: test-app-oauth
-              image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.3
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /ping
-                  port: auth-proxy
-                  scheme: HTTP
-              name: auth-proxy
-              ports:
-                - containerPort: 4180
-                  name: auth-proxy
-                - containerPort: 9090
-                  name: metrics
-              readinessProbe:
-                httpGet:
-                  path: /ping
-                  port: auth-proxy
-                  scheme: HTTP
-              resources:
-                limits:
-                  cpu: 200m
-                  memory: 128Mi
-                requests:
-                  cpu: 100m
-                  memory: 64Mi
           imagePullSecrets:
             - name: image-pull-gitlab
             - name: image-pull-docker-hub
           securityContext:
             runAsUser: 1000
-          serviceAccountName: test-app
+          serviceAccountName: example-app
           terminationGracePeriodSeconds: 30
           topologySpreadConstraints:
             - labelSelector:
                 matchLabels:
                   app.kubernetes.io/component: app
-                  app.kubernetes.io/name: test-app
+                  app.kubernetes.io/name: example-app
               maxSkew: 1
               topologyKey: topology.kubernetes.io/zone
               whenUnsatisfiable: DoNotSchedule
           volumes: null
-Check setting skip-auth-regex from extra passed in values:
+adds the Java injection annotation to the Deployment:
   1: |
+    apiVersion: opentelemetry.io/v1alpha1
+    kind: Instrumentation
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-20"
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app
+      name: example-app
+      namespace: test-namespace
+    spec:
+      exporter:
+        endpoint: http://grafana-agent.monitoring.svc.cluster.local:4317
+      java:
+        env:
+          - name: OTEL_ENV_VAR
+            value: mock-env-var-value
+      propagators:
+        - tracecontext
+        - baggage
+        - b3
+        - jaeger
+        - xray
+      resource:
+        resourceAttributes:
+          cloud.platform: aws_eks
+          cloud.provider: aws
+          deployment.environment: qa
+          service.name: example-app
+          service.namespace: test-namespace
+      sampler:
+        type: parentbased_always_on
+  2: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
       annotations:
         helm.sh/chart: standard-application-stack-3.60.0
-        secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
+        secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
+        app.kubernetes.io/name: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
+        name: example-app
+      name: example-app
       namespace: test-namespace
     spec:
       minReadySeconds: 10
@@ -175,7 +201,7 @@ Check setting skip-auth-regex from extra passed in values:
       selector:
         matchLabels:
           app.kubernetes.io/component: app
-          app.kubernetes.io/name: test-app
+          app.kubernetes.io/name: example-app
       strategy:
         rollingUpdate:
           maxSurge: 15%
@@ -184,14 +210,14 @@ Check setting skip-auth-regex from extra passed in values:
       template:
         metadata:
           annotations:
-            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
+            instrumentation.opentelemetry.io/inject-java: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: test-app
+            app.kubernetes.io/name: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
-            name: test-app
+            name: example-app
         spec:
           containers:
             - command:
@@ -207,7 +233,7 @@ Check setting skip-auth-regex from extra passed in values:
                   value: kubernetes
               envFrom:
                 - secretRef:
-                    name: test-app-app
+                    name: example-app-app
               image: registry.gitlab.com/test:auto-replaced
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -240,89 +266,76 @@ Check setting skip-auth-regex from extra passed in values:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-            - args:
-                - --redirect-url=https:///oauth2/callback
-                - --upstream=http://localhost:8000
-                - --http-address=http://0.0.0.0:4180
-                - --provider=oidc
-                - --skip-auth-regex=^/ping$
-                - --skip-auth-regex=^/healthz$
-                - --skip-auth-regex=^/readiness$
-                - --skip-auth-regex=^/external-health-check$
-                - --skip-auth-regex=^/readyz$
-                - --skip-provider-button=true
-                - --skip-jwt-bearer-tokens=true
-                - --ssl-insecure-skip-verify=true
-                - --ssl-upstream-insecure-skip-verify=true
-                - --oidc-groups-claim=groups
-                - --metrics-address=http://0.0.0.0:9090
-                - --email-domain=*
-                - --oidc-issuer-url=https://oauth.mintel.com
-                - --insecure-oidc-allow-unverified-email=true
-                - --cookie-secure=false
-                - --user-id-claim=sub
-                - --scope=openid profile email
-              env: null
-              envFrom:
-                - secretRef:
-                    name: test-app-oauth
-              image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.3
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /ping
-                  port: auth-proxy
-                  scheme: HTTP
-              name: auth-proxy
-              ports:
-                - containerPort: 4180
-                  name: auth-proxy
-                - containerPort: 9090
-                  name: metrics
-              readinessProbe:
-                httpGet:
-                  path: /ping
-                  port: auth-proxy
-                  scheme: HTTP
-              resources:
-                limits:
-                  cpu: 200m
-                  memory: 128Mi
-                requests:
-                  cpu: 100m
-                  memory: 64Mi
           imagePullSecrets:
             - name: image-pull-gitlab
             - name: image-pull-docker-hub
           securityContext:
             runAsUser: 1000
-          serviceAccountName: test-app
+          serviceAccountName: example-app
           terminationGracePeriodSeconds: 30
           topologySpreadConstraints:
             - labelSelector:
                 matchLabels:
                   app.kubernetes.io/component: app
-                  app.kubernetes.io/name: test-app
+                  app.kubernetes.io/name: example-app
               maxSkew: 1
               topologyKey: topology.kubernetes.io/zone
               whenUnsatisfiable: DoNotSchedule
           volumes: null
-Check setting skip-auth-regex from extra passed in values when they already contain start/end meta-characters:
+adds the NodeJS injection annotation to the Deployment:
   1: |
+    apiVersion: opentelemetry.io/v1alpha1
+    kind: Instrumentation
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-20"
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app
+      name: example-app
+      namespace: test-namespace
+    spec:
+      exporter:
+        endpoint: http://grafana-agent.monitoring.svc.cluster.local:4317
+      nodejs:
+        env:
+          - name: OTEL_ENV_VAR
+            value: mock-env-var-value
+      propagators:
+        - tracecontext
+        - baggage
+        - b3
+        - jaeger
+        - xray
+      resource:
+        resourceAttributes:
+          cloud.platform: aws_eks
+          cloud.provider: aws
+          deployment.environment: qa
+          service.name: example-app
+          service.namespace: test-namespace
+      sampler:
+        type: parentbased_always_on
+  2: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
       annotations:
         helm.sh/chart: standard-application-stack-3.60.0
-        secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
+        secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
+        app.kubernetes.io/name: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
+        name: example-app
+      name: example-app
       namespace: test-namespace
     spec:
       minReadySeconds: 10
@@ -330,7 +343,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
       selector:
         matchLabels:
           app.kubernetes.io/component: app
-          app.kubernetes.io/name: test-app
+          app.kubernetes.io/name: example-app
       strategy:
         rollingUpdate:
           maxSurge: 15%
@@ -339,14 +352,14 @@ Check setting skip-auth-regex from extra passed in values when they already cont
       template:
         metadata:
           annotations:
-            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
+            instrumentation.opentelemetry.io/inject-nodejs: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: test-app
+            app.kubernetes.io/name: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
-            name: test-app
+            name: example-app
         spec:
           containers:
             - command:
@@ -362,7 +375,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
                   value: kubernetes
               envFrom:
                 - secretRef:
-                    name: test-app-app
+                    name: example-app-app
               image: registry.gitlab.com/test:auto-replaced
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -395,89 +408,76 @@ Check setting skip-auth-regex from extra passed in values when they already cont
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-            - args:
-                - --redirect-url=https:///oauth2/callback
-                - --upstream=http://localhost:8000
-                - --http-address=http://0.0.0.0:4180
-                - --provider=oidc
-                - --skip-auth-regex=^/ping$
-                - --skip-auth-regex=^/healthz$
-                - --skip-auth-regex=^/readiness$
-                - --skip-auth-regex=^/external-health-check$
-                - --skip-auth-regex=^/readyz$
-                - --skip-provider-button=true
-                - --skip-jwt-bearer-tokens=true
-                - --ssl-insecure-skip-verify=true
-                - --ssl-upstream-insecure-skip-verify=true
-                - --oidc-groups-claim=groups
-                - --metrics-address=http://0.0.0.0:9090
-                - --email-domain=*
-                - --oidc-issuer-url=https://oauth.mintel.com
-                - --insecure-oidc-allow-unverified-email=true
-                - --cookie-secure=false
-                - --user-id-claim=sub
-                - --scope=openid profile email
-              env: null
-              envFrom:
-                - secretRef:
-                    name: test-app-oauth
-              image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.3
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /ping
-                  port: auth-proxy
-                  scheme: HTTP
-              name: auth-proxy
-              ports:
-                - containerPort: 4180
-                  name: auth-proxy
-                - containerPort: 9090
-                  name: metrics
-              readinessProbe:
-                httpGet:
-                  path: /ping
-                  port: auth-proxy
-                  scheme: HTTP
-              resources:
-                limits:
-                  cpu: 200m
-                  memory: 128Mi
-                requests:
-                  cpu: 100m
-                  memory: 64Mi
           imagePullSecrets:
             - name: image-pull-gitlab
             - name: image-pull-docker-hub
           securityContext:
             runAsUser: 1000
-          serviceAccountName: test-app
+          serviceAccountName: example-app
           terminationGracePeriodSeconds: 30
           topologySpreadConstraints:
             - labelSelector:
                 matchLabels:
                   app.kubernetes.io/component: app
-                  app.kubernetes.io/name: test-app
+                  app.kubernetes.io/name: example-app
               maxSkew: 1
               topologyKey: topology.kubernetes.io/zone
               whenUnsatisfiable: DoNotSchedule
           volumes: null
-Check setting skip-auth-regex from overridden health-check values:
+adds the Python injection annotation to the Deployment:
   1: |
+    apiVersion: opentelemetry.io/v1alpha1
+    kind: Instrumentation
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-20"
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app
+      name: example-app
+      namespace: test-namespace
+    spec:
+      exporter:
+        endpoint: http://grafana-agent.monitoring.svc.cluster.local:4317
+      propagators:
+        - tracecontext
+        - baggage
+        - b3
+        - jaeger
+        - xray
+      python:
+        env:
+          - name: OTEL_ENV_VAR
+            value: mock-env-var-value
+      resource:
+        resourceAttributes:
+          cloud.platform: aws_eks
+          cloud.provider: aws
+          deployment.environment: qa
+          service.name: example-app
+          service.namespace: test-namespace
+      sampler:
+        type: parentbased_always_on
+  2: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
       annotations:
         helm.sh/chart: standard-application-stack-3.60.0
-        secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
+        secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
+        app.kubernetes.io/name: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
+        name: example-app
+      name: example-app
       namespace: test-namespace
     spec:
       minReadySeconds: 10
@@ -485,7 +485,7 @@ Check setting skip-auth-regex from overridden health-check values:
       selector:
         matchLabels:
           app.kubernetes.io/component: app
-          app.kubernetes.io/name: test-app
+          app.kubernetes.io/name: example-app
       strategy:
         rollingUpdate:
           maxSurge: 15%
@@ -494,14 +494,14 @@ Check setting skip-auth-regex from overridden health-check values:
       template:
         metadata:
           annotations:
-            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
+            instrumentation.opentelemetry.io/inject-python: test-namespace/example-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: test-app
+            app.kubernetes.io/name: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
-            name: test-app
+            name: example-app
         spec:
           containers:
             - command:
@@ -517,161 +517,7 @@ Check setting skip-auth-regex from overridden health-check values:
                   value: kubernetes
               envFrom:
                 - secretRef:
-                    name: test-app-app
-              image: registry.gitlab.com/test:auto-replaced
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /healthz-overridden
-                  port: http
-                  scheme: HTTP
-                initialDelaySeconds: 0
-                periodSeconds: 10
-                timeoutSeconds: 1
-              name: main
-              ports:
-                - containerPort: 8000
-                  name: http
-              readinessProbe:
-                httpGet:
-                  path: /readiness-overridden
-                  port: http
-                  scheme: HTTP
-                initialDelaySeconds: 0
-                periodSeconds: 10
-                timeoutSeconds: 1
-              resources:
-                limits: {}
-                requests: {}
-              startupProbe:
-                failureThreshold: 60
-                httpGet:
-                  path: /healthz-overridden
-                  port: http
-                  scheme: HTTP
-                periodSeconds: 5
-            - args:
-                - --redirect-url=https:///oauth2/callback
-                - --upstream=http://localhost:8000
-                - --http-address=http://0.0.0.0:4180
-                - --provider=oidc
-                - --skip-auth-regex=^/ping$
-                - --skip-auth-regex=^/healthz-overridden$
-                - --skip-auth-regex=^/readiness-overridden$
-                - --skip-auth-regex=^/external-health-check-overridden$
-                - --skip-provider-button=true
-                - --skip-jwt-bearer-tokens=true
-                - --ssl-insecure-skip-verify=true
-                - --ssl-upstream-insecure-skip-verify=true
-                - --oidc-groups-claim=groups
-                - --metrics-address=http://0.0.0.0:9090
-                - --email-domain=*
-                - --oidc-issuer-url=https://oauth.mintel.com
-                - --insecure-oidc-allow-unverified-email=true
-                - --cookie-secure=false
-                - --user-id-claim=sub
-                - --scope=openid profile email
-              env: null
-              envFrom:
-                - secretRef:
-                    name: test-app-oauth
-              image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.3
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /ping
-                  port: auth-proxy
-                  scheme: HTTP
-              name: auth-proxy
-              ports:
-                - containerPort: 4180
-                  name: auth-proxy
-                - containerPort: 9090
-                  name: metrics
-              readinessProbe:
-                httpGet:
-                  path: /ping
-                  port: auth-proxy
-                  scheme: HTTP
-              resources:
-                limits:
-                  cpu: 200m
-                  memory: 128Mi
-                requests:
-                  cpu: 100m
-                  memory: 64Mi
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
-          securityContext:
-            runAsUser: 1000
-          serviceAccountName: test-app
-          terminationGracePeriodSeconds: 30
-          topologySpreadConstraints:
-            - labelSelector:
-                matchLabels:
-                  app.kubernetes.io/component: app
-                  app.kubernetes.io/name: test-app
-              maxSkew: 1
-              topologyKey: topology.kubernetes.io/zone
-              whenUnsatisfiable: DoNotSchedule
-          volumes: null
-Check sidecar present if enabled:
-  1: |
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
-        secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
-      labels:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/env: qa
-        app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
-      namespace: test-namespace
-    spec:
-      minReadySeconds: 10
-      replicas: 2
-      selector:
-        matchLabels:
-          app.kubernetes.io/component: app
-          app.kubernetes.io/name: test-app
-      strategy:
-        rollingUpdate:
-          maxSurge: 15%
-          maxUnavailable: 10%
-        type: RollingUpdate
-      template:
-        metadata:
-          annotations:
-            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
-          labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: test-app
-            app.mintel.com/env: qa
-            app.mintel.com/region: ${CLUSTER_REGION}
-            name: test-app
-        spec:
-          containers:
-            - command:
-                - /app/docker-entrypoint.sh
-              env:
-                - name: KUBERNETES_POD_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                - name: APP_ENVIRONMENT
-                  value: qa
-                - name: RUNTIME_ENVIRONMENT
-                  value: kubernetes
-              envFrom:
-                - secretRef:
-                    name: test-app-app
+                    name: example-app-app
               image: registry.gitlab.com/test:auto-replaced
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -704,68 +550,300 @@ Check sidecar present if enabled:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-            - args:
-                - --redirect-url=https:///oauth2/callback
-                - --upstream=http://localhost:8000
-                - --http-address=http://0.0.0.0:4180
-                - --provider=oidc
-                - --skip-auth-regex=^/ping$
-                - --skip-auth-regex=^/healthz$
-                - --skip-auth-regex=^/readiness$
-                - --skip-auth-regex=^/external-health-check$
-                - --skip-provider-button=true
-                - --skip-jwt-bearer-tokens=true
-                - --ssl-insecure-skip-verify=true
-                - --ssl-upstream-insecure-skip-verify=true
-                - --oidc-groups-claim=groups
-                - --metrics-address=http://0.0.0.0:9090
-                - --email-domain=*
-                - --oidc-issuer-url=https://oauth.mintel.com
-                - --insecure-oidc-allow-unverified-email=true
-                - --cookie-secure=false
-                - --user-id-claim=sub
-                - --scope=openid profile email
-              env: null
-              envFrom:
-                - secretRef:
-                    name: test-app-oauth
-              image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.3
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /ping
-                  port: auth-proxy
-                  scheme: HTTP
-              name: auth-proxy
-              ports:
-                - containerPort: 4180
-                  name: auth-proxy
-                - containerPort: 9090
-                  name: metrics
-              readinessProbe:
-                httpGet:
-                  path: /ping
-                  port: auth-proxy
-                  scheme: HTTP
-              resources:
-                limits:
-                  cpu: 200m
-                  memory: 128Mi
-                requests:
-                  cpu: 100m
-                  memory: 64Mi
           imagePullSecrets:
             - name: image-pull-gitlab
             - name: image-pull-docker-hub
           securityContext:
             runAsUser: 1000
-          serviceAccountName: test-app
+          serviceAccountName: example-app
           terminationGracePeriodSeconds: 30
           topologySpreadConstraints:
             - labelSelector:
                 matchLabels:
                   app.kubernetes.io/component: app
-                  app.kubernetes.io/name: test-app
+                  app.kubernetes.io/name: example-app
+              maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: DoNotSchedule
+          volumes: null
+adds the env var injection annotation to the Deployment:
+  1: |
+    apiVersion: opentelemetry.io/v1alpha1
+    kind: Instrumentation
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-20"
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app
+      name: example-app
+      namespace: test-namespace
+    spec:
+      exporter:
+        endpoint: http://grafana-agent.monitoring.svc.cluster.local:4317
+      propagators:
+        - tracecontext
+        - baggage
+        - b3
+        - jaeger
+        - xray
+      resource:
+        resourceAttributes:
+          cloud.platform: aws_eks
+          cloud.provider: aws
+          deployment.environment: qa
+          service.name: example-app
+          service.namespace: test-namespace
+      sampler:
+        type: parentbased_always_on
+  2: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        helm.sh/chart: standard-application-stack-3.60.0
+        secret.reloader.stakater.com/reload: example-app-app
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app
+      name: example-app
+      namespace: test-namespace
+    spec:
+      minReadySeconds: 10
+      replicas: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: app
+          app.kubernetes.io/name: example-app
+      strategy:
+        rollingUpdate:
+          maxSurge: 15%
+          maxUnavailable: 10%
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
+          labels:
+            app.kubernetes.io/component: app
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: example-app
+            app.mintel.com/env: qa
+            app.mintel.com/region: ${CLUSTER_REGION}
+            name: example-app
+        spec:
+          containers:
+            - command:
+                - /app/docker-entrypoint.sh
+              env:
+                - name: KUBERNETES_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: APP_ENVIRONMENT
+                  value: qa
+                - name: RUNTIME_ENVIRONMENT
+                  value: kubernetes
+              envFrom:
+                - secretRef:
+                    name: example-app-app
+              image: registry.gitlab.com/test:auto-replaced
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: http
+                  scheme: HTTP
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                timeoutSeconds: 1
+              name: main
+              ports:
+                - containerPort: 8000
+                  name: http
+              readinessProbe:
+                httpGet:
+                  path: /readiness
+                  port: http
+                  scheme: HTTP
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                timeoutSeconds: 1
+              resources:
+                limits: {}
+                requests: {}
+              startupProbe:
+                failureThreshold: 60
+                httpGet:
+                  path: /healthz
+                  port: http
+                  scheme: HTTP
+                periodSeconds: 5
+          imagePullSecrets:
+            - name: image-pull-gitlab
+            - name: image-pull-docker-hub
+          securityContext:
+            runAsUser: 1000
+          serviceAccountName: example-app
+          terminationGracePeriodSeconds: 30
+          topologySpreadConstraints:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: app
+                  app.kubernetes.io/name: example-app
+              maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: DoNotSchedule
+          volumes: null
+creates an Instrumentation:
+  1: |
+    apiVersion: opentelemetry.io/v1alpha1
+    kind: Instrumentation
+    metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-20"
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app
+      name: example-app
+      namespace: test-namespace
+    spec:
+      env:
+        - name: OTEL_ENV_VAR
+          value: mock-env-var-value
+      exporter:
+        endpoint: mock-endpoint
+      propagators:
+        - mock-propagators
+      resource:
+        addK8sUIDAttributes: true
+        resourceAttributes:
+          cloud.account.id: mock-account-id
+          cloud.platform: aws_eks
+          cloud.provider: aws
+          cloud.region: mock-aws-region
+          deployment.environment: qa
+          k8s.cluster.name: mock-cluster-name
+          mock-resource-key: mock-resource-value
+          service.name: example-app
+          service.namespace: test-namespace
+      sampler:
+        type: parentbased_always_on
+sets the container names annotation:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        helm.sh/chart: standard-application-stack-3.60.0
+        secret.reloader.stakater.com/reload: example-app-app
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app
+      name: example-app
+      namespace: test-namespace
+    spec:
+      minReadySeconds: 10
+      replicas: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: app
+          app.kubernetes.io/name: example-app
+      strategy:
+        rollingUpdate:
+          maxSurge: 15%
+          maxUnavailable: 10%
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations:
+            instrumentation.opentelemetry.io/container-names: bar,foo
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/example-app
+          labels:
+            app.kubernetes.io/component: app
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: example-app
+            app.mintel.com/env: qa
+            app.mintel.com/region: ${CLUSTER_REGION}
+            name: example-app
+        spec:
+          containers:
+            - command:
+                - /app/docker-entrypoint.sh
+              env:
+                - name: KUBERNETES_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: APP_ENVIRONMENT
+                  value: qa
+                - name: RUNTIME_ENVIRONMENT
+                  value: kubernetes
+              envFrom:
+                - secretRef:
+                    name: example-app-app
+              image: registry.gitlab.com/test:auto-replaced
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: http
+                  scheme: HTTP
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                timeoutSeconds: 1
+              name: main
+              ports:
+                - containerPort: 8000
+                  name: http
+              readinessProbe:
+                httpGet:
+                  path: /readiness
+                  port: http
+                  scheme: HTTP
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                timeoutSeconds: 1
+              resources:
+                limits: {}
+                requests: {}
+              startupProbe:
+                failureThreshold: 60
+                httpGet:
+                  path: /healthz
+                  port: http
+                  scheme: HTTP
+                periodSeconds: 5
+          imagePullSecrets:
+            - name: image-pull-gitlab
+            - name: image-pull-docker-hub
+          securityContext:
+            runAsUser: 1000
+          serviceAccountName: example-app
+          terminationGracePeriodSeconds: 30
+          topologySpreadConstraints:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: app
+                  app.kubernetes.io/name: example-app
               maxSkew: 1
               topologyKey: topology.kubernetes.io/zone
               whenUnsatisfiable: DoNotSchedule

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -7,7 +7,7 @@ Check all .job.* values can be set correctly, without overriding from main deplo
         argocd.argoproj.io/hook: PreSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
         argocd.argoproj.io/sync-wave: "-1"
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -65,7 +65,7 @@ Check all overrides/additions from main deployment work if enabled:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -122,7 +122,7 @@ Check default values are correct with minimal configuration:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -173,7 +173,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -198,6 +198,8 @@ Check combined template defaults:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -322,7 +324,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -347,6 +349,8 @@ Check combined template with extra ports and monitors:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -213,7 +213,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -238,6 +238,8 @@ Check combined template defaults:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
@@ -389,7 +391,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.59.1
+        helm.sh/chart: standard-application-stack-3.60.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -414,6 +416,8 @@ Check combined template with extra ports and monitors:
         type: RollingUpdate
       template:
         metadata:
+          annotations:
+            instrumentation.opentelemetry.io/inject-sdk: test-namespace/test-app
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/instrumentation_test.yaml
+++ b/charts/standard-application-stack/tests/instrumentation_test.yaml
@@ -1,0 +1,197 @@
+suite: Test opentelemetry-operator Instrumentation
+templates:
+  - instrumentation.yaml
+  - deployment.yaml
+release:
+  namespace: test-namespace
+tests:
+  - it: creates an Instrumentation
+    template: instrumentation.yaml
+    set:
+      global.clusterEnv: qa
+      global.cloudProvider.accountId: mock-account-id
+      global.cloudProvider.region: mock-aws-region
+      global.clusterName: mock-cluster-name
+      otelInstrumentation.enabled: true
+      otelInstrumentation.env:
+        - name: OTEL_ENV_VAR
+          value: mock-env-var-value
+      otelInstrumentation.exporter.endpoint: "mock-endpoint"
+      otelInstrumentation.resource.resourceAttributes.mock-resource-key: mock-resource-value
+      otelInstrumentation.resource.addK8sUIDAttributes: true
+      otelInstrumentation.propagators: [mock-propagators]
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Instrumentation
+      - equal:
+          path: spec.exporter.endpoint
+          value: "mock-endpoint"
+      - contains:
+          path: spec.env
+          content:
+            name: OTEL_ENV_VAR
+            value: mock-env-var-value
+      - equal:
+          path: spec.resource.resourceAttributes
+          value:
+            cloud.account.id: mock-account-id
+            cloud.platform: aws_eks
+            cloud.provider: aws
+            cloud.region: mock-aws-region
+            deployment.environment: qa
+            k8s.cluster.name: mock-cluster-name
+            mock-resource-key: mock-resource-value
+            service.name: example-app
+            service.namespace: test-namespace
+      - equal:
+          path: spec.resource.addK8sUIDAttributes
+          value: true
+      - equal:
+          path: spec.propagators
+          value: [mock-propagators]
+
+  - it: adds the env var injection annotation to the Deployment
+    set:
+      global.clusterEnv: qa
+      global.name: example-app
+      otelInstrumentation.enabled: true
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - template: instrumentation.yaml
+        equal:
+          path: metadata.namespace
+          value: "test-namespace"
+      - template: instrumentation.yaml
+        equal:
+          path: metadata.name
+          value: "example-app"
+      - template: deployment.yaml
+        equal:
+          path: spec.template.metadata.annotations["instrumentation.opentelemetry.io/inject-sdk"]
+          value: "test-namespace/example-app"
+
+  - it: adds the Python injection annotation to the Deployment
+    set:
+      global.clusterEnv: qa
+      global.name: example-app
+      otelInstrumentation.enabled: true
+      otelInstrumentation.injectPython.enabled: true
+      otelInstrumentation.injectPython.env:
+        - name: OTEL_ENV_VAR
+          value: mock-env-var-value
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - template: instrumentation.yaml
+        equal:
+          path: metadata.namespace
+          value: "test-namespace"
+      - template: instrumentation.yaml
+        equal:
+          path: metadata.name
+          value: "example-app"
+      - template: deployment.yaml
+        equal:
+          path: spec.template.metadata.annotations["instrumentation.opentelemetry.io/inject-python"]
+          value: "test-namespace/example-app"
+      - template: deployment.yaml
+        isNull:
+          path: spec.template.metadata.annotations["instrumentation.opentelemetry.io/inject-sdk"]
+
+  - it: adds the Java injection annotation to the Deployment
+    set:
+      global.clusterEnv: qa
+      global.name: example-app
+      otelInstrumentation.enabled: true
+      otelInstrumentation.injectJava.enabled: true
+      otelInstrumentation.injectJava.env:
+        - name: OTEL_ENV_VAR
+          value: mock-env-var-value
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - template: instrumentation.yaml
+        equal:
+          path: metadata.namespace
+          value: "test-namespace"
+      - template: instrumentation.yaml
+        equal:
+          path: metadata.name
+          value: "example-app"
+      - template: deployment.yaml
+        equal:
+          path: spec.template.metadata.annotations["instrumentation.opentelemetry.io/inject-java"]
+          value: "test-namespace/example-app"
+      - template: deployment.yaml
+        isNull:
+          path: spec.template.metadata.annotations["instrumentation.opentelemetry.io/inject-sdk"]
+
+  - it: adds the NodeJS injection annotation to the Deployment
+    set:
+      global.clusterEnv: qa
+      global.name: example-app
+      otelInstrumentation.enabled: true
+      otelInstrumentation.injectNodeJS.enabled: true
+      otelInstrumentation.injectNodeJS.env:
+        - name: OTEL_ENV_VAR
+          value: mock-env-var-value
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - template: instrumentation.yaml
+        equal:
+          path: metadata.namespace
+          value: "test-namespace"
+      - template: instrumentation.yaml
+        equal:
+          path: metadata.name
+          value: "example-app"
+      - template: deployment.yaml
+        equal:
+          path: spec.template.metadata.annotations["instrumentation.opentelemetry.io/inject-nodejs"]
+          value: "test-namespace/example-app"
+      - template: deployment.yaml
+        isNull:
+          path: spec.template.metadata.annotations["instrumentation.opentelemetry.io/inject-sdk"]
+
+  - it: adds the .NET injection annotation to the Deployment
+    set:
+      global.clusterEnv: qa
+      global.name: example-app
+      otelInstrumentation.enabled: true
+      otelInstrumentation.injectDotNet.enabled: true
+      otelInstrumentation.injectDotNet.env:
+        - name: OTEL_ENV_VAR
+          value: mock-env-var-value
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - template: instrumentation.yaml
+        equal:
+          path: metadata.namespace
+          value: "test-namespace"
+      - template: instrumentation.yaml
+        equal:
+          path: metadata.name
+          value: "example-app"
+      - template: deployment.yaml
+        equal:
+          path: spec.template.metadata.annotations["instrumentation.opentelemetry.io/inject-dotnet"]
+          value: "test-namespace/example-app"
+      - template: deployment.yaml
+        isNull:
+          path: spec.template.metadata.annotations["instrumentation.opentelemetry.io/inject-sdk"]
+
+  - it: sets the container names annotation
+    template: deployment.yaml
+    set:
+      global.clusterEnv: qa
+      global.name: example-app
+      otelInstrumentation.enabled: true
+      otelInstrumentation.containerNames:
+        - foo
+        - bar
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - equal:
+          path: spec.template.metadata.annotations["instrumentation.opentelemetry.io/container-names"]
+          value: "bar,foo"

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -19,8 +19,10 @@ global:
   clusterName: ""
   # -- Global variables relating to cloud provider
   cloudProvider:
-    # -- AWS ACcount Id
+    # -- AWS Account Id
     accountId: ""
+    # -- AWS region name
+    region: ""
   # -- Global variable definint RUNTIME_ENVIRONMENT
   runtimeEnvironment: kubernetes
   # -- Global dictionary of TLS secrets
@@ -404,6 +406,141 @@ persistentVolumes:
 
 # -- A list of volume mounts to be added to the pod
 volumeMounts: []
+
+# -- Enabled opentelemetry-operator Instrumentation
+# ref: https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection
+otelInstrumentation:
+  # -- If true, create opentelemetry-operator Instrumentation custom resource and add annotations to pods
+  # such that the OpenTelemetry config environment variables are automatically injected into pods.
+  # You can also optionally inject auto-instrumentation libraries for some languages.
+  # ref: https://github.com/open-telemetry/opentelemetry-operator/blob/v0.68.0/docs/api.md#instrumentation
+  enabled: true
+  # -- The ArgoCD sync-wave to use for the Instrumentation CR.
+  # This needs to be lower than the sync-wave of any deployments/statefulsets that use it.
+  # ref: https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/
+  syncWave: -20
+  # -- Extra labels to add to the Instrumentation resource.
+  labels: {}
+  # -- Extra annotations to add to the Instrumentation resource.
+  annotations: {}
+  # -- Configure where the OpenTelemetry client exporters traces/spans.
+  exporter:
+    # -- The endpoint to send traces/spans to.
+    endpoint: 'http://grafana-agent.monitoring.svc.cluster.local:4317'
+  # -- If the pod has multiple containers, only inject instrumentation to containers with these names.
+  containerNames: []
+  # -- Common environment variables to inject regardless of language.
+  # The `valueFrom` field is supported.  Only var names beginning with "OTEL_" or "SPLUNK_" are allowed.
+  # ref: https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/
+  env: []
+  # -- Set an annotation on the pods to have opentelemetry-operator inject
+  # environment variables to configure OpenTelemetry client libraries.
+  injectEnvVars:
+    # -- If true add the annotation to pods.
+    enabled: true
+  # -- Inject Python auto-instrumentation.
+  injectPython:
+    # -- Enable/disable injecting auto-instrumentation.
+    # Implies also injecting the OpenTelemetry config environment variables.
+    enabled: false
+    # -- Use a custom auto-instrumentation image.
+    image: null
+    # -- Additional environment variables to inject into the pod container(s).
+    # The `valueFrom` field is supported.  Only var names beginning with "OTEL_" or "SPLUNK_" are allowed.
+    # ref: https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/
+    env:
+      # Required if exporter endpoint is set to 4317.
+      # Python autoinstrumentation uses http/proto by default
+      # so data must be sent to 4318 instead of 4137.
+      - name: OTEL_EXPORTER_OTLP_ENDPOINT
+        value: http://grafana-agent.monitoring.svc.cluster.local:4318
+      # A lot of the Python instrumentation libraries respect this variable.
+      - name: OTEL_PYTHON_EXCLUDED_URLS
+        value: '/health[zy]?,/ready[z]?,/readiness,/external-health-check,/metrics'
+  # -- Inject Java auto-instrumentation.
+  injectJava:
+    # -- Enable/disable injecting auto-instrumentation.
+    # Implies also injecting the OpenTelemetry config environment variables.
+    enabled: false
+     # -- Use a custom auto-instrumentation image.
+    image: null
+    # -- Additional environment variables to inject into the pod container(s).
+    # The `valueFrom` field is supported.  Only var names beginning with "OTEL_" or "SPLUNK_" are allowed.
+    # ref: https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/
+    env: []
+  # -- Inject NodeJS auto-instrumentation.
+  injectNodeJS:
+    # -- Enable/disable injecting auto-instrumentation.
+    # Implies also injecting the OpenTelemetry config environment variables.
+    enabled: false
+     # -- Use a custom auto-instrumentation image.
+    image: null
+    # -- Additional environment variables to inject into the pod container(s).
+    # The `valueFrom` field is supported.  Only var names beginning with "OTEL_" or "SPLUNK_" are allowed.
+    # ref: https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/
+    env: []
+  # -- Inject .NET auto-instrumentation.
+  injectDotNet:
+    # -- Enable/disable injecting auto-instrumentation.
+    # Implies also injecting the OpenTelemetry config environment variables.
+    enabled: false
+     # -- Use a custom auto-instrumentation image.
+    image: null
+    # -- Additional environment variables to inject into the pod container(s).
+    # The `valueFrom` field is supported.  Only var names beginning with "OTEL_" or "SPLUNK_" are allowed.
+    # ref: https://opentelemetry.io/docs/reference/specification/sdk-environment-variables/
+    env: []
+  # -- Set client side trace sampling.
+  sampler:
+    # -- The type of sampling to use.
+    #
+    # Valid values:
+    # - `always_on` - Sampler that always samples spans, regardless of the parent span’s sampling decision.
+    # - `always_off` - Sampler that never samples spans, regardless of the parent span’s sampling decision.
+    # - `traceidratio` - Sampler that samples probabilistically based on rate.
+    # - `parentbased_always_on` - (default) Sampler that respects its parent span’s sampling decision, but otherwise always samples.
+    # - `parentbased_always_off` - Sampler that respects its parent span’s sampling decision, but otherwise never samples.
+    # - `parentbased_traceidratio` - Sampler that respects its parent span’s sampling decision, but otherwise samples probabilistically based on rate.
+    #
+    # ref: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sampling
+    # ref: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#built-in-samplers
+    type: "parentbased_always_on"
+    # -- Optional argument to pass to the sampler. For example, for the `traceidratio` sampler you
+    # would use this to pass the ratio of traces to sample.
+    argument: ""
+  # -- Resource defines the configuration for the resource attributes, as defined by the OpenTelemetry specification.
+  # ref: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.8.0/specification/overview.md#resources
+  resource:
+    # -- Key/value attributes that will be added to the trace spans exported by OpenTelemetry.
+    # The following attributes are added automatically, either by the opentelemetry-operator
+    # or by values from this chart:
+    # - `cloud.account.id`
+    # - `cloud.platform`
+    # - `cloud.provider`
+    # - `cloud.region`
+    # - `deployment.environment`
+    # - `k8s.cluster.name`
+    # - `k8s.container.name`
+    # - `k8s.deployment.name`
+    # - `k8s.namespace.name`
+    # - `k8s.node.name`
+    # - `k8s.pod.name`
+    # - `k8s.replicaset.name`
+    # - `service.name`
+    # - `service.namespace`
+    # ref: https://opentelemetry.io/docs/reference/specification/resource/semantic_conventions/
+    resourceAttributes: {}
+    # -- If true, add deployment and pod UID attributes e.g. `k8s.deployment.uid`.
+    addK8sUIDAttributes: false
+  # -- Enable OpenTelemetry propagators.
+  # Default to enabling all of the official list of propagators + AWS XRay.
+  # ref: https://opentelemetry.io/docs/reference/specification/context/api-propagators/
+  propagators:
+    - tracecontext
+    - baggage
+    - b3
+    - jaeger
+    - xray
 
 # -- Configure an NLB to route traffic direct to pods (for non HTTP traffic)
 nlb:


### PR DESCRIPTION
This adds an [opentelemetry-operator Instrumentation](https://github.com/open-telemetry/opentelemetry-operator#opentelemetry-auto-instrumentation-injection) custom resource to the standard-application-stack Helm chart. 

The instrumentation is enabled by default, but only to add OpenTelemetry environment variables to pods. If you also wanted to inject Python auto-instrumentation for example:

```yaml
---
# values.yaml
otelInstrumentation:
  injectPython:
    enabled: true
````

JIRA: INFRA-28793