### PR TITLE
Added option to support custom env-vars that are only applied to the main app deployment/container.

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v4.3.0] - 2023-04-26
+### Added
+- Added `main.env` option which allows main deployment/container access custom env-vars
+
 ## [v4.2.0] - 2023-03-24
 ### Added
 - Added option to re-map extra secrets key values

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.2.0
+version: 4.3.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -73,7 +73,7 @@ A generic chart to support most common application requirements
 | elasticsearch.enabled | bool | `false` |  |
 | elasticsearch.secretRefreshIntervalOverride | string | `""` | Optional: ExternalSecret refreshInterval override |
 | elasticsearch.secretStoreRefOverride | string | `""` | Optional: override the SecretStoreRef of the ExternalSecret |
-| env | list | `[]` | Optional environment variables injected into the container(s) This will typically inject variabless into all containers |
+| env | list | `[]` | Optional environment variables injected into container(s) NOTE: This is used across multiple deployments. |
 | envFrom | list | `[]` | Optional environment variables injected into the container using envFrom (secrets/configmaps) |
 | eventBus | object | `{"accountId":"","enabled":false,"interactiveApp":false,"maxWorkers":1,"region":"us-east-2","serviceName":""}` | Configure connection to the Event Bus |
 | eventBus.accountId | string | `""` | Required: AWS account ID where the Event Bus is located |
@@ -180,7 +180,7 @@ A generic chart to support most common application requirements
 | localstack.service.type | string | `"ClusterIP"` |  |
 | localstack.startServices | string | `"sns, sqs, s3"` |  |
 | mailhog.enabled | bool | `false` |  |
-| main | object | `{"env":[]}` | Optional environment variables injected into the 'main' container only |
+| main | object | `{"env":[]}` | Optional environment variables injected into the 'main' container of the app-deployment |
 | mariadb.client.enabled | bool | `true` |  |
 | mariadb.client.resources.limits.cpu | string | `"300m"` |  |
 | mariadb.client.resources.limits.memory | string | `"128Mi"` |  |

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 4.2.0](https://img.shields.io/badge/Version-4.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 4.3.0](https://img.shields.io/badge/Version-4.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -73,7 +73,7 @@ A generic chart to support most common application requirements
 | elasticsearch.enabled | bool | `false` |  |
 | elasticsearch.secretRefreshIntervalOverride | string | `""` | Optional: ExternalSecret refreshInterval override |
 | elasticsearch.secretStoreRefOverride | string | `""` | Optional: override the SecretStoreRef of the ExternalSecret |
-| env | list | `[]` | Optional environment variables injected into the container |
+| env | list | `[]` | Optional environment variables injected into the container(s) This will typically inject variabless into all containers |
 | envFrom | list | `[]` | Optional environment variables injected into the container using envFrom (secrets/configmaps) |
 | eventBus | object | `{"accountId":"","enabled":false,"interactiveApp":false,"maxWorkers":1,"region":"us-east-2","serviceName":""}` | Configure connection to the Event Bus |
 | eventBus.accountId | string | `""` | Required: AWS account ID where the Event Bus is located |
@@ -180,6 +180,7 @@ A generic chart to support most common application requirements
 | localstack.service.type | string | `"ClusterIP"` |  |
 | localstack.startServices | string | `"sns, sqs, s3"` |  |
 | mailhog.enabled | bool | `false` |  |
+| main | object | `{"env":[]}` | Optional environment variables injected into the 'main' container only |
 | mariadb.client.enabled | bool | `true` |  |
 | mariadb.client.resources.limits.cpu | string | `"300m"` |  |
 | mariadb.client.resources.limits.memory | string | `"128Mi"` |  |

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -193,6 +193,9 @@ spec:
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with .Values.main.env }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           envFrom:
             {{- if (and .Values.externalSecret .Values.externalSecret.enabled) }}
             {{- if (or (ne .Values.global.clusterEnv "local") (and (eq .Values.global.clusterEnv "local") .Values.externalSecret.localValues)) }}

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check DynamoDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check DynamoDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
@@ -1,0 +1,294 @@
+Check celery does not pull in `main.env` values:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        app.mintel.com/opa-skip-liveness-probe-check.main: "true"
+        app.mintel.com/opa-skip-readiness-probe-check.main: "true"
+        secret.reloader.stakater.com/reload: example-app-app
+      labels:
+        app.kubernetes.io/component: celery
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app-celery
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app-celery
+      name: example-app-celery
+      namespace: test-namespace
+    spec:
+      minReadySeconds: 10
+      replicas: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: celery
+          app.kubernetes.io/name: example-app-celery
+      strategy:
+        rollingUpdate:
+          maxSurge: 15%
+          maxUnavailable: 10%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: celery
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: example-app-celery
+            app.mintel.com/env: qa
+            app.mintel.com/region: ${CLUSTER_REGION}
+            name: example-app-celery
+        spec:
+          containers:
+            - args:
+                - celery
+              command:
+                - /app/docker-entrypoint.sh
+              env:
+                - name: KUBERNETES_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: APP_ENVIRONMENT
+                  value: qa
+                - name: RUNTIME_ENVIRONMENT
+                  value: kubernetes
+                - name: TEST_ENV
+                  value: test-value
+              envFrom:
+                - secretRef:
+                    name: example-app-app
+              image: registry.gitlab.com/test:v0.1.0
+              imagePullPolicy: IfNotPresent
+              name: main
+              ports:
+                - containerPort: 8000
+                  name: http
+              resources:
+                limits: {}
+                requests: {}
+          imagePullSecrets:
+            - name: image-pull-gitlab
+            - name: image-pull-docker-hub
+          securityContext:
+            runAsUser: 1000
+          serviceAccountName: example-app
+          topologySpreadConstraints:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: celery
+                  app.kubernetes.io/name: example-app-celery
+              maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: DoNotSchedule
+Check default env behavior:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        helm.sh/chart: standard-application-stack-4.2.0
+        secret.reloader.stakater.com/reload: example-app-app
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app
+      name: example-app
+      namespace: test-namespace
+    spec:
+      minReadySeconds: 10
+      replicas: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: app
+          app.kubernetes.io/name: example-app
+      strategy:
+        rollingUpdate:
+          maxSurge: 15%
+          maxUnavailable: 10%
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations: null
+          labels:
+            app.kubernetes.io/component: app
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: example-app
+            app.mintel.com/env: qa
+            app.mintel.com/region: ${CLUSTER_REGION}
+            name: example-app
+        spec:
+          containers:
+            - command:
+                - /app/docker-entrypoint.sh
+              env:
+                - name: KUBERNETES_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: APP_ENVIRONMENT
+                  value: qa
+                - name: RUNTIME_ENVIRONMENT
+                  value: kubernetes
+                - name: TEST_ENV
+                  value: test-value
+              envFrom:
+                - secretRef:
+                    name: example-app-app
+              image: registry.gitlab.com/test:v0.1.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: http
+                  scheme: HTTP
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                timeoutSeconds: 1
+              name: main
+              ports:
+                - containerPort: 8000
+                  name: http
+              readinessProbe:
+                httpGet:
+                  path: /readiness
+                  port: http
+                  scheme: HTTP
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                timeoutSeconds: 1
+              resources:
+                limits: {}
+                requests: {}
+              startupProbe:
+                failureThreshold: 60
+                httpGet:
+                  path: /healthz
+                  port: http
+                  scheme: HTTP
+                periodSeconds: 5
+          imagePullSecrets:
+            - name: image-pull-gitlab
+            - name: image-pull-docker-hub
+          securityContext:
+            runAsUser: 1000
+          serviceAccountName: example-app
+          terminationGracePeriodSeconds: 30
+          topologySpreadConstraints:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: app
+                  app.kubernetes.io/name: example-app
+              maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: DoNotSchedule
+          volumes: null
+Check main container combines default env and `main.env` values:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        helm.sh/chart: standard-application-stack-4.2.0
+        secret.reloader.stakater.com/reload: example-app-app
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app
+      name: example-app
+      namespace: test-namespace
+    spec:
+      minReadySeconds: 10
+      replicas: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: app
+          app.kubernetes.io/name: example-app
+      strategy:
+        rollingUpdate:
+          maxSurge: 15%
+          maxUnavailable: 10%
+        type: RollingUpdate
+      template:
+        metadata:
+          annotations: null
+          labels:
+            app.kubernetes.io/component: app
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: example-app
+            app.mintel.com/env: qa
+            app.mintel.com/region: ${CLUSTER_REGION}
+            name: example-app
+        spec:
+          containers:
+            - command:
+                - /app/docker-entrypoint.sh
+              env:
+                - name: KUBERNETES_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: APP_ENVIRONMENT
+                  value: qa
+                - name: RUNTIME_ENVIRONMENT
+                  value: kubernetes
+                - name: TEST_ENV
+                  value: test-value
+                - name: TEST_ENV_IN_MAIN_CONTAINER_ONLY
+                  value: test-value
+              envFrom:
+                - secretRef:
+                    name: example-app-app
+              image: registry.gitlab.com/test:v0.1.0
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: http
+                  scheme: HTTP
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                timeoutSeconds: 1
+              name: main
+              ports:
+                - containerPort: 8000
+                  name: http
+              readinessProbe:
+                httpGet:
+                  path: /readiness
+                  port: http
+                  scheme: HTTP
+                initialDelaySeconds: 0
+                periodSeconds: 10
+                timeoutSeconds: 1
+              resources:
+                limits: {}
+                requests: {}
+              startupProbe:
+                failureThreshold: 60
+                httpGet:
+                  path: /healthz
+                  port: http
+                  scheme: HTTP
+                periodSeconds: 5
+          imagePullSecrets:
+            - name: image-pull-gitlab
+            - name: image-pull-docker-hub
+          securityContext:
+            runAsUser: 1000
+          serviceAccountName: example-app
+          terminationGracePeriodSeconds: 30
+          topologySpreadConstraints:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: app
+                  app.kubernetes.io/name: example-app
+              maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: DoNotSchedule
+          volumes: null

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
@@ -86,7 +86,7 @@ Check default env behavior:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -191,7 +191,7 @@ Check main container combines default env and `main.env` values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -4,7 +4,7 @@ Has a pod template that uses the host network:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
@@ -4,7 +4,7 @@ Check custom python otel extraEnv vars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -127,7 +127,7 @@ Check custom sampler settings:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -250,7 +250,7 @@ Check default python otel envars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -371,7 +371,7 @@ Check global otel extraEnv vars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -4,7 +4,7 @@ Check AWS ALB lifecycle rule applied:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -120,7 +120,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -236,7 +236,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -345,7 +345,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -448,7 +448,7 @@ Check lifecycle rules:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check MariaDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check MariaDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check MariaDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -4,7 +4,7 @@ Check container extraPorts:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -111,7 +111,7 @@ Check container extraPorts are validated:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -220,7 +220,7 @@ Check container extraPorts protocol:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -328,7 +328,7 @@ Check container hybrid cloud ports:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -436,7 +436,7 @@ Check default container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -539,7 +539,7 @@ Check overridden container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -5,7 +5,7 @@ Check allowSingleReplica doesn't alter strategy:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -109,7 +109,7 @@ Check allowSingleReplica set annotations:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -212,7 +212,7 @@ Check replicas unset when autoscaling is enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -315,7 +315,7 @@ Check singleReplicaOnly applied:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -416,7 +416,7 @@ Check singleReplicaOnly ignore replicas value:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check S3 envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check S3 envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3
       labels:
         app.kubernetes.io/component: app
@@ -319,7 +319,7 @@ Check S3 secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app
@@ -422,7 +422,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3,test-app-app,test-app-extra-secret-1
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -326,7 +326,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -7,7 +7,7 @@ Check all .job.* values can be set correctly, without overriding from main deplo
         argocd.argoproj.io/hook: PreSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
         argocd.argoproj.io/sync-wave: "-1"
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -65,7 +65,7 @@ Check all overrides/additions from main deployment work if enabled:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -122,7 +122,7 @@ Check default values are correct with minimal configuration:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -4,7 +4,7 @@ Check default container args:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -157,7 +157,7 @@ Check setting skip-auth-regex from extra passed in values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -311,7 +311,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -465,7 +465,7 @@ Check setting skip-auth-regex from overridden health-check values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -618,7 +618,7 @@ Check sidecar present if enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -173,7 +173,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -323,7 +323,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -213,7 +213,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -390,7 +390,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-4.2.0
+        helm.sh/chart: standard-application-stack-4.3.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/deployment_env_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_env_test.yaml
@@ -1,0 +1,69 @@
+suite: Test Deployment Environment
+templates:
+  - deployment.yaml
+  - deployment-celery.yaml
+release:
+  namespace: test-namespace
+tests:
+  - it: Check default env behavior
+    template: deployment.yaml
+    set:
+      global.clusterEnv: qa
+      env:
+        - name: TEST_ENV
+          value: test-value
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - contains:
+         path: spec.template.spec.containers[0].env
+         content:
+            name: TEST_ENV
+            value: 'test-value'
+  - it: Check main container combines default env and `main.env` values
+    template: deployment.yaml
+    set:
+      global.clusterEnv: qa
+      env:
+        - name: TEST_ENV
+          value: test-value
+      main:
+        env:
+        - name: TEST_ENV_IN_MAIN_CONTAINER_ONLY
+          value: test-value
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - contains:
+         path: spec.template.spec.containers[0].env
+         content:
+            name: TEST_ENV
+            value: 'test-value'
+      - contains:
+         path: spec.template.spec.containers[0].env
+         content:
+            name: TEST_ENV_IN_MAIN_CONTAINER_ONLY
+            value: 'test-value'
+  - it: Check celery does not pull in `main.env` values
+    template: deployment-celery.yaml
+    set:
+      global.clusterEnv: qa
+      celery:
+        enabled: true
+      env:
+      - name: TEST_ENV
+        value: test-value
+      main:
+        env:
+        - name: TEST_ENV_IN_MAIN_CONTAINER_ONLY
+          value: test-value
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - contains:
+         path: spec.template.spec.containers[0].env
+         content:
+            name: TEST_ENV
+            value: 'test-value'
+      - notContains:
+         path: spec.template.spec.containers[0].env
+         content:
+            name: TEST_ENV_IN_MAIN_CONTAINER_ONLY
+            value: 'test-value'

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -92,14 +92,14 @@ args: []
 #   - 'gunicorn'
 #   - '--port=1234'
 
-# -- Optional environment variables injected into the container(s)
-# This will typically inject variabless into all containers
+# -- Optional environment variables injected into container(s)
+# NOTE: This is used across multiple deployments.
 env: []
 # env:
 #   - name: APP_ENVIRONMENT
 #     value: dev
 
-# -- Optional environment variables injected into the 'main' container only
+# -- Optional environment variables injected into the 'main' container of the app-deployment
 main:
   env: []
   # env:

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -92,11 +92,19 @@ args: []
 #   - 'gunicorn'
 #   - '--port=1234'
 
-# -- Optional environment variables injected into the container
+# -- Optional environment variables injected into the container(s)
+# This will typically inject variabless into all containers
 env: []
 # env:
 #   - name: APP_ENVIRONMENT
 #     value: dev
+
+# -- Optional environment variables injected into the 'main' container only
+main:
+  env: []
+  # env:
+  #   - name: CUSTOM_VAR
+  #     value: value
 
 # -- Optional environment variables injected into the container using envFrom (secrets/configmaps)
 envFrom: []


### PR DESCRIPTION
Various deployments are making use of `Values.env` , which means these envs can be duplicated across deployments and potentially containers.

The main examples is where we're using `Values.env` for both celery and the main-app deployment.

This MR introduces `Values.main.env` which is only applied the app-deployment's `main` container. 
