### PR TITLE
Allow extraIngresses to override any field of the top-level ingress

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.61.3] - 2023-02-24
+### Fixed
+- Allow `ingress.extraIngresses` to override any field of the top-level ingress
+
 ## [v3.61.2] - 2023-02-23
 ### Fixed
 - Disable default OpenTelemetry propagators

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.61.2
+version: 3.61.3
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.61.2](https://img.shields.io/badge/Version-3.61.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.61.3](https://img.shields.io/badge/Version-3.61.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -152,7 +152,7 @@ A generic chart to support most common application requirements
 | ingress.enabled | bool | `false` | Set to true to enable ingress record generation |
 | ingress.extraAnnotations | object | `{}` | Additional Ingress annotations For a full list of possible ingress annotations, please see ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md |
 | ingress.extraHosts | list | `[]` | List of extra ingress hosts to setup |
-| ingress.extraIngresses | list | `[]` | Optional: ability to construct multiple ingresses with different settings (names, cache headers, etc) Should be able to override all Ingress values be setting them again on a per instance basis |
+| ingress.extraIngresses | list | `[]` | Optional: ability to construct multiple ingresses with different settings (names, cache headers, etc) This accepts all the same values as the top-level ingress. It also inherits its default values from the top-level ingress, so all differences must be overridden per-instance. |
 | ingress.setNoCacheHeaders | bool | `false` | Only applies for 'haproxy' ingresses; Sets no-cache headers |
 | ingress.setXForwardedForHeaders | bool | `false` | Only applies for 'haproxy' ingresses; Sets X-Forwarded-For headers |
 | ingress.specificRulesHostsYaml | object | `{}` | Optional ingress Rules Hosts Yaml that doesn't fit standard pattern |

--- a/charts/standard-application-stack/templates/helpers/_ingress.yaml
+++ b/charts/standard-application-stack/templates/helpers/_ingress.yaml
@@ -124,7 +124,11 @@ alb.ingress.kubernetes.io/unhealthy-threshold-count: "{{ .alb.healthcheck.unheal
         {{- if (and .Values.oauthProxy .Values.oauthProxy.enabled) }}
         number: 4180
         {{- else }}
-        number: {{ .targetPort | default .Values.port }}
+        {{ $port := .targetPort | default .Values.port }}
+        {{- if not (eq ($port | int) 0) }}
+        {{- $port = $port | int }}
+        {{- end }}
+        {{ if $port | kindIs "int" }}number{{else}}name{{end}}: {{ $port }}
         {{- end }}
 {{- end -}}
 

--- a/charts/standard-application-stack/templates/ingress.yaml
+++ b/charts/standard-application-stack/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled }}
 {{- if (eq .Values.global.clusterEnv "local") }}
----
 {{- $ingressData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "ingress" .Values.ingress }}
+---
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
@@ -31,64 +31,60 @@ spec:
                   number: {{ .Values.port }}
                   {{- end }}
 {{- else }}
-{{- $ingresses := prepend .Values.ingress.extraIngresses .Values.ingress -}}
-{{- range $ingresses }}
----
+{{- range prepend .Values.ingress.extraIngresses .Values.ingress }}
+{{- with deepCopy $.Values.ingress | merge . }}
 {{- $ingressData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "ingress" . }}
+{{- $ingressName := include "mintel_common.ingressName" $ingressData }}
+{{- $ingressClass := include "mintel_common.ingress.className" $ingressData }}
+---
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
-  name: {{ include "mintel_common.ingressName" $ingressData }}
+  name: {{ $ingressName }}
   namespace: {{ $.Release.Namespace }}
   labels: {{ include "mintel_common.ingressLabels" $ingressData | nindent 4 }}
   annotations:
     {{ include "mintel_common.commonAnnotations" $ingressData | nindent 4 }}
-    {{- if (or $.Values.ingress.extraAnnotations $ingressData.ingress.extraAnnotations) }}
-    {{- $ingressData.extraAnnotations | default $.Values.ingress.extraAnnotations | toYaml | nindent 4 }}
+
+    {{- with .extraAnnotations }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 
-    {{- if (eq (include "mintel_common.ingress.className" $ingressData) "haproxy" ) }}
-    {{- include "mintel_common.ingress.haproxy_annotations" $ingressData | nindent 4 }}
-    {{- else }}
-
-    {{- if (and $.Values.ingress.alb $.Values.ingress.alb.enabled) }}
-    {{- $albData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "alb" $.Values.ingress.alb "defaultHost" $ingressData.ingress.defaultHost }}
-    {{- include "mintel_common.ingress.alb_annotations" $albData | nindent 4 }}
+    {{- if (eq $ingressClass "haproxy" ) }}
+      {{- include "mintel_common.ingress.haproxy_annotations" $ingressData | nindent 4 }}
+    {{- else if (and .alb .alb.enabled) }}
+      {{- $albData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "alb" .alb "defaultHost" .defaultHost }}
+      {{- include "mintel_common.ingress.alb_annotations" $albData | nindent 4 }}
     {{- end }}
 
-    {{- end }}
-    {{- if (and $.Values.ingress.blackbox $.Values.ingress.blackbox.enabled) }}
+    {{- if (and .blackbox .blackbox.enabled) }}
     prometheus.io/probe: "true"
-    prometheus.io/probepath: {{ $.Values.ingress.blackbox.probePath }}
+    prometheus.io/probepath: {{ .blackbox.probePath }}
     {{- end }}
 spec:
-  ingressClassName: {{ include "mintel_common.ingress.className" $ingressData }}
+  ingressClassName: {{ $ingressClass }}
   rules:
     - host: {{ .defaultHost }}
       http:
         paths:
           # 10
-          {{- if (not $.Values.ingress.pathBasedRouting) }}
-          {{- include "mintel_common.ingress.ingressPath" $ingressData | nindent 10 }}
+          {{- range .pathBasedRouting }}
+            {{- $pathData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "targetService" .targetService "targetPort" .targetPort "path" .path "pathType" .pathType }}
+            {{- include "mintel_common.ingress.ingressPath" $pathData | nindent 10 }}
           {{- else }}
-          {{- range $.Values.ingress.pathBasedRouting }}
-          {{- $pathData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "targetService" .targetService "targetPort" .targetPort "path" .path "pathType" .pathType }}
-          {{- include "mintel_common.ingress.ingressPath" $pathData | nindent 10 }}
-          {{- end }}
+            {{- include "mintel_common.ingress.ingressPath" $ingressData | nindent 10 }}
           {{- end }}
     {{- range .extraHosts }}
     {{- if (or (not $.Values.oauthProxy.enabled) (ne $.Values.oauthProxy.ingressHost .name)) }}
     - host: {{ .name }}
       http:
         paths:
-          {{- if (not $.Values.ingress.pathBasedRouting) }}
-          {{- $pathData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "targetService" .serviceName "targetPort" .servicePort "path" .path "pathType" .pathType }}
-          {{- include "mintel_common.ingress.ingressPath" $pathData | nindent 10 }}
+          {{- range .pathBasedRouting }}
+            {{- $pathData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "targetService" .targetService "targetPort" .targetPort "path" .path "pathType" .pathType }}
+            {{- include "mintel_common.ingress.ingressPath" $pathData | nindent 10 }}
           {{- else }}
-          {{- range $.Values.ingress.pathBasedRouting }}
-          {{- $pathData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "targetService" .targetService "targetPort" .targetPort "path" .path "pathType" .pathType }}
-          {{- include "mintel_common.ingress.ingressPath" $pathData | nindent 10 }}
-          {{- end }}
+            {{- $pathData := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "targetService" .serviceName "targetPort" .servicePort "path" .path "pathType" .pathType }}
+            {{- include "mintel_common.ingress.ingressPath" $pathData | nindent 10 }}
           {{- end }}
     {{- end }}
     {{- end }}
@@ -104,37 +100,42 @@ spec:
                 port:
                   number: 4180
     {{- end }}
-    {{- with $.Values.ingress.specificRulesHostsYaml }}
+
+    {{- with .specificRulesHostsYaml }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- if and $.Values.ingress.tls ( or $.Values.global.ingressTLSSecrets $.Values.ingress.specificTlsHostsYaml ) }}
+
+  {{- if and .tls ( or $.Values.global.ingressTLSSecrets .specificTlsHostsYaml ) }}
   tls:
     {{- range $key, $val := $.Values.global.ingressTLSSecrets }}
-    {{- $domainUsed := false -}}
-    {{- $domainHosts := list -}}
-    {{- if hasSuffix ($key | replace "_" ".") $.Values.ingress.defaultHost -}}
-    {{- $domainUsed = true -}}
-    {{- $domainHosts = append $domainHosts $.Values.ingress.defaultHost -}}
-    {{- end -}}
-    {{- range $.Values.ingress.extraHosts -}}
-    {{- if hasSuffix ($key | replace "_" ".") .name -}}
-    {{- $domainUsed = true -}}
-    {{- $domainHosts = append $domainHosts .name -}}
-    {{- end -}}
-    {{- end -}}
-    {{- if (and $.Values.oauthProxy $.Values.oauthProxy.ingressHost) }}
-    {{- $domainHosts = append $domainHosts $.Values.oauthProxy.ingressHost }}
-    {{- end }}
-    {{- if $domainUsed }}
+      {{- $domainUsed := false -}}
+      {{- $domainHosts := list -}}
+      {{- if hasSuffix ($key | replace "_" ".") $ingressData.ingress.defaultHost -}}
+        {{- $domainUsed = true -}}
+        {{- $domainHosts = append $domainHosts $ingressData.ingress.defaultHost -}}
+      {{- end -}}
+      {{- range $ingressData.ingress.extraHosts -}}
+        {{- if hasSuffix ($key | replace "_" ".") .name -}}
+          {{- $domainUsed = true -}}
+          {{- $domainHosts = append $domainHosts .name -}}
+        {{- end -}}
+      {{- end -}}
+      {{- if (and $.Values.oauthProxy $.Values.oauthProxy.ingressHost) }}
+        {{- $domainHosts = append $domainHosts $.Values.oauthProxy.ingressHost }}
+      {{- end }}
+      {{- if $domainUsed }}
     - hosts:
         {{- toYaml $domainHosts | nindent 8 }}
       secretName: {{ $val }}
+      {{- end }}
     {{- end }}
-    {{- end }}
-    {{- with $.Values.ingress.specificTlsHostsYaml }}
+
+    {{- with $ingressData.ingress.specificTlsHostsYaml }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
+
+{{- end }}
 {{- end }}
 
 {{- end }}

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check DynamoDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -108,7 +108,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -210,7 +210,7 @@ Check DynamoDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -4,7 +4,7 @@ Has a pod template that uses the host network:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -4,7 +4,7 @@ Check AWS ALB lifecycle rule applied:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -121,7 +121,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -238,7 +238,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -348,7 +348,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -452,7 +452,7 @@ Check lifecycle rules:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check MariaDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -108,7 +108,7 @@ Check MariaDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -210,7 +210,7 @@ Check MariaDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -4,7 +4,7 @@ Check container extraPorts:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -112,7 +112,7 @@ Check container extraPorts are validated:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -222,7 +222,7 @@ Check container extraPorts protocol:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -331,7 +331,7 @@ Check container hybrid cloud ports:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -440,7 +440,7 @@ Check default container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -544,7 +544,7 @@ Check overridden container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -5,7 +5,7 @@ Check allowSingleReplica doesn't alter strategy:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -110,7 +110,7 @@ Check allowSingleReplica set annotations:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -214,7 +214,7 @@ Check replicas unset when autoscaling is enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -318,7 +318,7 @@ Check singleReplicaOnly applied:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -420,7 +420,7 @@ Check singleReplicaOnly ignore replicas value:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check S3 envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -108,7 +108,7 @@ Check S3 envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -210,7 +210,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3
       labels:
         app.kubernetes.io/component: app
@@ -322,7 +322,7 @@ Check S3 secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app
@@ -426,7 +426,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3,test-app-app,test-app-extra-secret-1
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -326,7 +326,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -1085,7 +1085,7 @@ Default ingress with path based routing:
                       number: 5678
                 path: /i02
                 pathType: Prefix
-Multiple ingresses with different names:
+allows extraIngresses to override default values:
   1: |
     apiVersion: networking.k8s.io/v1
     kind: Ingress
@@ -1171,8 +1171,8 @@ Multiple ingresses with different names:
             paths:
               - backend:
                   service:
-                    name: example-app
+                    name: mock-service
                     port:
-                      number: 8000
-                path: /
+                      name: mock-port
+                path: /mock-path
                 pathType: Prefix

--- a/charts/standard-application-stack/tests/__snapshot__/instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/instrumentation_test.yaml.snap
@@ -36,7 +36,7 @@ adds the .NET injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -172,7 +172,7 @@ adds the Java injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -308,7 +308,7 @@ adds the NodeJS injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -444,7 +444,7 @@ adds the Python injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -576,7 +576,7 @@ adds the env var injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -719,7 +719,7 @@ sets the container names annotation:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -7,7 +7,7 @@ Check all .job.* values can be set correctly, without overriding from main deplo
         argocd.argoproj.io/hook: PreSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
         argocd.argoproj.io/sync-wave: "-1"
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -65,7 +65,7 @@ Check all overrides/additions from main deployment work if enabled:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -122,7 +122,7 @@ Check default values are correct with minimal configuration:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -4,7 +4,7 @@ Check default container args:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -158,7 +158,7 @@ Check setting skip-auth-regex from extra passed in values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -313,7 +313,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -468,7 +468,7 @@ Check setting skip-auth-regex from overridden health-check values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -622,7 +622,7 @@ Check sidecar present if enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -173,7 +173,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -324,7 +324,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -213,7 +213,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -391,7 +391,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.2
+        helm.sh/chart: standard-application-stack-3.61.3
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/ingress_test.yaml
+++ b/charts/standard-application-stack/tests/ingress_test.yaml
@@ -422,7 +422,7 @@ tests:
           path: spec.rules[0].http.paths[1].backend.service.port.number
           value: 5678
 
-  - it: Multiple ingresses with different names
+  - it: allows extraIngresses to override default values
     template: ingress.yaml
     set:
       global.clusterEnv: qa
@@ -433,6 +433,11 @@ tests:
       ingress.extraIngresses:
         - ingressNameSuffix: ops-media
           defaultHost: ops-media.mintel.com
+          pathBasedRouting:
+            - targetService: mock-service
+              targetPort: mock-port
+              path: /mock-path
+
     asserts:
       - matchSnapshot: {} # Check for regressions and unexpected changes.
       - hasDocuments:
@@ -452,4 +457,16 @@ tests:
       - equal:
           path: spec.rules[0].host
           value: ops-media.mintel.com
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.name
+          value: mock-service
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.service.port.name
+          value: mock-port
+        documentIndex: 1
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /mock-path
         documentIndex: 1

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -590,7 +590,8 @@ ingress:
   # ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
   extraAnnotations: {}
   # -- Optional: ability to construct multiple ingresses with different settings (names, cache headers, etc)
-  # Should be able to override all Ingress values be setting them again on a per instance basis
+  # This accepts all the same values as the top-level ingress. It also inherits its default
+  # values from the top-level ingress, so all differences must be overridden per-instance.
   extraIngresses: []
   # -- Explicitly set the 'tier: frontend' label on deployments even if ingress is disabled
   allowFrontendAccess: false


### PR DESCRIPTION
I had a problem where setting `ingress.extraIngresses.pathBasedRouting` was ignored because the extra ingresses would always use `ingress.pathBasedRouting`. This commit fixes that by allowing the extra ingresses to generically override any field of the top-level ingress i.e. the top-level ingress values are used as the defaults, which can be overridden.