### PR TITLE
Create no-op release of terraform-cloud chart to trigger chart releaser

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.40.1] - 2023-05-12
+### Changed
+- No-op release to trigger chart releaser action which didn't run for v0.40.0 release
+
 ## [v0.40.0] - 2023-05-10
 ### Added
 - Add `cms-backup` module

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.40.0
+version: 0.40.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 0.39.1](https://img.shields.io/badge/Version-0.39.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.40.1](https://img.shields.io/badge/Version-0.40.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
@@ -10,7 +10,7 @@ IRSA created explicitly:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: test-app-irsa
         app.mintel.com/env: dev
@@ -88,7 +88,7 @@ IRSA created for Dev S3 module workspace:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: test-app-irsa
         app.mintel.com/env: dev
@@ -167,7 +167,7 @@ IRSA created with default (0) syncWave:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "0"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: test-app-irsa
         app.mintel.com/env: dev
@@ -245,7 +245,7 @@ IRSA created with modified syncWave:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-100"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: test-app-irsa
         app.mintel.com/env: dev

--- a/charts/terraform-cloud/tests/__snapshot__/workspace_output_secret_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace_output_secret_test.yaml.snap
@@ -6,7 +6,7 @@ Dev S3 module instance workspace output secret with override:
       annotations:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.mintel.com/env: dev
         app.mintel.com/owner: sre
@@ -34,7 +34,7 @@ Dev S3 module workspace output secret:
       annotations:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.mintel.com/env: dev
         app.mintel.com/owner: sre
@@ -59,7 +59,7 @@ Dev S3 module workspace output secret with override:
       annotations:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.mintel.com/env: dev
         app.mintel.com/owner: sre

--- a/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
@@ -10,7 +10,7 @@ Dev S3 module workspace:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -92,7 +92,7 @@ Dev S3 module workspace - tags:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: test-sqs-sqs
         app.mintel.com/env: dev
@@ -172,7 +172,7 @@ Dev S3 module workspace adds correct env override:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -254,7 +254,7 @@ Dev S3 module workspace name does not repeat mntl-prefix:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -336,7 +336,7 @@ Dev S3 module workspace name override:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -418,7 +418,7 @@ Dev S3 module workspace with default (0) syncWave:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "0"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -500,7 +500,7 @@ Dev S3 module workspace with modified syncWave:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "200"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -582,7 +582,7 @@ Dev S3 module workspace with multiple instances:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: mntl-test-bucket-s3
         app.mintel.com/env: dev
@@ -663,7 +663,7 @@ Dev S3 module workspace with multiple instances:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: mntl-test-bucket-another-s3
         app.mintel.com/env: dev
@@ -745,7 +745,7 @@ Dev S3 module workspace with multiple instances - tags:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: test-instance-one-sqs
         app.mintel.com/env: dev
@@ -823,7 +823,7 @@ Dev S3 module workspace with multiple instances - tags:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: test-instance-two-sqs
         app.mintel.com/env: dev
@@ -903,7 +903,7 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "200"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: mntl-test-bucket-s3
         app.mintel.com/env: dev
@@ -984,7 +984,7 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "300"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: mntl-test-bucket-another-s3
         app.mintel.com/env: dev
@@ -1066,7 +1066,7 @@ Test workspace allow destroy env:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: prod
@@ -1143,7 +1143,7 @@ Test workspace extra annotations:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -1225,7 +1225,7 @@ Test workspace extra annotations override:
         app.mintel.com/terraform-owner: override
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.40.0
+        helm.sh/chart: terraform-cloud-0.40.1
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev


### PR DESCRIPTION
GitHub was facing outages around the time mintel/helm-charts#270 was merged, meaning the releaser action never triggered.