### PR TITLE
Upgrade from deprecated external-secrets API version

### DIFF
--- a/charts/basic-config/CHANGELOG.md
+++ b/charts/basic-config/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.2.3] - 2023-02-28
+### Fixed
+- Upgrade from deprecated external-secrets API version
+
 ## [v0.2.2] - 2023-02-06
 ### Added
 - Add snapshot tests

--- a/charts/basic-config/Chart.yaml
+++ b/charts/basic-config/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3

--- a/charts/basic-config/README.md
+++ b/charts/basic-config/README.md
@@ -1,6 +1,6 @@
 # basic-config
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for defining basic k8s configuration res
 

--- a/charts/basic-config/templates/_capabilities.tpl
+++ b/charts/basic-config/templates/_capabilities.tpl
@@ -22,7 +22,7 @@ rbac.authorization.k8s.io/v1
 
 {{/* Return the appropriate apiVersion for External Secrets. */}}
 {{- define "common.capabilities.externalsecret.apiVersion" -}}
-external-secrets.io/v1alpha1
+external-secrets.io/v1beta1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for Secrets. */}}

--- a/charts/basic-config/templates/secrets.yaml
+++ b/charts/basic-config/templates/secrets.yaml
@@ -27,7 +27,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ .pathOverride | default (printf "%s/%s/%s" $.Release.Namespace (include "mintel_common.fullname" $) .name) }}
+    - extract:
+        key: {{ .pathOverride | default (printf "%s/%s/%s" $.Release.Namespace (include "mintel_common.fullname" $) .name) }}
   refreshInterval: {{ .refreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
     name: {{ .secretStoreRefOverride | default "aws-secrets-manager-local" }}

--- a/charts/basic-config/tests/__snapshot__/configmaps_test.yaml.snap
+++ b/charts/basic-config/tests/__snapshot__/configmaps_test.yaml.snap
@@ -5,7 +5,7 @@ Empty configmap:
     kind: ConfigMap
     metadata:
       annotations:
-        helm.sh/chart: basic-config-0.2.2
+        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: local
@@ -25,7 +25,7 @@ Mixed singleline and  multiline data entries:
     kind: ConfigMap
     metadata:
       annotations:
-        helm.sh/chart: basic-config-0.2.2
+        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: local
@@ -44,7 +44,7 @@ Single multiline data entry:
     kind: ConfigMap
     metadata:
       annotations:
-        helm.sh/chart: basic-config-0.2.2
+        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: local
@@ -60,7 +60,7 @@ Single singleline data entry:
     kind: ConfigMap
     metadata:
       annotations:
-        helm.sh/chart: basic-config-0.2.2
+        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: local

--- a/charts/basic-config/tests/__snapshot__/network-policy-hybrid-consul_test.yaml.snap
+++ b/charts/basic-config/tests/__snapshot__/network-policy-hybrid-consul_test.yaml.snap
@@ -4,7 +4,7 @@ Renders hybrid consul network policy:
     kind: NetworkPolicy
     metadata:
       annotations:
-        helm.sh/chart: basic-config-0.2.2
+        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: local

--- a/charts/basic-config/tests/__snapshot__/secrets_test.yaml.snap
+++ b/charts/basic-config/tests/__snapshot__/secrets_test.yaml.snap
@@ -1,11 +1,11 @@
 Check renders a single external secret:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-        helm.sh/chart: basic-config-0.2.2
+        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: qa
@@ -15,7 +15,8 @@ Check renders a single external secret:
       namespace: test-namespace
     spec:
       dataFrom:
-        - key: test/external/secret
+        - extract:
+            key: test/external/secret
       refreshInterval: 5m0s
       secretStoreRef:
         kind: SecretStore
@@ -24,12 +25,12 @@ Check renders a single external secret:
         creationPolicy: Owner
 Check renders a single external secret with no overrides:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-        helm.sh/chart: basic-config-0.2.2
+        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: qa
@@ -39,7 +40,8 @@ Check renders a single external secret with no overrides:
       namespace: test-namespace
     spec:
       dataFrom:
-        - key: test-namespace/test-app/external-secret
+        - extract:
+            key: test-namespace/test-app/external-secret
       refreshInterval: 5m0s
       secretStoreRef:
         kind: SecretStore
@@ -48,12 +50,12 @@ Check renders a single external secret with no overrides:
         creationPolicy: Owner
 Check renders multiple external secrets:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-        helm.sh/chart: basic-config-0.2.2
+        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: qa
@@ -63,7 +65,8 @@ Check renders multiple external secrets:
       namespace: test-namespace
     spec:
       dataFrom:
-        - key: test/external/secret1
+        - extract:
+            key: test/external/secret1
       refreshInterval: 5m0s
       secretStoreRef:
         kind: SecretStore
@@ -71,12 +74,12 @@ Check renders multiple external secrets:
       target:
         creationPolicy: Owner
   2: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-        helm.sh/chart: basic-config-0.2.2
+        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: qa
@@ -86,7 +89,8 @@ Check renders multiple external secrets:
       namespace: test-namespace
     spec:
       dataFrom:
-        - key: test/external/secret2
+        - extract:
+            key: test/external/secret2
       refreshInterval: 5m0s
       secretStoreRef:
         kind: SecretStore
@@ -95,12 +99,12 @@ Check renders multiple external secrets:
         creationPolicy: Owner
 Check secret name override:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-        helm.sh/chart: basic-config-0.2.2
+        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: qa
@@ -110,7 +114,8 @@ Check secret name override:
       namespace: test-namespace
     spec:
       dataFrom:
-        - key: test/external/secret1
+        - extract:
+            key: test/external/secret1
       refreshInterval: 5m0s
       secretStoreRef:
         kind: SecretStore
@@ -119,12 +124,12 @@ Check secret name override:
         creationPolicy: Owner
 Check secret path override:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-        helm.sh/chart: basic-config-0.2.2
+        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: qa
@@ -134,7 +139,8 @@ Check secret path override:
       namespace: test-namespace
     spec:
       dataFrom:
-        - key: test/external/secret1
+        - extract:
+            key: test/external/secret1
       refreshInterval: 5m0s
       secretStoreRef:
         kind: SecretStore

--- a/charts/basic-config/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/basic-config/tests/__snapshot__/service_test.yaml.snap
@@ -4,7 +4,7 @@ Renders headless service:
     kind: Service
     metadata:
       annotations:
-        helm.sh/chart: basic-config-0.2.2
+        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: local

--- a/charts/basic-config/tests/secrets_test.yaml
+++ b/charts/basic-config/tests/secrets_test.yaml
@@ -22,7 +22,7 @@ tests:
           path: metadata.name
           value: test-app-external-secret
       - equal:
-          path: spec.dataFrom[0].key
+          path: spec.dataFrom[0].extract.key
           value: test-namespace/test-app/external-secret
       - hasDocuments:
           count: 1
@@ -61,7 +61,7 @@ tests:
           of: ExternalSecret
         documentIndex: 0
       - equal:
-          path: spec.dataFrom[0].key
+          path: spec.dataFrom[0].extract.key
           value: test/external/secret1
         documentIndex: 0
 
@@ -83,7 +83,7 @@ tests:
           path: metadata.name
           value: test-app-external-secret
       - equal:
-          path: spec.dataFrom[0].key
+          path: spec.dataFrom[0].extract.key
           value: test/external/secret
       - equal:
           path: spec.secretStoreRef.kind
@@ -129,11 +129,11 @@ tests:
           value: test-app-external-secret2
         documentIndex: 1
       - equal:
-          path: spec.dataFrom[0].key
+          path: spec.dataFrom[0].extract.key
           value: test/external/secret1
         documentIndex: 0
       - equal:
-          path: spec.dataFrom[0].key
+          path: spec.dataFrom[0].extract.key
           value: test/external/secret2
         documentIndex: 1
       - equal:
@@ -185,6 +185,6 @@ tests:
           of: ExternalSecret
         documentIndex: 0
       - equal:
-          path: spec.dataFrom[0].key
+          path: spec.dataFrom[0].extract.key
           value: test/external/secret1
         documentIndex: 0

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v3.61.5] - 2023-02-28
+### Fixed
+- Upgrade from deprecated external-secrets API version
+
 ## [v3.61.4] - 2023-02-27
 ### Fixed
 - Fix ingress values/rendering for extraIngresses

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.61.4
+version: 3.61.5
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 3.61.4](https://img.shields.io/badge/Version-3.61.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 3.61.5](https://img.shields.io/badge/Version-3.61.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/_capabilities.tpl
+++ b/charts/standard-application-stack/templates/_capabilities.tpl
@@ -71,7 +71,7 @@ monitoring.coreos.com/v1
 
 {{/* Return the appropriate apiVersion for External Secrets. */}}
 {{- define "common.capabilities.externalsecret.apiVersion" -}}
-external-secrets.io/v1alpha1
+external-secrets.io/v1beta1
 {{- end -}}
 
 {{/* Return the appropriate apiVersion for Secrets. */}}

--- a/charts/standard-application-stack/templates/secrets.yaml
+++ b/charts/standard-application-stack/templates/secrets.yaml
@@ -31,7 +31,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ .Values.externalSecret.pathOverride | default (printf "%s/%s/app" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
+    - extract:
+        key: {{ .Values.externalSecret.pathOverride | default (printf "%s/%s/app" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
   refreshInterval: {{ .Values.externalSecret.secretRefreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
     name: {{ .Values.externalSecret.secretStoreRefOverride | default "aws-secrets-manager-default" }}
@@ -74,7 +75,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ .pathOverride | default (printf "%s/%s/%s" $.Release.Namespace (include "mintel_common.fullname" $) .name) }}
+    - extract:
+        key: {{ .pathOverride | default (printf "%s/%s/%s" $.Release.Namespace (include "mintel_common.fullname" $) .name) }}
   refreshInterval: {{ .refreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
     name: {{ .secretStoreRefOverride | default "aws-secrets-manager-default" }}
@@ -200,7 +202,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ .Values.redis.secretPathOverride | default (printf "%s/%s/redis" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
+    - extract:
+        key: {{ .Values.redis.secretPathOverride | default (printf "%s/%s/redis" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
   refreshInterval: {{ .Values.redis.secretRefreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
     name: {{ .Values.redis.secretStoreRefOverride | default "aws-secrets-manager-default" }}
@@ -280,7 +283,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ .Values.elasticsearch.secretPathOverride | default (printf "%s/%s/elasticsearch" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
+    - extract:
+        key: {{ .Values.elasticsearch.secretPathOverride | default (printf "%s/%s/elasticsearch" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
   data:
     {{- $dataKey := ( .Values.elasticsearch.secretPathOverride | default (printf "%s/%s/elasticsearch" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
     - secretKey: ES_HOSTS
@@ -324,7 +328,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ .Values.opensearch.secretPathOverride | default (printf "%s/%s/opensearch" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
+    - extract:
+        key: {{ .Values.opensearch.secretPathOverride | default (printf "%s/%s/opensearch" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
   data:
     {{- $dataKey := ( .Values.opensearch.secretPathOverride | default (printf "%s/%s/opensearch" (.Release.Namespace) (include "mintel_common.fullname" .))) }}
     {{- if (not .Values.opensearch.awsEsProxy.enabled) }}
@@ -448,7 +453,8 @@ metadata:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   dataFrom:
-    - key: {{ .Values.oauthProxy.secretPathOverride | default (printf "%s/%s/oauth" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
+    - extract:
+        key: {{ .Values.oauthProxy.secretPathOverride | default (printf "%s/%s/oauth" (.Release.Namespace) (include "mintel_common.fullname" .)) }}
   refreshInterval: {{ .Values.oauthProxy.secretRefreshIntervalOverride | default "5m0s" }}
   secretStoreRef:
     name: {{ .Values.oauthProxy.secretStoreRefOverride | default "aws-secrets-manager-default" }}

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check DynamoDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -108,7 +108,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -210,7 +210,7 @@ Check DynamoDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -4,7 +4,7 @@ Has a pod template that uses the host network:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -4,7 +4,7 @@ Check AWS ALB lifecycle rule applied:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -121,7 +121,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -238,7 +238,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -348,7 +348,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -452,7 +452,7 @@ Check lifecycle rules:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check MariaDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -108,7 +108,7 @@ Check MariaDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -210,7 +210,7 @@ Check MariaDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -4,7 +4,7 @@ Check container extraPorts:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -112,7 +112,7 @@ Check container extraPorts are validated:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -222,7 +222,7 @@ Check container extraPorts protocol:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -331,7 +331,7 @@ Check container hybrid cloud ports:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -440,7 +440,7 @@ Check default container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -544,7 +544,7 @@ Check overridden container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -5,7 +5,7 @@ Check allowSingleReplica doesn't alter strategy:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -110,7 +110,7 @@ Check allowSingleReplica set annotations:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -214,7 +214,7 @@ Check replicas unset when autoscaling is enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -318,7 +318,7 @@ Check singleReplicaOnly applied:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -420,7 +420,7 @@ Check singleReplicaOnly ignore replicas value:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check S3 envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -108,7 +108,7 @@ Check S3 envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -210,7 +210,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3
       labels:
         app.kubernetes.io/component: app
@@ -322,7 +322,7 @@ Check S3 secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app
@@ -426,7 +426,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3,test-app-app,test-app-extra-secret-1
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -326,7 +326,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/instrumentation_test.yaml.snap
@@ -36,7 +36,7 @@ adds the .NET injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -172,7 +172,7 @@ adds the Java injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -308,7 +308,7 @@ adds the NodeJS injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -444,7 +444,7 @@ adds the Python injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -576,7 +576,7 @@ adds the env var injection annotation to the Deployment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -719,7 +719,7 @@ sets the container names annotation:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -7,7 +7,7 @@ Check all .job.* values can be set correctly, without overriding from main deplo
         argocd.argoproj.io/hook: PreSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
         argocd.argoproj.io/sync-wave: "-1"
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -65,7 +65,7 @@ Check all overrides/additions from main deployment work if enabled:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -122,7 +122,7 @@ Check default values are correct with minimal configuration:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -4,7 +4,7 @@ Check default container args:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -158,7 +158,7 @@ Check setting skip-auth-regex from extra passed in values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -313,7 +313,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -468,7 +468,7 @@ Check setting skip-auth-regex from overridden health-check values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -622,7 +622,7 @@ Check sidecar present if enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -173,7 +173,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -324,7 +324,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/secret_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_dynamodb_enabled_test.yaml.snap
@@ -1,6 +1,6 @@
 Check DynamoDB Secret Store Override:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
@@ -46,7 +46,7 @@ Check DynamoDB Secret is present for local environment:
     type: Opaque
 Check DynamoDB refresh interval override:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
@@ -74,7 +74,7 @@ Check DynamoDB refresh interval override:
         creationPolicy: Owner
 Check DynamoDB remoteRef key is present:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
@@ -102,7 +102,7 @@ Check DynamoDB remoteRef key is present:
         creationPolicy: Owner
 Check DynamoDB secretPath override:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:

--- a/charts/standard-application-stack/tests/__snapshot__/secret_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_s3_enabled_test.yaml.snap
@@ -1,6 +1,6 @@
 Check S3 Secret Store Override:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
@@ -46,7 +46,7 @@ Check S3 Secret is present for local environment:
     type: Opaque
 Check S3 refresh interval override:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
@@ -74,7 +74,7 @@ Check S3 refresh interval override:
         creationPolicy: Owner
 Check S3 remoteRef key is present:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
@@ -102,7 +102,7 @@ Check S3 remoteRef key is present:
         creationPolicy: Owner
 Check S3 secretPath override:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:

--- a/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
@@ -1,6 +1,6 @@
 ensures ArgoCD annotations are populated:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
@@ -19,7 +19,8 @@ ensures ArgoCD annotations are populated:
       namespace: test-namespace
     spec:
       dataFrom:
-        - key: test-namespace/example-app/app
+        - extract:
+            key: test-namespace/example-app/app
       refreshInterval: 5m0s
       secretStoreRef:
         kind: SecretStore

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -213,7 +213,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -391,7 +391,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-3.61.4
+        helm.sh/chart: standard-application-stack-3.61.5
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app


### PR DESCRIPTION
API version `external-secrets.io/v1alpha1` is deprecated. ArgoCD keeps logging warnings about it. Upgrade to `external-secrets.io/v1beta1`.

https://external-secrets.io/v0.7.2/guides/v1beta1/