### PR TITLE
Remove chart version annotation

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-helm 3.7.0
+helm 3.7.2
 helm-docs 1.7.0

--- a/charts/basic-config/CHANGELOG.md
+++ b/charts/basic-config/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.3.0] - 2023-06-28
+### Removed
+- Remove `helm.sh/chart` annotation from all remaining manifests.
+
 ## [v0.2.3] - 2023-02-28
 ### Fixed
 - Upgrade from deprecated external-secrets API version

--- a/charts/basic-config/Chart.yaml
+++ b/charts/basic-config/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.3.0

--- a/charts/basic-config/README.md
+++ b/charts/basic-config/README.md
@@ -1,6 +1,6 @@
 # basic-config
 
-![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for defining basic k8s configuration res
 

--- a/charts/basic-config/templates/_helpers.tpl
+++ b/charts/basic-config/templates/_helpers.tpl
@@ -23,6 +23,7 @@ Create chart name and version as used by the chart label.
 
 {{/* Common Annotations */}}
 {{- define "mintel_common.commonAnnotations" -}}
+app.mintel.com/placeholder: placeholder
 {{- end -}}
 
 {{/* Common labels */}}

--- a/charts/basic-config/templates/_helpers.tpl
+++ b/charts/basic-config/templates/_helpers.tpl
@@ -23,7 +23,6 @@ Create chart name and version as used by the chart label.
 
 {{/* Common Annotations */}}
 {{- define "mintel_common.commonAnnotations" -}}
-helm.sh/chart: {{ include "mintel_common.chart" . }}
 {{- end -}}
 
 {{/* Common labels */}}

--- a/charts/basic-config/tests/__snapshot__/configmaps_test.yaml.snap
+++ b/charts/basic-config/tests/__snapshot__/configmaps_test.yaml.snap
@@ -5,7 +5,7 @@ Empty configmap:
     kind: ConfigMap
     metadata:
       annotations:
-        helm.sh/chart: basic-config-0.2.3
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: local
@@ -25,7 +25,7 @@ Mixed singleline and  multiline data entries:
     kind: ConfigMap
     metadata:
       annotations:
-        helm.sh/chart: basic-config-0.2.3
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: local
@@ -44,7 +44,7 @@ Single multiline data entry:
     kind: ConfigMap
     metadata:
       annotations:
-        helm.sh/chart: basic-config-0.2.3
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: local
@@ -60,7 +60,7 @@ Single singleline data entry:
     kind: ConfigMap
     metadata:
       annotations:
-        helm.sh/chart: basic-config-0.2.3
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: local

--- a/charts/basic-config/tests/__snapshot__/network-policy-hybrid-consul_test.yaml.snap
+++ b/charts/basic-config/tests/__snapshot__/network-policy-hybrid-consul_test.yaml.snap
@@ -4,7 +4,7 @@ Renders hybrid consul network policy:
     kind: NetworkPolicy
     metadata:
       annotations:
-        helm.sh/chart: basic-config-0.2.3
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: local

--- a/charts/basic-config/tests/__snapshot__/secrets_test.yaml.snap
+++ b/charts/basic-config/tests/__snapshot__/secrets_test.yaml.snap
@@ -4,8 +4,8 @@ Check renders a single external secret:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: qa
@@ -29,8 +29,8 @@ Check renders a single external secret with no overrides:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: qa
@@ -54,8 +54,8 @@ Check renders multiple external secrets:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: qa
@@ -78,8 +78,8 @@ Check renders multiple external secrets:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: qa
@@ -103,8 +103,8 @@ Check secret name override:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: qa
@@ -128,8 +128,8 @@ Check secret path override:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-        helm.sh/chart: basic-config-0.2.3
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: qa

--- a/charts/basic-config/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/basic-config/tests/__snapshot__/service_test.yaml.snap
@@ -4,7 +4,7 @@ Renders headless service:
     kind: Service
     metadata:
       annotations:
-        helm.sh/chart: basic-config-0.2.3
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/managed-by: Helm
         app.mintel.com/env: local

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v5.7.0] - 2023-06-28
+### Removed
+- Remove `helm.sh/chart` annotation from all remaining manifests.
+
 ## [v5.6.0] - 2023-06-08
 ### Changed
 - Changed `blackbox.probeScheme` default value from `http` to `https`

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.6.0
+version: 5.7.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 5.6.0](https://img.shields.io/badge/Version-5.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.7.0](https://img.shields.io/badge/Version-5.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -41,6 +41,7 @@ matchExpressions:
 
 {{/* Common Annotations */}}
 {{- define "mintel_common.commonAnnotations" -}}
+app.mintel.com/placeholder: placeholder
 {{- end -}}
 
 {{/* Set up Argo annotations based on argo values block */}}

--- a/charts/standard-application-stack/templates/cronjobs.yaml
+++ b/charts/standard-application-stack/templates/cronjobs.yaml
@@ -8,7 +8,6 @@ metadata:
   labels: {{ include "mintel_common.labels" $data | nindent 4 }}
   annotations:
     {{- include "mintel_common.commonAnnotations" $ | nindent 4 }}
-    helm.sh/chart: {{ include "mintel_common.chart" $ }}
   namespace: {{ $.Release.Namespace }}
 spec:
   concurrencyPolicy: {{ .concurrencyPolicy | default $.Values.cronjobs.defaults.concurrencyPolicy }}

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -12,7 +12,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- include "mintel_common.commonAnnotations" . | nindent 4 }}
-    helm.sh/chart: {{ include "mintel_common.chart" . }}
     {{- if (and .Values.liveness (not .Values.liveness.enabled)) }}
     app.mintel.com/opa-skip-liveness-probe-check.main: "true"
     {{- end }}

--- a/charts/standard-application-stack/templates/jobs.yaml
+++ b/charts/standard-application-stack/templates/jobs.yaml
@@ -11,7 +11,6 @@ metadata:
     {{ if .argo }}
     {{ include "mintel_common.argoAnnotations" .argo | nindent 4 }}
     {{ end }}
-    helm.sh/chart: {{ include "mintel_common.chart" $ }}
   namespace: {{ $.Release.Namespace }}
 spec:
   {{- $ttl := (.ttlSecondsAfterFinished | default 60) | int }}

--- a/charts/standard-application-stack/tests/__snapshot__/configmaps_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/configmaps_test.yaml.snap
@@ -4,7 +4,8 @@ Empty configmap:
     data: null
     kind: ConfigMap
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: config
         app.kubernetes.io/managed-by: Helm
@@ -25,7 +26,8 @@ Mixed singleline and  multiline data entries:
       test2: even more test data
     kind: ConfigMap
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: config
         app.kubernetes.io/managed-by: Helm
@@ -45,7 +47,8 @@ Single multiline data entry:
         test data line 3
     kind: ConfigMap
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: config
         app.kubernetes.io/managed-by: Helm
@@ -62,7 +65,8 @@ Single singleline data entry:
       test1: test-data
     kind: ConfigMap
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: config
         app.kubernetes.io/managed-by: Helm
@@ -79,6 +83,7 @@ ensures ArgoCD annotations are populated:
     kind: ConfigMap
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/hook: PreSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
         argocd.argoproj.io/sync-wave: "-1"

--- a/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
@@ -3,8 +3,7 @@ Check CronJob Default Overrides:
     apiVersion: batch/v1
     kind: CronJob
     metadata:
-      annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
+      annotations: null
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
@@ -60,8 +59,7 @@ Check CronJob Defaults:
     apiVersion: batch/v1
     kind: CronJob
     metadata:
-      annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
+      annotations: null
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
@@ -117,8 +115,7 @@ Check CronJob Job Overrides:
     apiVersion: batch/v1
     kind: CronJob
     metadata:
-      annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
+      annotations: null
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
@@ -174,8 +171,7 @@ Check CronJob ttlSecondsAfterFinished zero value:
     apiVersion: batch/v1
     kind: CronJob
     metadata:
-      annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
+      annotations: null
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
@@ -3,7 +3,8 @@ Check CronJob Default Overrides:
     apiVersion: batch/v1
     kind: CronJob
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
@@ -59,7 +60,8 @@ Check CronJob Defaults:
     apiVersion: batch/v1
     kind: CronJob
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
@@ -115,7 +117,8 @@ Check CronJob Job Overrides:
     apiVersion: batch/v1
     kind: CronJob
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
@@ -171,7 +174,8 @@ Check CronJob ttlSecondsAfterFinished zero value:
     apiVersion: batch/v1
     kind: CronJob
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -4,6 +4,7 @@ Check DynamoDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -106,6 +107,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -206,6 +208,7 @@ Check DynamoDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -4,7 +4,6 @@ Check DynamoDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +106,6 @@ Check DynamoDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-dynamodb
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +206,6 @@ Check DynamoDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
@@ -86,7 +86,6 @@ Check default env behavior:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -191,7 +190,6 @@ Check main container combines default env and `main.env` values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
@@ -6,6 +6,7 @@ Check celery does not pull in `main.env` values:
       annotations:
         app.mintel.com/opa-skip-liveness-probe-check.main: "true"
         app.mintel.com/opa-skip-readiness-probe-check.main: "true"
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: celery
@@ -86,6 +87,7 @@ Check default env behavior:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -190,6 +192,7 @@ Check main container combines default env and `main.env` values:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -4,7 +4,6 @@ Has a pod template that uses the host network:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -4,6 +4,7 @@ Has a pod template that uses the host network:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
@@ -4,7 +4,6 @@ Check custom python otel extraEnv vars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -127,7 +126,6 @@ Check custom sampler settings:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -250,7 +248,6 @@ Check default python otel envars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -371,7 +368,6 @@ Check global otel extraEnv vars are added:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
@@ -4,6 +4,7 @@ Check custom python otel extraEnv vars are added:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -126,6 +127,7 @@ Check custom sampler settings:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -248,6 +250,7 @@ Check default python otel envars are added:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -368,6 +371,7 @@ Check global otel extraEnv vars are added:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -4,7 +4,6 @@ Check AWS ALB lifecycle rule applied:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -120,7 +119,6 @@ Check AWS ALB lifecycle rules applied with custom delay:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -236,7 +234,6 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -345,7 +342,6 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -448,7 +444,6 @@ Check lifecycle rules:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -4,6 +4,7 @@ Check AWS ALB lifecycle rule applied:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -119,6 +120,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -234,6 +236,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -342,6 +345,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -444,6 +448,7 @@ Check lifecycle rules:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -4,7 +4,6 @@ Check MariaDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +106,6 @@ Check MariaDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +206,6 @@ Check MariaDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -4,6 +4,7 @@ Check MariaDB envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -106,6 +107,7 @@ Check MariaDB envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-mariadb
       labels:
         app.kubernetes.io/component: app
@@ -206,6 +208,7 @@ Check MariaDB secretName Override:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
@@ -4,7 +4,6 @@ Check Memcached envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-memcached
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +106,6 @@ Check Memcached envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-memcached
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +206,6 @@ Check Memcached secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
@@ -4,6 +4,7 @@ Check Memcached envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-memcached
       labels:
         app.kubernetes.io/component: app
@@ -106,6 +107,7 @@ Check Memcached envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-memcached
       labels:
         app.kubernetes.io/component: app
@@ -206,6 +208,7 @@ Check Memcached secretName Override:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -4,6 +4,7 @@ Check container extraPorts:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -110,6 +111,7 @@ Check container extraPorts are validated:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -218,6 +220,7 @@ Check container extraPorts protocol:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -325,6 +328,7 @@ Check container hybrid cloud ports:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -432,6 +436,7 @@ Check default container main port:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -534,6 +539,7 @@ Check overridden container main port:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -4,7 +4,6 @@ Check container extraPorts:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -111,7 +110,6 @@ Check container extraPorts are validated:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -220,7 +218,6 @@ Check container extraPorts protocol:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -328,7 +325,6 @@ Check container hybrid cloud ports:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -436,7 +432,6 @@ Check default container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -539,7 +534,6 @@ Check overridden container main port:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -5,6 +5,7 @@ Check allowSingleReplica doesn't alter strategy:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -108,6 +109,7 @@ Check allowSingleReplica set annotations:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -210,6 +212,7 @@ Check replicas unset when autoscaling is enabled:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -312,6 +315,7 @@ Check singleReplicaOnly applied:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -412,6 +416,7 @@ Check singleReplicaOnly ignore replicas value:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -5,7 +5,6 @@ Check allowSingleReplica doesn't alter strategy:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -109,7 +108,6 @@ Check allowSingleReplica set annotations:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -212,7 +210,6 @@ Check replicas unset when autoscaling is enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -315,7 +312,6 @@ Check singleReplicaOnly applied:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -416,7 +412,6 @@ Check singleReplicaOnly ignore replicas value:
     metadata:
       annotations:
         app.mintel.com/opa-allow-single-replica: "true"
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -4,6 +4,7 @@ Check S3 envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -106,6 +107,7 @@ Check S3 envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -206,6 +208,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3
       labels:
         app.kubernetes.io/component: app
@@ -316,6 +319,7 @@ Check S3 secretName Override:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app
@@ -418,6 +422,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3,test-app-app,test-app-extra-secret-1
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -4,7 +4,6 @@ Check S3 envfrom secretRef is present:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -107,7 +106,6 @@ Check S3 envfrom secretRef is present for local environment:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-s3
       labels:
         app.kubernetes.io/component: app
@@ -208,7 +206,6 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3
       labels:
         app.kubernetes.io/component: app
@@ -319,7 +316,6 @@ Check S3 secretName Override:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: overrideName
       labels:
         app.kubernetes.io/component: app
@@ -422,7 +418,6 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: mntl-test-bucket-another-s3,mntl-test-bucket-s3,test-app-app,test-app-extra-secret-1
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
@@ -4,6 +4,7 @@ Check stateful set is rendered with volumeClaimTemplates:
     kind: StatefulSet
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
@@ -4,7 +4,6 @@ Check stateful set is rendered with volumeClaimTemplates:
     kind: StatefulSet
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -333,7 +333,6 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -18,6 +18,7 @@ Check ALB HTTP2 default settings:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: null
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -65,6 +66,7 @@ Check ALB className set by default:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: null
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -112,6 +114,7 @@ Check ALB custom health-check port:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: null
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -159,6 +162,7 @@ Check ALB default health-check port:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: null
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -206,6 +210,7 @@ Check ALB gRPC custom settings:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: null
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -253,6 +258,7 @@ Check ALB gRPC default settings:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: null
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -300,6 +306,7 @@ Check ALB health-check port with oauthProxy enabled:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: null
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -333,6 +340,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-app
       labels:
         app.kubernetes.io/component: app
@@ -448,6 +456,7 @@ Check HAProxy className set if ALB is disabled:
     kind: Ingress
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         ingress.kubernetes.io/config-backend: |
           acl k8s-monitoring-endpoints path /healthz /metrics /readiness
           http-request deny if k8s-monitoring-endpoints
@@ -497,6 +506,7 @@ Check TLS set if ingressTLSSecrets is not empty:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: test-app.example.org
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -548,6 +558,7 @@ Check extraHosts:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: test.default.com
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -605,6 +616,7 @@ Check extraHosts with TLS:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: test.default.com
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -667,6 +679,7 @@ Check extraHosts with TLS and oauthProxy.ingressHost (different):
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: test.default.com
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -740,6 +753,7 @@ Check extraHosts with TLS and oauthProxy.ingressHost (same as extra host):
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: test.default.com
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -803,6 +817,7 @@ Check extraHosts with oauthProxy.ingressHost (different):
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: test.default.com
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -870,6 +885,7 @@ Check extraHosts with oauthProxy.ingressHost (same as extra host):
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: test.default.com
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -927,6 +943,7 @@ Check ingress name override:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: null
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -974,6 +991,7 @@ Check ingress name suffix setting:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: null
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -1021,6 +1039,7 @@ Check no TLS set if ingressTLSSecrets and specificTlsHostsYaml is empty:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: test-app.example.org
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -1068,6 +1087,7 @@ Default ingress with path based routing:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: null
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -1122,6 +1142,7 @@ allows extraIngresses to override default values:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: media.mintel.com
         external-dns.alpha.kubernetes.io/ttl: "60"
         prometheus.io/probe: "true"
@@ -1154,6 +1175,7 @@ allows extraIngresses to override default values:
     kind: Ingress
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         ingress.kubernetes.io/config-backend: |
           acl k8s-monitoring-endpoints path /healthz /metrics /readiness
           http-request deny if k8s-monitoring-endpoints

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -7,7 +7,6 @@ Check all .job.* values can be set correctly, without overriding from main deplo
         argocd.argoproj.io/hook: PreSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
         argocd.argoproj.io/sync-wave: "-1"
-        helm.sh/chart: standard-application-stack-5.6.0
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -65,8 +64,7 @@ Check all overrides/additions from main deployment work if enabled:
     apiVersion: batch/v1
     kind: Job
     metadata:
-      annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
+      annotations: null
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -123,8 +121,7 @@ Check default values are correct with minimal configuration:
     apiVersion: batch/v1
     kind: Job
     metadata:
-      annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
+      annotations: null
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -4,6 +4,7 @@ Check all .job.* values can be set correctly, without overriding from main deplo
     kind: Job
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/hook: PreSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
         argocd.argoproj.io/sync-wave: "-1"
@@ -64,7 +65,8 @@ Check all overrides/additions from main deployment work if enabled:
     apiVersion: batch/v1
     kind: Job
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
@@ -121,7 +123,8 @@ Check default values are correct with minimal configuration:
     apiVersion: batch/v1
     kind: Job
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/networkpolicy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/networkpolicy_test.yaml.snap
@@ -3,7 +3,8 @@ Check ALB NetworkPolicy created if enabled:
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -33,7 +34,8 @@ Check ALB NetworkPolicy created if internal alb selected:
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -63,7 +65,8 @@ Check ALB NetworkPolicy ports are unique:
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -93,7 +96,8 @@ Check ALB NetworkPolicy ports set for default conatiner:
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -123,7 +127,8 @@ Check ALB NetworkPolicy ports set with oauth2proxy:
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -153,7 +158,8 @@ Check ALB NetworkPolicy ports set with oauth2proxy and healthcheck:
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -4,6 +4,7 @@ Check default container args:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -156,6 +157,7 @@ Check setting skip-auth-regex from extra passed in values:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -309,6 +311,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -462,6 +465,7 @@ Check setting skip-auth-regex from overridden health-check values:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -614,6 +618,7 @@ Check sidecar present if enabled:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -4,7 +4,6 @@ Check default container args:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -157,7 +156,6 @@ Check setting skip-auth-regex from extra passed in values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -311,7 +309,6 @@ Check setting skip-auth-regex from extra passed in values when they already cont
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -465,7 +462,6 @@ Check setting skip-auth-regex from overridden health-check values:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app
@@ -618,7 +614,6 @@ Check sidecar present if enabled:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app,test-app-oauth
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/opensearch_aws_es_proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/opensearch_aws_es_proxy_test.yaml.snap
@@ -18,6 +18,7 @@ Check awsEsProxy Ingress is created if enabled:
         alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
         alb.ingress.kubernetes.io/target-type: ip
         alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
         external-dns.alpha.kubernetes.io/hostname: null
         external-dns.alpha.kubernetes.io/ttl: "60"
       labels:
@@ -47,7 +48,8 @@ Check awsEsProxy NetworkPolicy is created if enabled:
     apiVersion: networking.k8s.io/v1
     kind: NetworkPolicy
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -77,7 +79,8 @@ Check awsEsProxy aws-load-balancer-controller okta role binding is created if en
     apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -100,7 +103,8 @@ Check awsEsProxy aws-load-balancer-controller okta role is created if enabled:
     apiVersion: rbac.authorization.k8s.io/v1
     kind: Role
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -128,6 +132,7 @@ Check awsEsProxy deployment is created if enabled:
         app.mintel.com/opa-allow-single-replica: "true"
         app.mintel.com/opa-skip-readiness-probe-check.main: "true"
         app.mintel.com/opa-skip-security-context-check: "true"
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: example-app-opensearch
       labels:
         app.kubernetes.io/component: aws-es-proxy
@@ -211,7 +216,8 @@ Check awsEsProxy service is created if enabled:
     apiVersion: v1
     kind: Service
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: aws-es-proxy
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/pdb_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pdb_test.yaml.snap
@@ -3,7 +3,8 @@ Creates a PDB when autoscaling is disabled and autoscaling.minReplicaCount is se
     apiVersion: policy/v1
     kind: PodDisruptionBudget
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -24,7 +25,8 @@ Creates a PDB when replicas > 1:
     apiVersion: policy/v1
     kind: PodDisruptionBudget
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -173,7 +173,6 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -323,7 +322,6 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -4,6 +4,7 @@ Check additional PodMonitor resources:
     kind: PodMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -44,6 +45,7 @@ Check additional PodMonitor resources:
     kind: PodMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: metrics-2
@@ -84,6 +86,7 @@ Check additional PodMonitor resources:
     kind: PodMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: metrics-3
@@ -125,6 +128,7 @@ Check basic-auth:
     kind: PodMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -173,6 +177,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -281,6 +286,7 @@ Check combined template defaults:
     kind: PodMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -322,6 +328,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -434,6 +441,7 @@ Check combined template with extra ports and monitors:
     kind: PodMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -474,6 +482,7 @@ Check combined template with extra ports and monitors:
     kind: PodMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: metrics-2
@@ -514,6 +523,7 @@ Check combined template with extra ports and monitors:
     kind: PodMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: metrics-3
@@ -555,6 +565,7 @@ Check default endpoints:
     kind: PodMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -596,6 +607,7 @@ Check default targetLabels:
     kind: PodMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -637,6 +649,7 @@ Check metric overrides:
     kind: PodMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -678,6 +691,7 @@ Check name, namespace and labels:
     kind: PodMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/secret_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_dynamodb_enabled_test.yaml.snap
@@ -4,6 +4,7 @@ Check DynamoDB Secret Store Override:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -33,7 +34,8 @@ Check DynamoDB Secret is present for local environment:
       DYNAMODB_TABLE_NAME: dGVzdC1hcHAtZHluYW1vZGI=
     kind: Secret
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -50,6 +52,7 @@ Check DynamoDB refresh interval override:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -78,6 +81,7 @@ Check DynamoDB remoteRef key is present:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -106,6 +110,7 @@ Check DynamoDB secretPath override:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/secret_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_s3_enabled_test.yaml.snap
@@ -4,6 +4,7 @@ Check S3 Secret Store Override:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -33,7 +34,8 @@ Check S3 Secret is present for local environment:
       BUCKET_NAME: dGVzdC1hcHAtczM=
     kind: Secret
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -50,6 +52,7 @@ Check S3 refresh interval override:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -78,6 +81,7 @@ Check S3 remoteRef key is present:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -106,6 +110,7 @@ Check S3 secretPath override:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
@@ -4,6 +4,7 @@ Extra secrets with output secret map:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: extra-secret
@@ -32,6 +33,7 @@ ensures ArgoCD annotations are populated:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/hook: PreSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true

--- a/charts/standard-application-stack/tests/__snapshot__/service_account_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_account_test.yaml.snap
@@ -5,6 +5,7 @@ ensures annotations are populated:
     kind: ServiceAccount
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/hook: PreSync
         argocd.argoproj.io/hook-delete-policy: HookSucceeded
         argocd.argoproj.io/sync-wave: "-1"

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -3,7 +3,8 @@ Check Service defaults:
     apiVersion: v1
     kind: Service
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -28,6 +29,7 @@ Check additional ServiceMonitor resources:
     kind: ServiceMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -72,6 +74,7 @@ Check additional ServiceMonitor resources:
     kind: ServiceMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: metrics-2
@@ -116,6 +119,7 @@ Check additional ServiceMonitor resources:
     kind: ServiceMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: metrics-3
@@ -161,6 +165,7 @@ Check basic-auth:
     kind: ServiceMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -213,6 +218,7 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -320,7 +326,8 @@ Check combined template defaults:
     apiVersion: v1
     kind: Service
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -344,6 +351,7 @@ Check combined template defaults:
     kind: ServiceMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -389,6 +397,7 @@ Check combined template with extra ports and monitors:
     kind: Deployment
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -500,7 +509,8 @@ Check combined template with extra ports and monitors:
     apiVersion: v1
     kind: Service
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -530,6 +540,7 @@ Check combined template with extra ports and monitors:
     kind: ServiceMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -574,6 +585,7 @@ Check combined template with extra ports and monitors:
     kind: ServiceMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: metrics-2
@@ -618,6 +630,7 @@ Check combined template with extra ports and monitors:
     kind: ServiceMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: metrics-3
@@ -663,6 +676,7 @@ Check default endpoints:
     kind: ServiceMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -708,6 +722,7 @@ Check default targetLabels:
     kind: ServiceMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -753,6 +768,7 @@ Check metric overrides:
     kind: ServiceMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
@@ -798,6 +814,7 @@ Check name, namespace and labels:
     kind: ServiceMonitor
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -213,7 +213,6 @@ Check combined template defaults:
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -318,6 +317,29 @@ Check combined template defaults:
               whenUnsatisfiable: DoNotSchedule
           volumes: null
   2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: null
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: test-app
+        app.mintel.com/env: prod
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: test-app
+      name: test-app
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: main-http
+          port: 8000
+          targetPort: 8000
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: test-app
+      type: ClusterIP
+  3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -361,36 +383,12 @@ Check combined template defaults:
       targetLabels:
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  3: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations: null
-      labels:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/env: prod
-        app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
-      namespace: test-namespace
-    spec:
-      ports:
-        - name: main-http
-          port: 8000
-          targetPort: 8000
-      selector:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/name: test-app
-      type: ClusterIP
 Check combined template with extra ports and monitors:
   1: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
       annotations:
-        helm.sh/chart: standard-application-stack-5.6.0
         secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
@@ -499,6 +497,35 @@ Check combined template with extra ports and monitors:
               whenUnsatisfiable: DoNotSchedule
           volumes: null
   2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations: null
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: test-app
+        app.mintel.com/env: prod
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: test-app
+      name: test-app
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: main-http
+          port: 8000
+          targetPort: 8000
+        - name: main-metrics-2
+          port: 9002
+          targetPort: 9002
+        - name: main-metrics-3
+          port: 9003
+          targetPort: 9003
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: test-app
+      type: ClusterIP
+  3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -542,7 +569,7 @@ Check combined template with extra ports and monitors:
       targetLabels:
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  3: |
+  4: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -586,7 +613,7 @@ Check combined template with extra ports and monitors:
       targetLabels:
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  4: |
+  5: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -630,35 +657,6 @@ Check combined template with extra ports and monitors:
       targetLabels:
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  5: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations: null
-      labels:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/env: prod
-        app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
-      namespace: test-namespace
-    spec:
-      ports:
-        - name: main-http
-          port: 8000
-          targetPort: 8000
-        - name: main-metrics-2
-          port: 9002
-          targetPort: 9002
-        - name: main-metrics-3
-          port: 9003
-          targetPort: 9003
-      selector:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/name: test-app
-      type: ClusterIP
 Check default endpoints:
   1: |
     apiVersion: monitoring.coreos.com/v1

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -323,30 +323,6 @@ Check combined template defaults:
               whenUnsatisfiable: DoNotSchedule
           volumes: null
   2: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations:
-        app.mintel.com/placeholder: placeholder
-      labels:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/env: prod
-        app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
-      namespace: test-namespace
-    spec:
-      ports:
-        - name: main-http
-          port: 8000
-          targetPort: 8000
-      selector:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/name: test-app
-      type: ClusterIP
-  3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -391,6 +367,30 @@ Check combined template defaults:
       targetLabels:
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+  3: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        app.mintel.com/placeholder: placeholder
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: test-app
+        app.mintel.com/env: prod
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: test-app
+      name: test-app
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: main-http
+          port: 8000
+          targetPort: 8000
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: test-app
+      type: ClusterIP
 Check combined template with extra ports and monitors:
   1: |
     apiVersion: apps/v1
@@ -506,36 +506,6 @@ Check combined template with extra ports and monitors:
               whenUnsatisfiable: DoNotSchedule
           volumes: null
   2: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations:
-        app.mintel.com/placeholder: placeholder
-      labels:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/env: prod
-        app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
-      namespace: test-namespace
-    spec:
-      ports:
-        - name: main-http
-          port: 8000
-          targetPort: 8000
-        - name: main-metrics-2
-          port: 9002
-          targetPort: 9002
-        - name: main-metrics-3
-          port: 9003
-          targetPort: 9003
-      selector:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/name: test-app
-      type: ClusterIP
-  3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -580,7 +550,7 @@ Check combined template with extra ports and monitors:
       targetLabels:
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  4: |
+  3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -625,7 +595,7 @@ Check combined template with extra ports and monitors:
       targetLabels:
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  5: |
+  4: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -670,6 +640,36 @@ Check combined template with extra ports and monitors:
       targetLabels:
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+  5: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        app.mintel.com/placeholder: placeholder
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: test-app
+        app.mintel.com/env: prod
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: test-app
+      name: test-app
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: main-http
+          port: 8000
+          targetPort: 8000
+        - name: main-metrics-2
+          port: 9002
+          targetPort: 9002
+        - name: main-metrics-3
+          port: 9003
+          targetPort: 9003
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: test-app
+      type: ClusterIP
 Check default endpoints:
   1: |
     apiVersion: monitoring.coreos.com/v1

--- a/charts/standard-application-stack/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_test.yaml.snap
@@ -5,6 +5,7 @@ Check ALB annotation can be set when enabled:
     metadata:
       annotations:
         alb.ingress.kubernetes.io/tags: Owner=my-team
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -30,6 +31,7 @@ Check ALB annotation not set when ALB Ingress is disabled:
     kind: Service
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         k: v
       labels:
         app.kubernetes.io/component: app
@@ -56,6 +58,7 @@ Check ALB annotation not set when when Owner missing:
     kind: Service
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         k: v
       labels:
         app.kubernetes.io/component: app
@@ -80,7 +83,8 @@ Check default port set:
     apiVersion: v1
     kind: Service
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: Helm
@@ -104,7 +108,8 @@ Check extraPorts:
     apiVersion: v1
     kind: Service
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: Helm
@@ -140,7 +145,8 @@ Check name, namespace and labels:
     apiVersion: v1
     kind: Service
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: Helm
@@ -164,7 +170,8 @@ Check port and targetPort can be set from Service:
     apiVersion: v1
     kind: Service
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: Helm
@@ -188,7 +195,8 @@ Check port can be overridden:
     apiVersion: v1
     kind: Service
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/vpa_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/vpa_test.yaml.snap
@@ -3,7 +3,8 @@ Creates a VerticalPodAutoscaler for a Deployment:
     apiVersion: autoscaling.k8s.io/v1
     kind: VerticalPodAutoscaler
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -25,7 +26,8 @@ Creates a VerticalPodAutoscaler for a StatefulSet:
     apiVersion: autoscaling.k8s.io/v1
     kind: VerticalPodAutoscaler
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -47,7 +49,8 @@ Only creates VerticalPodAutoscaler for CronJobs if cronjobsOnly is true:
     apiVersion: autoscaling.k8s.io/v1
     kind: VerticalPodAutoscaler
     metadata:
-      annotations: null
+      annotations:
+        app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm

--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.43.0] - 2023-06-28
+### Removed
+- Remove `helm.sh/chart` annotation from all remaining manifests.
+
 ## [v0.42.0] - 2023-06-20
 ## Added
 - Support for creating Lambda functions

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.42.0
+version: 0.43.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 0.42.0](https://img.shields.io/badge/Version-0.42.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.43.0](https://img.shields.io/badge/Version-0.43.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 

--- a/charts/terraform-cloud/templates/_helpers.tpl
+++ b/charts/terraform-cloud/templates/_helpers.tpl
@@ -30,6 +30,7 @@ Create chart name and version as used by the chart label.
 
 {{/* Common Annotations */}}
 {{- define "mintel_common.commonAnnotations" -}}
+app.mintel.com/placeholder: placeholder
 {{- end -}}
 
 {{/* Common labels */}}

--- a/charts/terraform-cloud/templates/_helpers.tpl
+++ b/charts/terraform-cloud/templates/_helpers.tpl
@@ -30,7 +30,6 @@ Create chart name and version as used by the chart label.
 
 {{/* Common Annotations */}}
 {{- define "mintel_common.commonAnnotations" -}}
-helm.sh/chart: {{ include "mintel_common.chart" . }}
 {{- end -}}
 
 {{/* Common labels */}}

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
@@ -5,6 +5,7 @@ IRSA created explicitly:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: test-app-irsa
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:irsa
         app.mintel.com/terraform-owner: sre
@@ -82,6 +83,7 @@ IRSA created for Dev S3 module workspace:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: test-app-irsa
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:irsa
         app.mintel.com/terraform-owner: sre
@@ -160,6 +162,7 @@ IRSA created with default (0) syncWave:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: test-app-irsa
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:irsa
         app.mintel.com/terraform-owner: sre
@@ -237,6 +240,7 @@ IRSA created with modified syncWave:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: test-app-irsa
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:irsa
         app.mintel.com/terraform-owner: sre

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
@@ -10,7 +10,6 @@ IRSA created explicitly:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: test-app-irsa
         app.mintel.com/env: dev
@@ -88,7 +87,6 @@ IRSA created for Dev S3 module workspace:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: test-app-irsa
         app.mintel.com/env: dev
@@ -167,7 +165,6 @@ IRSA created with default (0) syncWave:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "0"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: test-app-irsa
         app.mintel.com/env: dev
@@ -245,7 +242,6 @@ IRSA created with modified syncWave:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-100"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: test-app-irsa
         app.mintel.com/env: dev

--- a/charts/terraform-cloud/tests/__snapshot__/workspace_output_secret_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace_output_secret_test.yaml.snap
@@ -4,6 +4,7 @@ Dev S3 module instance workspace output secret with override:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
       labels:
@@ -31,6 +32,7 @@ Dev S3 module workspace output secret:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
       labels:
@@ -55,6 +57,7 @@ Dev S3 module workspace output secret with override:
     kind: ExternalSecret
     metadata:
       annotations:
+        app.mintel.com/placeholder: placeholder
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
       labels:

--- a/charts/terraform-cloud/tests/__snapshot__/workspace_output_secret_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace_output_secret_test.yaml.snap
@@ -6,7 +6,6 @@ Dev S3 module instance workspace output secret with override:
       annotations:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.mintel.com/env: dev
         app.mintel.com/owner: sre
@@ -34,7 +33,6 @@ Dev S3 module workspace output secret:
       annotations:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.mintel.com/env: dev
         app.mintel.com/owner: sre
@@ -59,7 +57,6 @@ Dev S3 module workspace output secret with override:
       annotations:
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.mintel.com/env: dev
         app.mintel.com/owner: sre

--- a/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
@@ -5,6 +5,7 @@ Dev S3 module workspace:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
         app.mintel.com/terraform-owner: sre
@@ -86,6 +87,7 @@ Dev S3 module workspace - tags:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: test-sqs-sqs
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:sqs
         app.mintel.com/terraform-owner: sre
@@ -165,6 +167,7 @@ Dev S3 module workspace adds correct env override:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
         app.mintel.com/terraform-owner: sre
@@ -246,6 +249,7 @@ Dev S3 module workspace name does not repeat mntl-prefix:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
         app.mintel.com/terraform-owner: sre
@@ -327,6 +331,7 @@ Dev S3 module workspace name override:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
         app.mintel.com/terraform-owner: sre
@@ -408,6 +413,7 @@ Dev S3 module workspace with default (0) syncWave:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
         app.mintel.com/terraform-owner: sre
@@ -489,6 +495,7 @@ Dev S3 module workspace with modified syncWave:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
         app.mintel.com/terraform-owner: sre
@@ -570,6 +577,7 @@ Dev S3 module workspace with multiple instances:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-bucket-s3
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
         app.mintel.com/terraform-owner: sre
@@ -650,6 +658,7 @@ Dev S3 module workspace with multiple instances:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-bucket-another-s3
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
         app.mintel.com/terraform-owner: sre
@@ -731,6 +740,7 @@ Dev S3 module workspace with multiple instances - tags:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: test-instance-one-sqs
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:sqs
         app.mintel.com/terraform-owner: sre
@@ -808,6 +818,7 @@ Dev S3 module workspace with multiple instances - tags:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: test-instance-two-sqs
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:sqs
         app.mintel.com/terraform-owner: sre
@@ -887,6 +898,7 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-bucket-s3
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
         app.mintel.com/terraform-owner: sre
@@ -967,6 +979,7 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-bucket-another-s3
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
         app.mintel.com/terraform-owner: sre
@@ -1048,6 +1061,7 @@ Test workspace allow destroy env:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "false"
         app.mintel.com/terraform-cloud-tags: env:prod,owner:sre,mod:s3
         app.mintel.com/terraform-owner: sre
@@ -1124,6 +1138,7 @@ Test workspace extra annotations:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "true"
         app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
         app.mintel.com/terraform-owner: sre
@@ -1205,6 +1220,7 @@ Test workspace extra annotations override:
     metadata:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
         app.mintel.com/terraform-allow-destroy: "false"
         app.mintel.com/terraform-cloud-tags: test
         app.mintel.com/terraform-owner: override

--- a/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
@@ -10,7 +10,6 @@ Dev S3 module workspace:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -92,7 +91,6 @@ Dev S3 module workspace - tags:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: test-sqs-sqs
         app.mintel.com/env: dev
@@ -172,7 +170,6 @@ Dev S3 module workspace adds correct env override:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -254,7 +251,6 @@ Dev S3 module workspace name does not repeat mntl-prefix:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -336,7 +332,6 @@ Dev S3 module workspace name override:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -418,7 +413,6 @@ Dev S3 module workspace with default (0) syncWave:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "0"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -500,7 +494,6 @@ Dev S3 module workspace with modified syncWave:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "200"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -582,7 +575,6 @@ Dev S3 module workspace with multiple instances:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: mntl-test-bucket-s3
         app.mintel.com/env: dev
@@ -663,7 +655,6 @@ Dev S3 module workspace with multiple instances:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: mntl-test-bucket-another-s3
         app.mintel.com/env: dev
@@ -745,7 +736,6 @@ Dev S3 module workspace with multiple instances - tags:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: test-instance-one-sqs
         app.mintel.com/env: dev
@@ -823,7 +813,6 @@ Dev S3 module workspace with multiple instances - tags:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: test-instance-two-sqs
         app.mintel.com/env: dev
@@ -903,7 +892,6 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "200"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: mntl-test-bucket-s3
         app.mintel.com/env: dev
@@ -984,7 +972,6 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "300"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: mntl-test-bucket-another-s3
         app.mintel.com/env: dev
@@ -1066,7 +1053,6 @@ Test workspace allow destroy env:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: prod
@@ -1143,7 +1129,6 @@ Test workspace extra annotations:
         app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev
@@ -1225,7 +1210,6 @@ Test workspace extra annotations override:
         app.mintel.com/terraform-owner: override
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
-        helm.sh/chart: terraform-cloud-0.42.0
       labels:
         app.kubernetes.io/name: mntl-test-app-s3
         app.mintel.com/env: dev


### PR DESCRIPTION
We have never used this and it produces a lot of noise when running `helm unittest` and when reviewing MRs for Tanka repos that include a chart version update (you get hundreds of changes and they're all just this annotation changing). The argument in the past has been that it might be useful for selecting workloads but it's an annotation - not a label - so this isn't possible anyway. I've added a dummy annotation that doesn't change instead so that we don't lose the functionality of being able to apply common annotations to all resources if necessary in future and to avoid `null` annotation errors.