### PR TITLE
Remove the `NET_BIND_SERVICE` capability from default securityContext

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v5.9.2] - 2023-07-24
+### Removed
+- Remove the `NET_BIND_SERVICE` capability from the default securityContext
+
 ## [v5.9.1] - 2023-07-21
 ### Fixed
 - securityContext does not have an apparmor field

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.9.1
+version: 5.9.2
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
@@ -50,8 +50,6 @@ Check CronJob Default Overrides:
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
-                      add:
-                        - NET_BIND_SERVICE
                       drop:
                         - ALL
                     runAsNonRoot: true
@@ -119,8 +117,6 @@ Check CronJob Defaults:
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
-                      add:
-                        - NET_BIND_SERVICE
                       drop:
                         - ALL
                     runAsNonRoot: true
@@ -188,8 +184,6 @@ Check CronJob Job Overrides:
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
-                      add:
-                        - NET_BIND_SERVICE
                       drop:
                         - ALL
                     runAsNonRoot: true
@@ -257,8 +251,6 @@ Check CronJob ttlSecondsAfterFinished zero value:
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
-                      add:
-                        - NET_BIND_SERVICE
                       drop:
                         - ALL
                     runAsNonRoot: true
@@ -325,8 +317,6 @@ CronJob can have a timezone:
                   securityContext:
                     allowPrivilegeEscalation: false
                     capabilities:
-                      add:
-                        - NET_BIND_SERVICE
                       drop:
                         - ALL
                     runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -81,8 +81,6 @@ Check DynamoDB envfrom secretRef is present:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -199,8 +197,6 @@ Check DynamoDB envfrom secretRef is present for local environment:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -303,8 +299,6 @@ Check DynamoDB secretName Override:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
@@ -70,8 +70,6 @@ Check celery does not pull in `main.env` values:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -176,8 +174,6 @@ Check default env behavior:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -292,8 +288,6 @@ Check main container combines default env and `main.env` values:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -81,8 +81,6 @@ Has a pod template that uses the host network:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
@@ -101,8 +101,6 @@ Check custom python otel extraEnv vars are added:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -233,8 +231,6 @@ Check custom sampler settings:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -363,8 +359,6 @@ Check default python otel envars are added:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -495,8 +489,6 @@ Check global otel extraEnv vars are added:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -94,8 +94,6 @@ Check AWS ALB lifecycle rule applied:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -219,8 +217,6 @@ Check AWS ALB lifecycle rules applied with custom delay:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -337,8 +333,6 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -449,8 +443,6 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -566,8 +558,6 @@ Check lifecycle rules:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -81,8 +81,6 @@ Check MariaDB envfrom secretRef is present:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -199,8 +197,6 @@ Check MariaDB envfrom secretRef is present for local environment:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -303,8 +299,6 @@ Check MariaDB secretName Override:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
@@ -81,8 +81,6 @@ Check Memcached envfrom secretRef is present:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -199,8 +197,6 @@ Check Memcached envfrom secretRef is present for local environment:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -303,8 +299,6 @@ Check Memcached secretName Override:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -85,8 +85,6 @@ Check container extraPorts:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -203,8 +201,6 @@ Check container extraPorts are validated:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -320,8 +316,6 @@ Check container extraPorts protocol:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -437,8 +431,6 @@ Check container hybrid cloud ports:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -549,8 +541,6 @@ Check default container main port:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -661,8 +651,6 @@ Check overridden container main port:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -82,8 +82,6 @@ Check allowSingleReplica doesn't alter strategy:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -195,8 +193,6 @@ Check allowSingleReplica set annotations:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -306,8 +302,6 @@ Check replicas unset when autoscaling is enabled:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -416,8 +410,6 @@ Check singleReplicaOnly applied:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -526,8 +518,6 @@ Check singleReplicaOnly ignore replicas value:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -81,8 +81,6 @@ Check S3 envfrom secretRef is present:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -199,8 +197,6 @@ Check S3 envfrom secretRef is present for local environment:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -310,8 +306,6 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -423,8 +417,6 @@ Check S3 secretName Override:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -546,8 +538,6 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
@@ -76,8 +76,6 @@ Check stateful set is rendered with volumeClaimTemplates:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -430,8 +430,6 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -52,8 +52,6 @@ Check all .job.* values can be set correctly, without overriding from main deplo
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -122,8 +120,6 @@ Check all overrides/additions from main deployment work if enabled:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -180,8 +176,6 @@ Check default values are correct with minimal configuration:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -81,8 +81,6 @@ Check default container args:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -147,8 +145,6 @@ Check default container args:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -252,8 +248,6 @@ Check setting skip-auth-regex from extra passed in values:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -319,8 +313,6 @@ Check setting skip-auth-regex from extra passed in values:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -424,8 +416,6 @@ Check setting skip-auth-regex from extra passed in values when they already cont
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -491,8 +481,6 @@ Check setting skip-auth-regex from extra passed in values when they already cont
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -596,8 +584,6 @@ Check setting skip-auth-regex from overridden health-check values:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -662,8 +648,6 @@ Check setting skip-auth-regex from overridden health-check values:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -767,8 +751,6 @@ Check sidecar present if enabled:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -833,8 +815,6 @@ Check sidecar present if enabled:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -254,8 +254,6 @@ Check combined template defaults:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -418,8 +416,6 @@ Check combined template with extra ports and monitors:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -295,8 +295,6 @@ Check combined template defaults:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true
@@ -487,8 +485,6 @@ Check combined template with extra ports and monitors:
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:
-                  add:
-                    - NET_BIND_SERVICE
                   drop:
                     - ALL
                 runAsNonRoot: true

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -197,7 +197,6 @@ securityContext:
 #  readOnlyRootFilesystem: true
   capabilities:
     drop: ["ALL"]
-    add: ["NET_BIND_SERVICE"]
   runAsNonRoot: true
   runAsUser: 1000
 


### PR DESCRIPTION
Most services don't need this capability.