### PR TITLE
INFRA-29309: Add argocd annotation support to configmaps, secrets and service accounts

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.61.0] - 2023-02-17
+### Added
+- INFRA-29309: Support for setting ArgoCD annotations on config maps, secrets and service accounts
+
 ## [v3.60.0] - 2023-02-07
 ### Added
 - Add opentelemetry-operator Instrumentation custom resource

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v3.61.0] - 2023-02-17
 ### Added
 - INFRA-29309: Support for setting ArgoCD annotations on config maps, secrets and service accounts
+### Fixed
+- Contents of `serviceAccount.annotations` do not get applied to the manifest.
 
 ## [v3.60.0] - 2023-02-07
 ### Added

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.60.0
+version: 3.61.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.60.0](https://img.shields.io/badge/Version-3.60.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.61.0](https://img.shields.io/badge/Version-3.61.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.61.0](https://img.shields.io/badge/Version-3.61.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.60.0](https://img.shields.io/badge/Version-3.60.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -323,7 +323,8 @@ A generic chart to support most common application requirements
 | service.enabled | bool | `true` | Whether to create Service resource or not |
 | service.labels | object | `{}` | Provide any additional labels which may be required. |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
-| serviceAccount | object | `{"automountServiceAccountToken":true,"clusterRoles":[],"create":true,"irsa":{"enabled":false,"nameOverride":""},"name":"","roles":[]}` | ServiceAccount parameters ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
+| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"clusterRoles":[],"create":true,"irsa":{"enabled":false,"nameOverride":""},"name":"","roles":[]}` | ServiceAccount parameters ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
+| serviceAccount.annotations | object | `{}` | Additional Service Account annotations |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Whether to automount the service account token or not |
 | serviceAccount.clusterRoles | list | `[]` | Define list of ClusterRole's to create and bind to the service account ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/ |
 | serviceAccount.create | bool | `true` | Determine whether a Service Account should be created or it should reuse a exiting one. |

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -323,8 +323,7 @@ A generic chart to support most common application requirements
 | service.enabled | bool | `true` | Whether to create Service resource or not |
 | service.labels | object | `{}` | Provide any additional labels which may be required. |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |
-| serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"clusterRoles":[],"create":true,"irsa":{"enabled":false,"nameOverride":""},"name":"","roles":[]}` | ServiceAccount parameters ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
-| serviceAccount.annotations | object | `{}` | Additional Service Account annotations |
+| serviceAccount | object | `{"automountServiceAccountToken":true,"clusterRoles":[],"create":true,"irsa":{"enabled":false,"nameOverride":""},"name":"","roles":[]}` | ServiceAccount parameters ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
 | serviceAccount.automountServiceAccountToken | bool | `true` | Whether to automount the service account token or not |
 | serviceAccount.clusterRoles | list | `[]` | Define list of ClusterRole's to create and bind to the service account ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/ |
 | serviceAccount.create | bool | `true` | Determine whether a Service Account should be created or it should reuse a exiting one. |

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -43,6 +43,19 @@ matchExpressions:
 {{- define "mintel_common.commonAnnotations" -}}
 {{- end -}}
 
+{{/* Set up Argo annotations based on argo values block */}}
+{{ define "mintel_common.argoAnnotations" }}
+  {{ if .hook }}
+argocd.argoproj.io/hook: {{ toYaml .hook }}
+    {{ if .hookDeletePolicy }}
+argocd.argoproj.io/hook-delete-policy: {{ toYaml .hookDeletePolicy }}
+    {{ end }}
+  {{ end }}
+  {{ if .syncWave }}
+argocd.argoproj.io/sync-wave: {{ toYaml .syncWave }}
+  {{ end }}
+{{ end }}
+
 {{/* Common labels */}}
 {{- define "mintel_common.labels" -}}
 name: {{ include "mintel_common.fullname" . }}

--- a/charts/standard-application-stack/templates/configmaps.yaml
+++ b/charts/standard-application-stack/templates/configmaps.yaml
@@ -7,7 +7,11 @@ kind: ConfigMap
 metadata:
   name: {{ include "mintel_common.fullname" $data }}
   labels: {{ include "mintel_common.labels" $data | nindent 4 }}
-  annotations: {{ include "mintel_common.commonAnnotations" $data | nindent 4 }}
+  annotations:
+    {{ include "mintel_common.commonAnnotations" $data | nindent 4 }}
+    {{ if .argo }}
+    {{ include "mintel_common.argoAnnotations" .argo | nindent 4 }}
+    {{ end }}
   namespace: {{ $.Release.Namespace }}
 data:
   {{- range (required "Configmap content required." .configs) }}

--- a/charts/standard-application-stack/templates/jobs.yaml
+++ b/charts/standard-application-stack/templates/jobs.yaml
@@ -8,18 +8,10 @@ metadata:
   labels: {{ include "mintel_common.labels" $data | nindent 4 }}
   annotations:
     {{- include "mintel_common.commonAnnotations" $ | nindent 4 }}
+    {{ if .argo }}
+    {{ include "mintel_common.argoAnnotations" .argo | nindent 4 }}
+    {{ end }}
     helm.sh/chart: {{ include "mintel_common.chart" $ }}
-    {{- if .argo }}
-    {{- if .argo.hook }}
-    argocd.argoproj.io/hook: {{ toYaml .argo.hook }}
-    {{- if .argo.hookDeletePolicy }}
-    argocd.argoproj.io/hook-delete-policy: {{ toYaml .argo.hookDeletePolicy }}
-    {{- end }}
-    {{- end }}
-    {{- if .argo.syncWave }}
-    argocd.argoproj.io/sync-wave: {{ toYaml .argo.syncWave }}
-    {{- end }}
-    {{- end }}
   namespace: {{ $.Release.Namespace }}
 spec:
   template:

--- a/charts/standard-application-stack/templates/secrets.yaml
+++ b/charts/standard-application-stack/templates/secrets.yaml
@@ -25,6 +25,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
+    {{ if .Values.externalSecret.argo }}
+    {{ include "mintel_common.argoAnnotations" .Values.externalSecret.argo | nindent 4 }}
+    {{ end }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
@@ -65,6 +68,9 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   annotations:
     {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}
+    {{ if .argo }}
+    {{ include "mintel_common.argoAnnotations" .argo | nindent 4 }}
+    {{ end }}
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:

--- a/charts/standard-application-stack/templates/service-accounts.yaml
+++ b/charts/standard-application-stack/templates/service-accounts.yaml
@@ -5,14 +5,18 @@ metadata:
   name: {{ .Values.serviceAccount.name | default (include "mintel_common.fullname" .) }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "mintel_common.labels" . | nindent 4 }}
-  {{- if (or .Values.serviceAccount.annotations (and .Values.serviceAccount.irsa.enabled (ne .Values.global.clusterEnv "local"))) }}
   annotations:
     {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
-    {{- if .Values.global.terraform.irsa }}
+    {{ .Values.serviceAccount.annotations | toYaml | nindent 4 }}
+    {{ if (and .Values.serviceAccount.irsa.enabled (ne .Values.global.clusterEnv "local")) }}
+    {{ if .Values.global.terraform.irsa }}
     eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.global.cloudProvider.accountId }}:role/app-iam-{{ .Values.global.clusterName }}-{{ .Release.Namespace }}-{{ coalesce .Values.serviceAccount.irsa.nameOverride .Values.serviceAccount.name (include "mintel_common.fullname" .) }}
     {{- else }}
     eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.global.cloudProvider.accountId }}:role/{{ .Values.global.clusterName }}-{{ .Release.Namespace }}-{{ coalesce .Values.serviceAccount.irsa.nameOverride .Values.serviceAccount.name (include "mintel_common.fullname" .) }}
     {{- end }}
-  {{- end }}
+    {{- end }}
+    {{ if .Values.serviceAccount.argo }}
+    {{ include "mintel_common.argoAnnotations" .Values.serviceAccount.argo | nindent 4 }}
+    {{ end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}

--- a/charts/standard-application-stack/tests/__snapshot__/configmaps_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/configmaps_test.yaml.snap
@@ -1,4 +1,4 @@
-ArgoCD annotations:
+ensures ArgoCD annotations are populated:
   1: |
     apiVersion: v1
     data: null

--- a/charts/standard-application-stack/tests/__snapshot__/configmaps_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/configmaps_test.yaml.snap
@@ -1,3 +1,22 @@
+ArgoCD annotations:
+  1: |
+    apiVersion: v1
+    data: null
+    kind: ConfigMap
+    metadata:
+      annotations:
+        argocd.argoproj.io/hook: PreSync
+        argocd.argoproj.io/hook-delete-policy: HookSucceeded
+        argocd.argoproj.io/sync-wave: "-1"
+      labels:
+        app.kubernetes.io/component: config
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app-config
+        app.mintel.com/env: test
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app-config
+      name: example-app-config
+      namespace: test-namespace
 Empty configmap:
   1: |
     apiVersion: v1

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check DynamoDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -108,7 +108,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -210,7 +210,7 @@ Check DynamoDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -4,7 +4,7 @@ Has a pod template that uses the host network:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -4,7 +4,7 @@ Check AWS ALB lifecycle rule applied:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -121,7 +121,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -238,7 +238,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -348,7 +348,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -452,7 +452,7 @@ Check lifecycle rules:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check MariaDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -108,7 +108,7 @@ Check MariaDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -210,7 +210,7 @@ Check MariaDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -4,7 +4,7 @@ Check container extraPorts:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -112,7 +112,7 @@ Check container extraPorts are validated:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -222,7 +222,7 @@ Check container extraPorts protocol:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -331,7 +331,7 @@ Check container hybrid cloud ports:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -440,7 +440,7 @@ Check default container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -544,7 +544,7 @@ Check overridden container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -5,7 +5,7 @@ Check allowSingleReplica doesn't alter strategy:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -110,7 +110,7 @@ Check allowSingleReplica set annotations:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -214,7 +214,7 @@ Check replicas unset when autoscaling is enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -318,7 +318,7 @@ Check singleReplicaOnly applied:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -420,7 +420,7 @@ Check singleReplicaOnly ignore replicas value:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check S3 envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -108,7 +108,7 @@ Check S3 envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -210,7 +210,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3
       labels:
         app.kubernetes.io/component: app
@@ -322,7 +322,7 @@ Check S3 secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app
@@ -426,7 +426,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3,test-app-app,test-app-extra-secret-1
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -326,7 +326,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/instrumentation_test.yaml.snap
@@ -42,7 +42,7 @@ adds the .NET injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -184,7 +184,7 @@ adds the Java injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -326,7 +326,7 @@ adds the NodeJS injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -468,7 +468,7 @@ adds the Python injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -606,7 +606,7 @@ adds the env var injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -749,7 +749,7 @@ sets the container names annotation:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -7,7 +7,7 @@ Check all .job.* values can be set correctly, without overriding from main deplo
         argocd.argoproj.io/hook: PreSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
         argocd.argoproj.io/sync-wave: "-1"
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -65,7 +65,7 @@ Check all overrides/additions from main deployment work if enabled:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -122,7 +122,7 @@ Check default values are correct with minimal configuration:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -4,7 +4,7 @@ Check default container args:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -158,7 +158,7 @@ Check setting skip-auth-regex from extra passed in values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -313,7 +313,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -468,7 +468,7 @@ Check setting skip-auth-regex from overridden health-check values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -622,7 +622,7 @@ Check sidecar present if enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -173,7 +173,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -324,7 +324,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
@@ -1,0 +1,28 @@
+ArgoCD annotations:
+  1: |
+    apiVersion: external-secrets.io/v1alpha1
+    kind: ExternalSecret
+    metadata:
+      annotations:
+        argocd.argoproj.io/hook: PreSync
+        argocd.argoproj.io/hook-delete-policy: HookSucceeded
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-1"
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app
+        app.mintel.com/env: test
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app
+      name: example-app-app
+      namespace: test-namespace
+    spec:
+      dataFrom:
+        - key: test-namespace/example-app/app
+      refreshInterval: 5m0s
+      secretStoreRef:
+        kind: SecretStore
+        name: aws-secrets-manager-default
+      target:
+        creationPolicy: Owner

--- a/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
@@ -1,4 +1,4 @@
-ArgoCD annotations:
+ensures ArgoCD annotations are populated:
   1: |
     apiVersion: external-secrets.io/v1alpha1
     kind: ExternalSecret

--- a/charts/standard-application-stack/tests/__snapshot__/service_account_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_account_test.yaml.snap
@@ -1,0 +1,20 @@
+ensures annotations are populated:
+  1: |
+    apiVersion: v1
+    automountServiceAccountToken: true
+    kind: ServiceAccount
+    metadata:
+      annotations:
+        argocd.argoproj.io/hook: PreSync
+        argocd.argoproj.io/hook-delete-policy: HookSucceeded
+        argocd.argoproj.io/sync-wave: "-1"
+        test: value
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app
+        app.mintel.com/env: local
+        app.mintel.com/region: local
+        name: example-app
+      name: example-app
+      namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -213,7 +213,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -391,7 +391,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.60.0
+        helm.sh/chart: standard-application-stack-3.61.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/configmaps_test.yaml
+++ b/charts/standard-application-stack/tests/configmaps_test.yaml
@@ -84,7 +84,7 @@ tests:
           path: data["test2"]
           value: even more test data
 
-  - it: ArgoCD annotations
+  - it: ensures ArgoCD annotations are populated
     set:
       global.clusterEnv: test
       configMaps:

--- a/charts/standard-application-stack/tests/configmaps_test.yaml
+++ b/charts/standard-application-stack/tests/configmaps_test.yaml
@@ -83,3 +83,28 @@ tests:
       - equal:
           path: data["test2"]
           value: even more test data
+
+  - it: ArgoCD annotations
+    set:
+      global.clusterEnv: test
+      configMaps:
+        - name: "config"
+          argo:
+            hook: PreSync
+            hookDeletePolicy: HookSucceeded
+            syncWave: "-1"
+          create: true
+          configs: []
+    asserts:
+      - matchSnapshot: {}
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook"]
+          value: PreSync
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+          value: HookSucceeded
+      - equal:
+          path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+          value: "-1"

--- a/charts/standard-application-stack/tests/secret_test.yaml
+++ b/charts/standard-application-stack/tests/secret_test.yaml
@@ -4,7 +4,7 @@ templates:
 release:
   namespace: test-namespace
 tests:
-- it: ArgoCD annotations
+- it: ensures ArgoCD annotations are populated
   set:
     global.clusterEnv: test
     externalSecret:

--- a/charts/standard-application-stack/tests/secret_test.yaml
+++ b/charts/standard-application-stack/tests/secret_test.yaml
@@ -1,0 +1,28 @@
+suite: Test ExternalSecret Creation
+templates:
+- secrets.yaml
+release:
+  namespace: test-namespace
+tests:
+- it: ArgoCD annotations
+  set:
+    global.clusterEnv: test
+    externalSecret:
+      enabled: true
+      argo:
+        hook: PreSync
+        hookDeletePolicy: HookSucceeded
+        syncWave: "-1"
+  asserts:
+  - matchSnapshot: {}
+  - hasDocuments:
+      count: 1
+  - equal:
+      path: metadata.annotations["argocd.argoproj.io/hook"]
+      value: PreSync
+  - equal:
+      path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+      value: HookSucceeded
+  - equal:
+      path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+      value: "-1"

--- a/charts/standard-application-stack/tests/service_account_test.yaml
+++ b/charts/standard-application-stack/tests/service_account_test.yaml
@@ -1,0 +1,32 @@
+suite: Test ServiceAccount Creation
+templates:
+- service-accounts.yaml
+release:
+  namespace: test-namespace
+tests:
+- it: ensures annotations are populated
+  set:
+    serviceAccount:
+      create: true
+      annotations:
+        test: value
+      argo:
+        hook: PreSync
+        hookDeletePolicy: HookSucceeded
+        syncWave: "-1"
+  asserts:
+  - matchSnapshot: {}
+  - hasDocuments:
+      count: 1
+  - equal:
+      path: metadata.annotations["argocd.argoproj.io/hook"]
+      value: PreSync
+  - equal:
+      path: metadata.annotations["argocd.argoproj.io/hook-delete-policy"]
+      value: HookSucceeded
+  - equal:
+      path: metadata.annotations["argocd.argoproj.io/sync-wave"]
+      value: "-1"
+  - equal:
+      path: metadata.annotations.test
+      value: value

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -217,8 +217,6 @@ serviceAccount:
   create: true
   # -- ServiceAccount to use. A name is generated using the mintel_common.fullname template if it is not set
   name: ""
-  # -- Additional Service Account annotations
-  annotations: {}
   # -- Configures IRSA for the Service Account
   irsa:
     # -- Determines whether service account is IRSA enabled
@@ -227,6 +225,12 @@ serviceAccount:
     nameOverride: ""
   # -- Whether to automount the service account token or not
   automountServiceAccountToken: true
+
+  # # -- ArgoCD settings
+  # argo:
+  #   hook: PreSync
+  #   hookDeletePolicy: HookSucceeded
+  #   syncWave: "-1"
 
   # -- Define list of Role's to create and bind to the service account
   # ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
@@ -365,6 +369,10 @@ metrics:
 # ref: https://github.com/external-secrets/kubernetes-external-secrets
 externalSecret:
   enabled: true
+  #  argo:
+  #   hook: PreSync
+  #   hookDeletePolicy: HookSucceeded
+  #   syncWave: "-1"
   #  nameOverride: ""
   #  pathOverride: ""
   #  secretRefreshIntervalOverride: ""
@@ -374,6 +382,10 @@ externalSecret:
   #      value: test_value
 extraSecrets: []
 #  - name: ""
+#    argo:
+#     hook: PreSync
+#     hookDeletePolicy: HookSucceeded
+#     syncWave: "-1"
 #    pathOverride: ""
 #    pathSuffix: ""
 #    refreshIntervalOverride: ""
@@ -387,6 +399,11 @@ configMaps: []
 #  - name: ""
 #    # -- Whether or not to create the configmap
 #    create: false
+#    # -- ArgoCD settings
+#    argo:
+#      hook: PreSync
+#      hookDeletePolicy: HookSucceeded
+#      syncWave: "-1"
 #    # -- List of configs (files) within the configmap
 #    configs:
 #      - name: ""

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -217,6 +217,8 @@ serviceAccount:
   create: true
   # -- ServiceAccount to use. A name is generated using the mintel_common.fullname template if it is not set
   name: ""
+  # -- Additional Service Account annotations
+  annotations: {}
   # -- Configures IRSA for the Service Account
   irsa:
     # -- Determines whether service account is IRSA enabled


### PR DESCRIPTION
Sometimes we want jobs to run before the main workload but if those jobs require the same secrets, config maps or service accounts as the main workload then those also need to be synced at the same time as the job or it'll fail.