### PR TITLE
INFRA-29571: Disable `OTEL_METRICS_EXPORTER` as we don't use it

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v4.1.0] - 2023-03-14
+### Changed
+- Set `OTEL_METRICS_EXPORTER=none` to disable metrics-exporter (not used) and avoids unwanted log warnings
+
 ## [v4.0.0] - 2023-03-09
 ### Changed
 - Configure open-telemetry for apps using env-vars rather than the operator

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.0.0
+version: 4.1.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/helpers/_instrumentation.yaml
+++ b/charts/standard-application-stack/templates/helpers/_instrumentation.yaml
@@ -21,7 +21,7 @@ Generate the otel pod enivonrment vars
 - name: OTEL_EXPORTER_OTLP_ENDPOINT
   value: {{ .exporter.endpoint }}
 - name: OTEL_METRICS_EXPORTER
-  value: otlp
+  value: none
 - name: OTEL_SERVICE_NAME
   value: {{ include "mintel_common.fullname" $ | quote }}
 - name: OTEL_RESOURCE_ATTRIBUTES_POD_IP

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check DynamoDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check DynamoDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -4,7 +4,7 @@ Has a pod template that uses the host network:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
@@ -4,7 +4,7 @@ Check custom python otel extraEnv vars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -55,7 +55,7 @@ Check custom python otel extraEnv vars are added:
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://grafana-agent.monitoring.svc.cluster.local:4317
                 - name: OTEL_METRICS_EXPORTER
-                  value: otlp
+                  value: none
                 - name: OTEL_SERVICE_NAME
                   value: test-app
                 - name: OTEL_RESOURCE_ATTRIBUTES_POD_IP
@@ -127,7 +127,7 @@ Check custom sampler settings:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -178,7 +178,7 @@ Check custom sampler settings:
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://grafana-agent.monitoring.svc.cluster.local:4317
                 - name: OTEL_METRICS_EXPORTER
-                  value: otlp
+                  value: none
                 - name: OTEL_SERVICE_NAME
                   value: test-app
                 - name: OTEL_RESOURCE_ATTRIBUTES_POD_IP
@@ -250,7 +250,7 @@ Check default python otel envars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -301,7 +301,7 @@ Check default python otel envars are added:
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://grafana-agent.monitoring.svc.cluster.local:4317
                 - name: OTEL_METRICS_EXPORTER
-                  value: otlp
+                  value: none
                 - name: OTEL_SERVICE_NAME
                   value: test-app
                 - name: OTEL_RESOURCE_ATTRIBUTES_POD_IP
@@ -371,7 +371,7 @@ Check global otel extraEnv vars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -422,7 +422,7 @@ Check global otel extraEnv vars are added:
                 - name: OTEL_EXPORTER_OTLP_ENDPOINT
                   value: http://grafana-agent.monitoring.svc.cluster.local:4317
                 - name: OTEL_METRICS_EXPORTER
-                  value: otlp
+                  value: none
                 - name: OTEL_SERVICE_NAME
                   value: test-app
                 - name: OTEL_RESOURCE_ATTRIBUTES_POD_IP

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -4,7 +4,7 @@ Check AWS ALB lifecycle rule applied:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -120,7 +120,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -236,7 +236,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -345,7 +345,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -448,7 +448,7 @@ Check lifecycle rules:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check MariaDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check MariaDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check MariaDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -4,7 +4,7 @@ Check container extraPorts:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -111,7 +111,7 @@ Check container extraPorts are validated:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -220,7 +220,7 @@ Check container extraPorts protocol:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -328,7 +328,7 @@ Check container hybrid cloud ports:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -436,7 +436,7 @@ Check default container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -539,7 +539,7 @@ Check overridden container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -5,7 +5,7 @@ Check allowSingleReplica doesn't alter strategy:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -109,7 +109,7 @@ Check allowSingleReplica set annotations:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -212,7 +212,7 @@ Check replicas unset when autoscaling is enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -315,7 +315,7 @@ Check singleReplicaOnly applied:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -416,7 +416,7 @@ Check singleReplicaOnly ignore replicas value:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check S3 envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check S3 envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3
       labels:
         app.kubernetes.io/component: app
@@ -319,7 +319,7 @@ Check S3 secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app
@@ -422,7 +422,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3,test-app-app,test-app-extra-secret-1
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -326,7 +326,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -7,7 +7,7 @@ Check all .job.* values can be set correctly, without overriding from main deplo
         argocd.argoproj.io/hook: PreSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
         argocd.argoproj.io/sync-wave: "-1"
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -65,7 +65,7 @@ Check all overrides/additions from main deployment work if enabled:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -122,7 +122,7 @@ Check default values are correct with minimal configuration:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -4,7 +4,7 @@ Check default container args:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -157,7 +157,7 @@ Check setting skip-auth-regex from extra passed in values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -311,7 +311,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -465,7 +465,7 @@ Check setting skip-auth-regex from overridden health-check values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -618,7 +618,7 @@ Check sidecar present if enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -173,7 +173,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -323,7 +323,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -213,7 +213,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -390,7 +390,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.0.0
+        helm.sh/chart: standard-application-stack-4.1.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/deployment_instrumentation_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_instrumentation_test.yaml
@@ -34,7 +34,7 @@ tests:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://grafana-agent.monitoring.svc.cluster.local:4317
             - name: OTEL_METRICS_EXPORTER
-              value: otlp
+              value: none
             - name: OTEL_SERVICE_NAME
               value: test-app
             - name: OTEL_RESOURCE_ATTRIBUTES_POD_IP
@@ -81,7 +81,7 @@ tests:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://grafana-agent.monitoring.svc.cluster.local:4317
             - name: OTEL_METRICS_EXPORTER
-              value: otlp
+              value: none
             - name: OTEL_SERVICE_NAME
               value: test-app
             - name: OTEL_RESOURCE_ATTRIBUTES_POD_IP
@@ -130,7 +130,7 @@ tests:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://grafana-agent.monitoring.svc.cluster.local:4317
             - name: OTEL_METRICS_EXPORTER
-              value: otlp
+              value: none
             - name: OTEL_SERVICE_NAME
               value: test-app
             - name: OTEL_RESOURCE_ATTRIBUTES_POD_IP
@@ -178,7 +178,7 @@ tests:
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: http://grafana-agent.monitoring.svc.cluster.local:4317
             - name: OTEL_METRICS_EXPORTER
-              value: otlp
+              value: none
             - name: OTEL_SERVICE_NAME
               value: test-app
             - name: OTEL_RESOURCE_ATTRIBUTES_POD_IP


### PR DESCRIPTION
This typically causes apps to attempt to export metrics even though we don't collect this info.

Setting it to `none` avoids this (and avoids the unwanted err message on underlying apps)