### PR TITLE
[INFRA-27011] add `blackbox.probeScheme` value to standard-application-stack chart

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v5.5.0] - 2023-06-05
+### Added
+- Added `blackbox.probeScheme` value to standard-application-stack chart
+
 ## [v5.4.0] - 2023-05-10
 ### Changed
 - Updated template to use volume claim templates for stateful sets and normal volumes for deployments

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.4.0
+version: 5.5.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 5.4.0](https://img.shields.io/badge/Version-5.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.5.0](https://img.shields.io/badge/Version-5.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -126,7 +126,7 @@ A generic chart to support most common application requirements
 | image.repository | string | `"test"` | Docker repository |
 | image.tag | string | `"v0.1.0"` | Container image tag |
 | imagePullSecrets | list | `[]` | Optional array of imagePullSecrets ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
-| ingress | object | `{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","enabled":true,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"okta":{"authOnUnauthenticated":"authenticate","enabled":false,"extraRedirectPaths":[],"groups":"","ingressName":"","redirectPath":"","users":""},"preStopDelay":{"delaySeconds":15,"enabled":true},"scheme":"internet-facing","targetGroupAttributes":{"deregistration_delay.timeout_seconds":5,"load_balancing.algorithm.type":"least_outstanding_requests"}},"allowFrontendAccess":false,"allowLivenessUrl":false,"allowReadinessUrl":false,"blackbox":{"enabled":true,"probePath":"/external-health-check"},"enabled":false,"extraAnnotations":{},"extraHosts":[],"extraIngresses":[],"setNoCacheHeaders":false,"setXForwardedForHeaders":false,"specificRulesHostsYaml":{},"specificTlsHostsYaml":{},"tls":true}` | Configure the ingress resource that allows you to access the application from public-internet ref: http://kubernetes.io/docs/user-guide/ingress/ |
+| ingress | object | `{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","enabled":true,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"okta":{"authOnUnauthenticated":"authenticate","enabled":false,"extraRedirectPaths":[],"groups":"","ingressName":"","redirectPath":"","users":""},"preStopDelay":{"delaySeconds":15,"enabled":true},"scheme":"internet-facing","targetGroupAttributes":{"deregistration_delay.timeout_seconds":5,"load_balancing.algorithm.type":"least_outstanding_requests"}},"allowFrontendAccess":false,"allowLivenessUrl":false,"allowReadinessUrl":false,"blackbox":{"enabled":true,"probePath":"/external-health-check","probeScheme":"http"},"enabled":false,"extraAnnotations":{},"extraHosts":[],"extraIngresses":[],"setNoCacheHeaders":false,"setXForwardedForHeaders":false,"specificRulesHostsYaml":{},"specificTlsHostsYaml":{},"tls":true}` | Configure the ingress resource that allows you to access the application from public-internet ref: http://kubernetes.io/docs/user-guide/ingress/ |
 | ingress.alb.backendProtocol | string | `"HTTP"` | Application Version (HTTP / HTTPS) |
 | ingress.alb.backendProtocolVersion | string | `"HTTP1"` | Application Protocol Version (HTTP1 / HTTP2 / GRPC) |
 | ingress.alb.healthcheck.healthyThresholdCount | int | `2` | Success threshold |
@@ -148,9 +148,10 @@ A generic chart to support most common application requirements
 | ingress.allowFrontendAccess | bool | `false` | Explicitly set the 'tier: frontend' label on deployments even if ingress is disabled |
 | ingress.allowLivenessUrl | bool | `false` | Set to true to allow the liveness URL through the ingress |
 | ingress.allowReadinessUrl | bool | `false` | Set to true to allow the readiness URL through the ingress |
-| ingress.blackbox | object | `{"enabled":true,"probePath":"/external-health-check"}` | Configures annotations defining blackbox endpoints |
+| ingress.blackbox | object | `{"enabled":true,"probePath":"/external-health-check","probeScheme":"http"}` | Configures annotations defining blackbox endpoints |
 | ingress.blackbox.enabled | bool | `true` | Set to true to tell blackboxes to hit endpoint |
 | ingress.blackbox.probePath | string | `"/external-health-check"` | Endpoint for blackboxes to hit |
+| ingress.blackbox.probeScheme | string | `"http"` | Scheme (http/https) for blackboxes to hit |
 | ingress.enabled | bool | `false` | Set to true to enable ingress record generation |
 | ingress.extraAnnotations | object | `{}` | Additional Ingress annotations For a full list of possible ingress annotations, please see ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md |
 | ingress.extraHosts | list | `[]` | List of extra ingress hosts to setup |

--- a/charts/standard-application-stack/templates/ingress.yaml
+++ b/charts/standard-application-stack/templates/ingress.yaml
@@ -60,6 +60,7 @@ metadata:
     {{- if (and .blackbox .blackbox.enabled) }}
     prometheus.io/probe: "true"
     prometheus.io/probepath: {{ .blackbox.probePath }}
+    prometheus.io/probescheme: {{ .blackbox.probeScheme }}
     {{- end }}
 spec:
   ingressClassName: {{ $ingressClass }}

--- a/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
@@ -4,7 +4,7 @@ Check CronJob Default Overrides:
     kind: CronJob
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
@@ -61,7 +61,7 @@ Check CronJob Defaults:
     kind: CronJob
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
@@ -118,7 +118,7 @@ Check CronJob Job Overrides:
     kind: CronJob
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
@@ -175,7 +175,7 @@ Check CronJob ttlSecondsAfterFinished zero value:
     kind: CronJob
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check DynamoDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check DynamoDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
@@ -86,7 +86,7 @@ Check default env behavior:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -191,7 +191,7 @@ Check main container combines default env and `main.env` values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -4,7 +4,7 @@ Has a pod template that uses the host network:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
@@ -4,7 +4,7 @@ Check custom python otel extraEnv vars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -127,7 +127,7 @@ Check custom sampler settings:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -250,7 +250,7 @@ Check default python otel envars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -371,7 +371,7 @@ Check global otel extraEnv vars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -4,7 +4,7 @@ Check AWS ALB lifecycle rule applied:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -120,7 +120,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -236,7 +236,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -345,7 +345,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -448,7 +448,7 @@ Check lifecycle rules:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check MariaDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check MariaDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check MariaDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check Memcached envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-memcached
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check Memcached envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-memcached
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check Memcached secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -4,7 +4,7 @@ Check container extraPorts:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -111,7 +111,7 @@ Check container extraPorts are validated:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -220,7 +220,7 @@ Check container extraPorts protocol:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -328,7 +328,7 @@ Check container hybrid cloud ports:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -436,7 +436,7 @@ Check default container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -539,7 +539,7 @@ Check overridden container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -5,7 +5,7 @@ Check allowSingleReplica doesn't alter strategy:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -109,7 +109,7 @@ Check allowSingleReplica set annotations:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -212,7 +212,7 @@ Check replicas unset when autoscaling is enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -315,7 +315,7 @@ Check singleReplicaOnly applied:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -416,7 +416,7 @@ Check singleReplicaOnly ignore replicas value:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -4,7 +4,7 @@ Check S3 envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +107,7 @@ Check S3 envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +208,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3
       labels:
         app.kubernetes.io/component: app
@@ -319,7 +319,7 @@ Check S3 secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app
@@ -422,7 +422,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3,test-app-app,test-app-extra-secret-1
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
@@ -4,7 +4,7 @@ Check stateful set is rendered with volumeClaimTemplates:
     kind: StatefulSet
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -333,7 +333,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -22,6 +22,7 @@ Check ALB HTTP2 default settings:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -68,6 +69,7 @@ Check ALB className set by default:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -114,6 +116,7 @@ Check ALB custom health-check port:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -160,6 +163,7 @@ Check ALB default health-check port:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -206,6 +210,7 @@ Check ALB gRPC custom settings:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -252,6 +257,7 @@ Check ALB gRPC default settings:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -298,6 +304,7 @@ Check ALB health-check port with oauthProxy enabled:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -448,6 +455,7 @@ Check HAProxy className set if ALB is disabled:
         ingress.kubernetes.io/rewrite-target: /
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -494,6 +502,7 @@ Check TLS set if ingressTLSSecrets is not empty:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -544,6 +553,7 @@ Check extraHosts:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -600,6 +610,7 @@ Check extraHosts with TLS:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -661,6 +672,7 @@ Check extraHosts with TLS and oauthProxy.ingressHost (different):
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -733,6 +745,7 @@ Check extraHosts with TLS and oauthProxy.ingressHost (same as extra host):
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -795,6 +808,7 @@ Check extraHosts with oauthProxy.ingressHost (different):
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -861,6 +875,7 @@ Check extraHosts with oauthProxy.ingressHost (same as extra host):
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -917,6 +932,7 @@ Check ingress name override:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -963,6 +979,7 @@ Check ingress name suffix setting:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -1009,6 +1026,7 @@ Check no TLS set if ingressTLSSecrets and specificTlsHostsYaml is empty:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -1055,6 +1073,7 @@ Default ingress with path based routing:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -1108,6 +1127,7 @@ allows extraIngresses to override default values:
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -1141,6 +1161,7 @@ allows extraIngresses to override default values:
         ingress.kubernetes.io/rewrite-target: /
         prometheus.io/probe: "true"
         prometheus.io/probepath: /external-health-check
+        prometheus.io/probescheme: http
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -7,7 +7,7 @@ Check all .job.* values can be set correctly, without overriding from main deplo
         argocd.argoproj.io/hook: PreSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
         argocd.argoproj.io/sync-wave: "-1"
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -66,7 +66,7 @@ Check all overrides/additions from main deployment work if enabled:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -124,7 +124,7 @@ Check default values are correct with minimal configuration:
     kind: Job
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -4,7 +4,7 @@ Check default container args:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -157,7 +157,7 @@ Check setting skip-auth-regex from extra passed in values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -311,7 +311,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -465,7 +465,7 @@ Check setting skip-auth-regex from overridden health-check values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -618,7 +618,7 @@ Check sidecar present if enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -173,7 +173,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -323,7 +323,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -213,7 +213,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -318,29 +318,6 @@ Check combined template defaults:
               whenUnsatisfiable: DoNotSchedule
           volumes: null
   2: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations: null
-      labels:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/env: prod
-        app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
-      namespace: test-namespace
-    spec:
-      ports:
-        - name: main-http
-          port: 8000
-          targetPort: 8000
-      selector:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/name: test-app
-      type: ClusterIP
-  3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -384,13 +361,36 @@ Check combined template defaults:
       targetLabels:
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+  3: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: null
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: test-app
+        app.mintel.com/env: prod
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: test-app
+      name: test-app
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: main-http
+          port: 8000
+          targetPort: 8000
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: test-app
+      type: ClusterIP
 Check combined template with extra ports and monitors:
   1: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.4.0
+        helm.sh/chart: standard-application-stack-5.5.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -499,35 +499,6 @@ Check combined template with extra ports and monitors:
               whenUnsatisfiable: DoNotSchedule
           volumes: null
   2: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations: null
-      labels:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/env: prod
-        app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
-      namespace: test-namespace
-    spec:
-      ports:
-        - name: main-http
-          port: 8000
-          targetPort: 8000
-        - name: main-metrics-2
-          port: 9002
-          targetPort: 9002
-        - name: main-metrics-3
-          port: 9003
-          targetPort: 9003
-      selector:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/name: test-app
-      type: ClusterIP
-  3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -571,7 +542,7 @@ Check combined template with extra ports and monitors:
       targetLabels:
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  4: |
+  3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -615,7 +586,7 @@ Check combined template with extra ports and monitors:
       targetLabels:
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  5: |
+  4: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -659,6 +630,35 @@ Check combined template with extra ports and monitors:
       targetLabels:
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+  5: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: null
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: test-app
+        app.mintel.com/env: prod
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: test-app
+      name: test-app
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: main-http
+          port: 8000
+          targetPort: 8000
+        - name: main-metrics-2
+          port: 9002
+          targetPort: 9002
+        - name: main-metrics-3
+          port: 9003
+          targetPort: 9003
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: test-app
+      type: ClusterIP
 Check default endpoints:
   1: |
     apiVersion: monitoring.coreos.com/v1

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -531,6 +531,8 @@ ingress:
     enabled: true
     # -- Endpoint for blackboxes to hit
     probePath: /external-health-check
+    # -- Scheme (http/https) for blackboxes to hit
+    probeScheme: http
   # -- Optional ingress Rules Hosts Yaml that doesn't fit standard pattern
   specificRulesHostsYaml: {}
   # -- Optional ingress Tls Hosts Yaml that doesn't fit standard pattern


### PR DESCRIPTION
## [v5.5.0] - 2023-06-05
### Added
- Added `blackbox.probeScheme` value to standard-application-stack chart

This will be used to specify an https scheme for some blackbox probe endpoints