### PR TITLE
Upgrade external-secrets API version to v1beta1

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.43.3] - 2023-8-04
+### Changed
+- Upgrade external-secrets api version from v1alpha1 to v1beta1.
+
 ## [v0.43.2] - 2023-07-28
 ### Changed
 - Bump ssh key module (fixes key generation script)

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.43.2
+version: 0.43.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 0.43.2](https://img.shields.io/badge/Version-0.43.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.43.3](https://img.shields.io/badge/Version-0.43.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 

--- a/charts/terraform-cloud/templates/helpers/_workspace-output-secret.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace-output-secret.yaml
@@ -4,7 +4,7 @@
 {{- $resourceType := index . 3 }}
 {{- $global := $.Values.global }}
 {{- with index . 1 }}
-apiVersion: external-secrets.io/v1alpha1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: "{{ .name | kebabcase }}-{{ $resourceType | kebabcase }}"
@@ -19,15 +19,16 @@ metadata:
 spec:
   {{- if $instanceConfig.outputSecretMap }}
   data:
-    {{- range $newKey, $secretManagerKey := $instanceConfig.outputSecretMap }}
-      - secretKey: {{ $newKey }}
-        remoteRef:
-          key: {{ $instanceConfig.output_secret_name | quote }}
-          property: {{ $secretManagerKey }}
-    {{- end }}
+  {{- range $newKey, $secretManagerKey := $instanceConfig.outputSecretMap }}
+    - secretKey: {{ $newKey }}
+      remoteRef:
+        key: {{ $instanceConfig.output_secret_name | quote }}
+        property: {{ $secretManagerKey }}
+  {{- end }}
   {{- else }}
   dataFrom:
-    - key: {{ $instanceConfig.output_secret_name | quote }}
+    - extract:
+        key: {{ $instanceConfig.output_secret_name | quote }}
   {{- end }}
   refreshInterval: 5m0s
   secretStoreRef:

--- a/charts/terraform-cloud/tests/__snapshot__/workspace_output_secret_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace_output_secret_test.yaml.snap
@@ -1,6 +1,6 @@
 Dev S3 module instance workspace output secret with override:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
@@ -28,7 +28,7 @@ Dev S3 module instance workspace output secret with override:
         creationPolicy: Owner
 Dev S3 module workspace output secret:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:
@@ -44,7 +44,8 @@ Dev S3 module workspace output secret:
       namespace: test-namespace
     spec:
       dataFrom:
-        - key: test-namespace/mntl-test-app/s3
+        - extract:
+            key: test-namespace/mntl-test-app/s3
       refreshInterval: 5m0s
       secretStoreRef:
         kind: SecretStore
@@ -53,7 +54,7 @@ Dev S3 module workspace output secret:
         creationPolicy: Owner
 Dev S3 module workspace output secret with override:
   1: |
-    apiVersion: external-secrets.io/v1alpha1
+    apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
       annotations:

--- a/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
@@ -1,3 +1,85 @@
+Dev S3 module name label override:
+  1: |
+    apiVersion: app.terraform.io/v1alpha1
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
+        app.mintel.com/terraform-allow-destroy: "true"
+        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
+        app.mintel.com/terraform-owner: sre
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-app-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-app-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      namespace: test-namespace
+    spec:
+      agentPoolID: ""
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 1.4.1
+      omitNamespacePrefix: true
+      organization: Mintel
+      secretsMountPath: /tmp/secrets
+      sshKeyID: mintel-ssh
+      terraformVersion: 1.0.7
+      variables:
+        - environmentVariable: false
+          hcl: false
+          key: aws_account_name
+          sensitive: false
+          value: dev
+        - environmentVariable: false
+          hcl: false
+          key: aws_region
+          sensitive: false
+          value: eu-west-1
+        - environmentVariable: false
+          hcl: false
+          key: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - environmentVariable: false
+          hcl: false
+          key: enable_versioning
+          sensitive: false
+          value: "false"
+        - environmentVariable: false
+          hcl: false
+          key: name
+          sensitive: false
+          value: mntl-test-app
+        - environmentVariable: false
+          hcl: false
+          key: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-test-app/s3
+        - environmentVariable: false
+          hcl: true
+          key: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - environmentVariable: false
+          hcl: true
+          key: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "mntl-test-app"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - environmentVariable: false
+          hcl: false
+          key: tfcloud_agent
+          sensitive: false
+          value: "true"
 Dev S3 module workspace:
   1: |
     apiVersion: app.terraform.io/v1alpha1
@@ -212,6 +294,88 @@ Dev S3 module workspace adds correct env override:
           key: enable_versioning
           sensitive: false
           value: "false"
+        - environmentVariable: false
+          hcl: false
+          key: name
+          sensitive: false
+          value: mntl-test-app
+        - environmentVariable: false
+          hcl: false
+          key: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-test-app/s3
+        - environmentVariable: false
+          hcl: true
+          key: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - environmentVariable: false
+          hcl: true
+          key: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "mntl-test-app"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - environmentVariable: false
+          hcl: false
+          key: tfcloud_agent
+          sensitive: false
+          value: "true"
+Dev S3 module workspace ignores env override when added explicitly:
+  1: |
+    apiVersion: app.terraform.io/v1alpha1
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
+        app.mintel.com/terraform-allow-destroy: "true"
+        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
+        app.mintel.com/terraform-owner: sre
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-app-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-app-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      namespace: test-namespace
+    spec:
+      agentPoolID: ""
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 1.4.1
+      omitNamespacePrefix: true
+      organization: Mintel
+      secretsMountPath: /tmp/secrets
+      sshKeyID: mintel-ssh
+      terraformVersion: 1.0.7
+      variables:
+        - environmentVariable: false
+          hcl: false
+          key: aws_account_name
+          sensitive: false
+          value: dev
+        - environmentVariable: false
+          hcl: false
+          key: aws_region
+          sensitive: false
+          value: eu-west-1
+        - environmentVariable: false
+          hcl: false
+          key: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - environmentVariable: false
+          hcl: false
+          key: enable_versioning
+          sensitive: false
+          value: "true"
         - environmentVariable: false
           hcl: false
           key: name

--- a/charts/terraform-cloud/tests/workspace_output_secret_test.yaml
+++ b/charts/terraform-cloud/tests/workspace_output_secret_test.yaml
@@ -110,7 +110,7 @@ tests:
           path: metadata.name
           value: mntl-test-app-s3
       - equal:
-          path: spec.dataFrom[0].key
+          path: spec.dataFrom[0].extract.key
           value: test-namespace/mntl-test-app/s3
       - equal:
           path: spec.secretStoreRef.kind

--- a/charts/terraform-cloud/tests/workspace_test.yaml
+++ b/charts/terraform-cloud/tests/workspace_test.yaml
@@ -14,11 +14,11 @@ tests:
       global.partOf: test-project
       s3:
         enabled: true
-      asserts:
-        - matchSnapshot: {} # Check for regressions and unexpected changes.
-        - equal:
-            path: metadata.labels.name
-            value: mntl-test-app-s3
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - equal:
+          path: metadata.labels.name
+          value: mntl-test-app-s3
   - it: Dev S3 module workspace name override
     set:
       global.name: mntl-test-app
@@ -72,16 +72,16 @@ tests:
         terraform:
           defaultVars:
             enable_versioning: true
-      asserts:
-        - matchSnapshot: {} # Check for regressions and unexpected changes.
-        - contains:
-            path: spec.variables
-            content:
-              environmentVariable: false
-              hcl: false
-              key: enable_versioning
-              sensitive: false
-              value: "true"
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - contains:
+          path: spec.variables
+          content:
+            environmentVariable: false
+            hcl: false
+            key: enable_versioning
+            sensitive: false
+            value: "true"
   - it: Dev S3 module workspace adds correct env override
     set:
       global.name: mntl-test-app
@@ -195,11 +195,11 @@ tests:
             key: tags
             sensitive: false
             value: |-
-                {
-                  Application = "test-app"
-                  Owner = "sre"
-                  Project = "test-project"
-                }
+              {
+                Application = "test-app"
+                Owner = "sre"
+                Project = "test-project"
+              }
   - it: Test workspace extra annotations
     set:
       global.name: test-app
@@ -409,12 +409,10 @@ tests:
           enabled: true
         terraform:
           instances:
-            test-sqs: {
-              tags: {
-                ExtraTagOne: "testTagValueOne",
+            test-sqs:
+              tags:
+                ExtraTagOne: "testTagValueOne"
                 ExtraTagTwo: "testTagValueTwo"
-              }
-            }
     asserts:
       - matchSnapshot: {} # Check for regressions and unexpected changes.
       - contains:
@@ -447,17 +445,15 @@ tests:
           enabled: true
         terraform:
           instances:
-            test-instance-one: {
-              tags: {
-                ExtraTagOne: "testTagValueOne",
+            test-instance-one: { tags: { ExtraTagOne: "testTagValueOne" } }
+            test-instance-two:
+              {
+                tags:
+                  {
+                    ExtraTagOne: "testTagValueOne",
+                    ExtraTagTwo: "testTagValueTwo",
+                  },
               }
-            }
-            test-instance-two: {
-              tags: {
-                ExtraTagOne: "testTagValueOne",
-                ExtraTagTwo: "testTagValueTwo"
-              }
-            }
     asserts:
       - matchSnapshot: {} # Check for regressions and unexpected changes.
       - hasDocuments:


### PR DESCRIPTION
The v1alpha1 version of the external-secrets API has been deprecated since external-secrets v0.5.

See: https://external-secrets.io/latest/guides/v1beta1/