### PR TITLE
Infra 28274: Add cronjob ttl support

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v5.2.0] - 2023-04-26
+### Changed
+- Added `ttlSecondsAfterFinished` to cleanup old Jobs (ttl defaults to 60 seconds)
+
 ## [v5.1.0] - 2023-04-24
 ### Changed
 - Update `OTEL_RESOURCE_ATTRIBUTES` to set container name on main deployment

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.1.0
+version: 5.2.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 5.1.0](https://img.shields.io/badge/Version-5.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.2.0](https://img.shields.io/badge/Version-5.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -61,11 +61,12 @@ A generic chart to support most common application requirements
 | celeryBeat.resources.requests | object | `{}` | The requested resources for the container |
 | command | list | `["/app/docker-entrypoint.sh"]` | Optional command to the container |
 | configMaps | list | `[]` | A list of configuration maps for this application |
-| cronjobs | object | `{"defaults":{"concurrencyPolicy":"Forbid","restartPolicy":"Never","suspend":false},"jobs":[]}` | Define and Configure CronJob's Defaults to same image as main deployment but with defined arguments |
-| cronjobs.defaults | object | `{"concurrencyPolicy":"Forbid","restartPolicy":"Never","suspend":false}` | Defaults for all CronJob's |
+| cronjobs | object | `{"defaults":{"concurrencyPolicy":"Forbid","restartPolicy":"Never","suspend":false,"ttlSecondsAfterFinished":60},"jobs":[]}` | Define and Configure CronJob's Defaults to same image as main deployment but with defined arguments |
+| cronjobs.defaults | object | `{"concurrencyPolicy":"Forbid","restartPolicy":"Never","suspend":false,"ttlSecondsAfterFinished":60}` | Defaults for all CronJob's |
 | cronjobs.defaults.concurrencyPolicy | string | `"Forbid"` | Tells controller how to handle concurrent executions of a CronJob ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec |
 | cronjobs.defaults.restartPolicy | string | `"Never"` | Configure CronJob pod restart Policy ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy |
 | cronjobs.defaults.suspend | bool | `false` | Tells controller to suspend future executions ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec |
+| cronjobs.defaults.ttlSecondsAfterFinished | int | `60` | If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted. ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#cronjob-v1beta1-batch |
 | cronjobs.jobs | list | `[]` | List of Cronjob configurations to be defined |
 | cronjobsOnly | bool | `false` | Only show cronjobs and relevant resources (i.e. if set to `true`, hide the main deployment resource) |
 | dynamodb.enabled | bool | `false` |  |

--- a/charts/standard-application-stack/templates/cronjobs.yaml
+++ b/charts/standard-application-stack/templates/cronjobs.yaml
@@ -20,6 +20,10 @@ spec:
   schedule: {{ quote .schedule }}
   jobTemplate:
     spec:
+      {{- $ttl := (.ttlSecondsAfterFinished | default $.Values.cronjobs.defaults.ttlSecondsAfterFinished) | int }}
+      {{- if (gt $ttl 0) }}
+      ttlSecondsAfterFinished: {{ $ttl}}
+      {{- end }}
       template:
         metadata:
           labels: {{ include "mintel_common.labels" $data | nindent 12 }}

--- a/charts/standard-application-stack/templates/jobs.yaml
+++ b/charts/standard-application-stack/templates/jobs.yaml
@@ -14,6 +14,10 @@ metadata:
     helm.sh/chart: {{ include "mintel_common.chart" $ }}
   namespace: {{ $.Release.Namespace }}
 spec:
+  {{- $ttl := (.ttlSecondsAfterFinished | default 60) | int }}
+  {{- if (gt $ttl 0) }}
+  ttlSecondsAfterFinished: {{ $ttl}}
+  {{- end }}
   template:
     spec:
       {{- include "mintel_common.imagePullSecrets" $ | nindent 6 }}

--- a/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
@@ -1,0 +1,227 @@
+Check CronJob Default Overrides:
+  1: |
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      annotations:
+        helm.sh/chart: standard-application-stack-5.1.0
+      labels:
+        app.kubernetes.io/component: daily
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app-daily
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app-daily
+      name: example-app-daily
+      namespace: test-namespace
+    spec:
+      concurrencyPolicy: Allow
+      jobTemplate:
+        spec:
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: daily
+                app.kubernetes.io/managed-by: Helm
+                app.kubernetes.io/name: example-app-daily
+                app.mintel.com/env: qa
+                app.mintel.com/region: ${CLUSTER_REGION}
+                name: example-app-daily
+            spec:
+              containers:
+                - args:
+                    - -c
+                    - /app/docker-entrypoint.sh
+                  command:
+                    - /bin/sh
+                  env:
+                    - name: KUBERNETES_POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: APP_ENVIRONMENT
+                      value: qa
+                    - name: RUNTIME_ENVIRONMENT
+                      value: kubernetes
+                  envFrom: null
+                  image: registry.gitlab.com/test:v0.1.0
+                  imagePullPolicy: IfNotPresent
+                  name: main
+              imagePullSecrets:
+                - name: image-pull-gitlab
+                - name: image-pull-docker-hub
+              restartPolicy: OnFailure
+              serviceAccountName: example-app
+          ttlSecondsAfterFinished: 120
+      schedule: 0 1 * * *
+      suspend: true
+Check CronJob Defaults:
+  1: |
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      annotations:
+        helm.sh/chart: standard-application-stack-5.1.0
+      labels:
+        app.kubernetes.io/component: daily
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app-daily
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app-daily
+      name: example-app-daily
+      namespace: test-namespace
+    spec:
+      concurrencyPolicy: Forbid
+      jobTemplate:
+        spec:
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: daily
+                app.kubernetes.io/managed-by: Helm
+                app.kubernetes.io/name: example-app-daily
+                app.mintel.com/env: qa
+                app.mintel.com/region: ${CLUSTER_REGION}
+                name: example-app-daily
+            spec:
+              containers:
+                - args:
+                    - -c
+                    - /app/docker-entrypoint.sh
+                  command:
+                    - /bin/sh
+                  env:
+                    - name: KUBERNETES_POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: APP_ENVIRONMENT
+                      value: qa
+                    - name: RUNTIME_ENVIRONMENT
+                      value: kubernetes
+                  envFrom: null
+                  image: registry.gitlab.com/test:v0.1.0
+                  imagePullPolicy: IfNotPresent
+                  name: main
+              imagePullSecrets:
+                - name: image-pull-gitlab
+                - name: image-pull-docker-hub
+              restartPolicy: Never
+              serviceAccountName: example-app
+          ttlSecondsAfterFinished: 60
+      schedule: 0 0 * * *
+      suspend: false
+Check CronJob Job Overrides:
+  1: |
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      annotations:
+        helm.sh/chart: standard-application-stack-5.1.0
+      labels:
+        app.kubernetes.io/component: daily
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app-daily
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app-daily
+      name: example-app-daily
+      namespace: test-namespace
+    spec:
+      concurrencyPolicy: Allow
+      jobTemplate:
+        spec:
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: daily
+                app.kubernetes.io/managed-by: Helm
+                app.kubernetes.io/name: example-app-daily
+                app.mintel.com/env: qa
+                app.mintel.com/region: ${CLUSTER_REGION}
+                name: example-app-daily
+            spec:
+              containers:
+                - args:
+                    - -c
+                    - /app/docker-entrypoint.sh
+                  command:
+                    - /bin/sh
+                  env:
+                    - name: KUBERNETES_POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: APP_ENVIRONMENT
+                      value: qa
+                    - name: RUNTIME_ENVIRONMENT
+                      value: kubernetes
+                  envFrom: null
+                  image: registry.gitlab.com/test:v0.1.0
+                  imagePullPolicy: IfNotPresent
+                  name: main
+              imagePullSecrets:
+                - name: image-pull-gitlab
+                - name: image-pull-docker-hub
+              restartPolicy: OnFailure
+              serviceAccountName: example-app
+          ttlSecondsAfterFinished: 120
+      schedule: 0 1 * * *
+      suspend: true
+Check CronJob ttlSecondsAfterFinished zero value:
+  1: |
+    apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      annotations:
+        helm.sh/chart: standard-application-stack-5.1.0
+      labels:
+        app.kubernetes.io/component: daily
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app-daily
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app-daily
+      name: example-app-daily
+      namespace: test-namespace
+    spec:
+      concurrencyPolicy: Forbid
+      jobTemplate:
+        spec:
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: daily
+                app.kubernetes.io/managed-by: Helm
+                app.kubernetes.io/name: example-app-daily
+                app.mintel.com/env: qa
+                app.mintel.com/region: ${CLUSTER_REGION}
+                name: example-app-daily
+            spec:
+              containers:
+                - args:
+                    - -c
+                    - /app/docker-entrypoint.sh
+                  command:
+                    - /bin/sh
+                  env:
+                    - name: KUBERNETES_POD_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: APP_ENVIRONMENT
+                      value: qa
+                    - name: RUNTIME_ENVIRONMENT
+                      value: kubernetes
+                  envFrom: null
+                  image: registry.gitlab.com/test:v0.1.0
+                  imagePullPolicy: IfNotPresent
+                  name: main
+              imagePullSecrets:
+                - name: image-pull-gitlab
+                - name: image-pull-docker-hub
+              restartPolicy: Never
+              serviceAccountName: example-app
+      schedule: 0 1 * * *
+      suspend: false

--- a/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
@@ -4,7 +4,7 @@ Check CronJob Default Overrides:
     kind: CronJob
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
@@ -61,7 +61,7 @@ Check CronJob Defaults:
     kind: CronJob
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
@@ -118,7 +118,7 @@ Check CronJob Job Overrides:
     kind: CronJob
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
@@ -175,7 +175,7 @@ Check CronJob ttlSecondsAfterFinished zero value:
     kind: CronJob
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check DynamoDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check DynamoDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
@@ -86,7 +86,7 @@ Check default env behavior:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -191,7 +191,7 @@ Check main container combines default env and `main.env` values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -4,7 +4,7 @@ Has a pod template that uses the host network:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
@@ -4,7 +4,7 @@ Check custom python otel extraEnv vars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -127,7 +127,7 @@ Check custom sampler settings:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -250,7 +250,7 @@ Check default python otel envars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -371,7 +371,7 @@ Check global otel extraEnv vars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -4,7 +4,7 @@ Check AWS ALB lifecycle rule applied:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -120,7 +120,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -236,7 +236,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -345,7 +345,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -448,7 +448,7 @@ Check lifecycle rules:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check MariaDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check MariaDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check MariaDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check Memcached envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-memcached
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check Memcached envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-memcached
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check Memcached secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -4,7 +4,7 @@ Check container extraPorts:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -111,7 +111,7 @@ Check container extraPorts are validated:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -220,7 +220,7 @@ Check container extraPorts protocol:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -328,7 +328,7 @@ Check container hybrid cloud ports:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -436,7 +436,7 @@ Check default container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -539,7 +539,7 @@ Check overridden container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -5,7 +5,7 @@ Check allowSingleReplica doesn't alter strategy:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -109,7 +109,7 @@ Check allowSingleReplica set annotations:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -212,7 +212,7 @@ Check replicas unset when autoscaling is enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -315,7 +315,7 @@ Check singleReplicaOnly applied:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -416,7 +416,7 @@ Check singleReplicaOnly ignore replicas value:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check S3 envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check S3 envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3
       labels:
         app.kubernetes.io/component: app
@@ -319,7 +319,7 @@ Check S3 secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app
@@ -422,7 +422,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3,test-app-app,test-app-extra-secret-1
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -326,7 +326,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -7,7 +7,7 @@ Check all .job.* values can be set correctly, without overriding from main deplo
         argocd.argoproj.io/hook: PreSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
         argocd.argoproj.io/sync-wave: "-1"
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -59,13 +59,14 @@ Check all .job.* values can be set correctly, without overriding from main deplo
           securityContext:
             runAsUser: 1001
           serviceAccountName: test-app
+      ttlSecondsAfterFinished: 120
 Check all overrides/additions from main deployment work if enabled:
   1: |
     apiVersion: batch/v1
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -116,13 +117,14 @@ Check all overrides/additions from main deployment work if enabled:
           securityContext:
             runAsUser: 1000
           serviceAccountName: test-app
+      ttlSecondsAfterFinished: 120
 Check default values are correct with minimal configuration:
   1: |
     apiVersion: batch/v1
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -161,3 +163,4 @@ Check default values are correct with minimal configuration:
             - name: image-pull-docker-hub
           restartPolicy: Never
           serviceAccountName: test-app
+      ttlSecondsAfterFinished: 60

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -4,7 +4,7 @@ Check default container args:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -157,7 +157,7 @@ Check setting skip-auth-regex from extra passed in values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -311,7 +311,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -465,7 +465,7 @@ Check setting skip-auth-regex from overridden health-check values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -618,7 +618,7 @@ Check sidecar present if enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -173,7 +173,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -323,7 +323,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -213,7 +213,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -390,7 +390,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.1.0
+        helm.sh/chart: standard-application-stack-5.2.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/cronjob_test.yaml
+++ b/charts/standard-application-stack/tests/cronjob_test.yaml
@@ -1,0 +1,160 @@
+suite: Test Cronjobs
+templates:
+  - cronjobs.yaml
+release:
+  namespace: test-namespace
+tests:
+  - it: Check CronJob Defaults
+    set:
+      global.clusterEnv: qa
+      cronjobsOnly: true
+      cronjobs.jobs:
+        - name: daily
+          image: ""
+          schedule: "0 0 * * *"
+          command: [/bin/sh]
+          args:
+            - "-c"
+            - "/app/docker-entrypoint.sh"
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: example-app-daily
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Forbid
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.restartPolicy
+          value: Never
+      - equal:
+          path: spec.schedule
+          value: 0 0 * * *
+      - equal:
+          path: spec.suspend
+          value: false
+      - equal:
+          path: spec.jobTemplate.spec.ttlSecondsAfterFinished
+          value: 60
+  - it: Check CronJob Default Overrides
+    set:
+      global.clusterEnv: qa
+      cronjobsOnly: true
+      cronjobs.defaults:
+          concurrencyPolicy: Allow
+          suspend: true
+          restartPolicy: OnFailure
+          ttlSecondsAfterFinished: 120
+      cronjobs.jobs:
+        - name: daily
+          schedule: "0 1 * * *"
+          image: ""
+          command: [/bin/sh]
+          args:
+            - "-c"
+            - "/app/docker-entrypoint.sh"
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: example-app-daily
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Allow
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.restartPolicy
+          value: OnFailure
+      - equal:
+          path: spec.schedule
+          value: 0 1 * * *
+      - equal:
+          path: spec.suspend
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.ttlSecondsAfterFinished
+          value: 120
+  - it: Check CronJob Job Overrides
+    set:
+      global.clusterEnv: qa
+      cronjobsOnly: true
+      cronjobs.jobs:
+        - name: daily
+          concurrencyPolicy: Allow
+          suspend: true
+          restartPolicy: OnFailure
+          schedule: "0 1 * * *"
+          ttlSecondsAfterFinished: 120
+          image: ""
+          command: [/bin/sh]
+          args:
+            - "-c"
+            - "/app/docker-entrypoint.sh"
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: example-app-daily
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.concurrencyPolicy
+          value: Allow
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.restartPolicy
+          value: OnFailure
+      - equal:
+          path: spec.schedule
+          value: 0 1 * * *
+      - equal:
+          path: spec.suspend
+          value: true
+      - equal:
+          path: spec.jobTemplate.spec.ttlSecondsAfterFinished
+          value: 120
+  - it: Check CronJob ttlSecondsAfterFinished zero value
+    set:
+      global.clusterEnv: qa
+      cronjobsOnly: true
+      cronjobs.defaults:
+          ttlSecondsAfterFinished: 0
+      cronjobs.jobs:
+        - name: daily
+          schedule: "0 1 * * *"
+          image: ""
+          command: [/bin/sh]
+          args:
+            - "-c"
+            - "/app/docker-entrypoint.sh"
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - isKind:
+          of: CronJob
+      - equal:
+          path: metadata.name
+          value: example-app-daily
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - isNull:
+          path: spec.jobTemplate.spec.ttlSecondsAfterFinished

--- a/charts/standard-application-stack/tests/jobs_test.yaml
+++ b/charts/standard-application-stack/tests/jobs_test.yaml
@@ -34,6 +34,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: registry.example.com/test/image/repo:v0.1.0
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 60
   - it: Check all .job.* values can be set correctly, without overriding from main deployment
     set:
       global.clusterEnv: qa
@@ -48,6 +51,7 @@ tests:
             hookDeletePolicy: HookSucceeded
             syncWave: '-1'
           restartPolicy: OnFailure
+          ttlSecondsAfterFinished: 120
           image: registry.example.com/another/image/repo:anotherTag
           command:
             - echo
@@ -135,6 +139,9 @@ tests:
             requests:
               cpu: 1000m
               memory: 2Gi
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 120
   - it: Check all overrides/additions from main deployment work if enabled
     set:
       global.clusterEnv: qa
@@ -154,6 +161,7 @@ tests:
           includeBaseEnv: true
           includeAppSecret: true
           includeBasePodSecurityContext: true
+          ttlSecondsAfterFinished: 120
           env:
             - name: TEST_VAR_3
               value: baz
@@ -203,3 +211,6 @@ tests:
       - equal:
           path: spec.template.spec.securityContext.runAsUser
           value: 1000
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 120

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -939,19 +939,22 @@ jobs:
   #     # The name of the job. Required.
   # - name: ''
   #   argo:
-  #       # Phase ArgoCD should apply the manifest, such as PreSync, Sync, PostSync.
-  #       # See https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#usage.
+  #     # Phase ArgoCD should apply the manifest, such as PreSync, Sync, PostSync.
+  #     # See https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#usage.
   #     hook: 'Sync'
-  #       # When to delete the hook in an automated fashion, suck as HookSucceeded, HookFailed, etc.
-  #       # See https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#hook-deletion-policies.
+  #     # When to delete the hook in an automated fashion, suck as HookSucceeded, HookFailed, etc.
+  #     # See https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#hook-deletion-policies.
   #     hookDeletePolicy: 'BeforeHookCreation'
-  #       # Order ArgoCD should apply the manifest. Lower values are applied first, and negative values are allowed.
-  #       # See https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/.
+  #     # Order ArgoCD should apply the manifest. Lower values are applied first, and negative values are allowed.
+  #     # See https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/.
   #     syncWave: '0'
-  #     # Whether the pod should be restarted on failure.
-  #     # See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy.
+  #   # Whether the pod should be restarted on failure.
+  #   # See https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy.
   #   restartPolicy: Never
-  #     # Configuration for the job image, command, arguments, environment variables, resources, etc. `resources` is required.
+  #   # If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted.
+  #   # See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#cronjob-v1beta1-batch
+  #   ttlSecondsAfterFinished: 60
+  #   # Configuration for the job image, command, arguments, environment variables, resources, etc. `resources` is required.
   #   image: '${.image.registry + "/" + .image.repository + ":" + .image.tag}'
   #   command:
   #     - ''

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -874,15 +874,21 @@ cronjobsOnly: false
 cronjobs:
   # -- Defaults for all CronJob's
   defaults:
-    # -- Tells controller to suspend future executions
-    # ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec
-    suspend: false
     # -- Tells controller how to handle concurrent executions of a CronJob
     # ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec
     concurrencyPolicy: Forbid
+
     # -- Configure CronJob pod restart Policy
     # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
     restartPolicy: Never
+
+    # -- Tells controller to suspend future executions
+    # ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec
+    suspend: false
+
+    # -- If this field is set, ttlSecondsAfterFinished after the Job finishes, it is eligible to be automatically deleted.
+    # ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#cronjob-v1beta1-batch
+    ttlSecondsAfterFinished: 60
   # -- List of Cronjob configurations to be defined
   jobs:
     []
@@ -891,6 +897,7 @@ cronjobs:
     #   suspend: false
     #   restartPolicy: Never
     #   schedule: "0 0 * * *"
+    #   ttlSecondsAfterFinished: 60
     #   image: ''
     #   command:
     #     - '/bin/sh'


### PR DESCRIPTION
Cleanup old jobs using the new ttl option 

ref: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/

By default this is applied to all cronjobs/jobs with a ttl of `60` seconds.

---

Changes:
- Added support to `.Values.cronjobs` (can be applied using `defaults` or per job)
- Added support to `.Values.jobs`
- Added cronjob tests
- Updated jobs tests

To disable this, the user can set `ttlSecondsAfterFinished: 0`