### PR TITLE
Adding deployment labels for cost reporting

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [v5.12.0] - 2023-08-21
+### Added
+- Added support for new reporting labels `application` and `component`
+
 ## [v5.11.3] - 2023-08-03
 ### Fixed
 - Bugfix for py-dba when rds secret name is overridden

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.11.3
+version: 5.12.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 5.11.3](https://img.shields.io/badge/Version-5.11.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.12.0](https://img.shields.io/badge/Version-5.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -101,14 +101,16 @@ A generic chart to support most common application requirements
 | filebeatSidecar.resources.requests.memory | string | `"100Mi"` |  |
 | gitSyncSidecar | object | `{"branch":"main","enabled":false,"resources":{"limits":{"cpu":"200m","memory":"200Mi"},"requests":{"cpu":"50m","memory":"50Mi"}},"root":"/data/git-sync"}` | Helper to sync a local directory with Git ref: https://github.com/kubernetes/git-sync |
 | gitSyncSidecar.branch | string | `"main"` | The git branch to check out |
-| global | object | `{"additionalLabels":{},"cloudProvider":{"accountId":"","region":""},"clusterDomain":"127.0.0.1.nip.io","clusterEnv":"local","clusterName":"","ingressTLSSecrets":{},"name":"example-app","owner":"","partOf":"","runtimeEnvironment":"kubernetes","terraform":{"externalSecrets":false,"irsa":false}}` | Global variables for us in all charts and sub charts |
+| global | object | `{"additionalLabels":{},"application":"","cloudProvider":{"accountId":"","region":""},"clusterDomain":"127.0.0.1.nip.io","clusterEnv":"local","clusterName":"","component":"","ingressTLSSecrets":{},"name":"example-app","owner":"","partOf":"","runtimeEnvironment":"kubernetes","terraform":{"externalSecrets":false,"irsa":false}}` | Global variables for us in all charts and sub charts |
 | global.additionalLabels | object | `{}` | Additional labels to apply to all resources |
+| global.application | string | `""` | Name of the application (defaults to global.name) |
 | global.cloudProvider | object | `{"accountId":"","region":""}` | Global variables relating to cloud provider |
 | global.cloudProvider.accountId | string | `""` | AWS Account Id |
 | global.cloudProvider.region | string | `""` | AWS region name |
 | global.clusterDomain | string | `"127.0.0.1.nip.io"` | Kubernetes cluster domain |
 | global.clusterEnv | string | `"local"` | Environment (local, dev, qa, prod) |
 | global.clusterName | string | `""` | Kubernetes cluster name |
+| global.component | string | `""` | Name of the application (defaults to global.partOf) |
 | global.ingressTLSSecrets | object | `{}` | Global dictionary of TLS secrets |
 | global.name | string | `"example-app"` | Name of the application |
 | global.owner | string | `""` | Team which "owns" the application |

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -110,7 +110,7 @@ A generic chart to support most common application requirements
 | global.clusterDomain | string | `"127.0.0.1.nip.io"` | Kubernetes cluster domain |
 | global.clusterEnv | string | `"local"` | Environment (local, dev, qa, prod) |
 | global.clusterName | string | `""` | Kubernetes cluster name |
-| global.component | string | `""` | Name of the application (defaults to global.partOf) |
+| global.component | string | `""` | Component of the application |
 | global.ingressTLSSecrets | object | `{}` | Global dictionary of TLS secrets |
 | global.name | string | `"example-app"` | Name of the application |
 | global.owner | string | `""` | Team which "owns" the application |

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -62,10 +62,12 @@ argocd.argoproj.io/sync-wave: {{ toYaml .syncWave }}
 name: {{ include "mintel_common.fullname" . }}
 {{ include "mintel_common.selectorLabels" . }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- if .Values.owner }}
-app.mintel.com/owner: .Values.owner }}
-{{- else if (and .Values.global .Values.global.owner) }}
+{{- if .Values.global.owner }}
 app.mintel.com/owner: {{ .Values.global.owner }}
+{{- end }}
+app.mintel.com/application: {{ .Values.global.application | default .Values.global.name }}
+{{- if .Values.global.component }}
+app.mintel.com/component: {{ .Values.global.component}}
 {{- end }}
 app.mintel.com/env: {{ .Values.global.clusterEnv }}
 {{- if (eq .Values.global.clusterEnv "local") }}
@@ -119,6 +121,8 @@ app.kubernetes.io/component: app
 
 {{/* Target Labels */}}
 {{- define "mintel_common.targetLabelNames" -}}
+- app.mintel.com/application
+- app.mintel.com/component
 - app.mintel.com/owner
 - app.mintel.com/ignore_alerts
 {{- end -}}

--- a/charts/standard-application-stack/tests/__snapshot__/configmaps_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/configmaps_test.yaml.snap
@@ -10,6 +10,7 @@ Empty configmap:
         app.kubernetes.io/component: config
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-config
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app-config
@@ -32,6 +33,7 @@ Mixed singleline and  multiline data entries:
         app.kubernetes.io/component: config
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-config
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app-config
@@ -53,6 +55,7 @@ Single multiline data entry:
         app.kubernetes.io/component: config
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-config
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app-config
@@ -71,6 +74,7 @@ Single singleline data entry:
         app.kubernetes.io/component: config
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-config
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app-config
@@ -91,6 +95,7 @@ ensures ArgoCD annotations are populated:
         app.kubernetes.io/component: config
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-config
+        app.mintel.com/application: example-app
         app.mintel.com/env: test
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-config

--- a/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
@@ -9,6 +9,7 @@ Check CronJob Default Overrides:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-daily
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-daily
@@ -24,6 +25,7 @@ Check CronJob Default Overrides:
                 app.kubernetes.io/component: daily
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: example-app-daily
+                app.mintel.com/application: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
                 name: example-app-daily
@@ -76,6 +78,7 @@ Check CronJob Defaults:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-daily
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-daily
@@ -91,6 +94,7 @@ Check CronJob Defaults:
                 app.kubernetes.io/component: daily
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: example-app-daily
+                app.mintel.com/application: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
                 name: example-app-daily
@@ -143,6 +147,7 @@ Check CronJob Job Overrides:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-daily
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-daily
@@ -158,6 +163,7 @@ Check CronJob Job Overrides:
                 app.kubernetes.io/component: daily
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: example-app-daily
+                app.mintel.com/application: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
                 name: example-app-daily
@@ -210,6 +216,7 @@ Check CronJob ttlSecondsAfterFinished zero value:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-daily
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-daily
@@ -225,6 +232,7 @@ Check CronJob ttlSecondsAfterFinished zero value:
                 app.kubernetes.io/component: daily
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: example-app-daily
+                app.mintel.com/application: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
                 name: example-app-daily
@@ -276,6 +284,7 @@ CronJob can have a timezone:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-daily
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-daily
@@ -291,6 +300,7 @@ CronJob can have a timezone:
                 app.kubernetes.io/component: daily
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: example-app-daily
+                app.mintel.com/application: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
                 name: example-app-daily

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -10,6 +10,7 @@ Check DynamoDB envfrom secretRef is present:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -34,6 +35,7 @@ Check DynamoDB envfrom secretRef is present:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -120,6 +122,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -144,6 +147,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: local
             app.mintel.com/region: local
             name: test-app
@@ -228,6 +232,7 @@ Check DynamoDB secretName Override:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -252,6 +257,7 @@ Check DynamoDB secretName Override:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
@@ -12,6 +12,7 @@ Check celery does not pull in `main.env` values:
         app.kubernetes.io/component: celery
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-celery
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-celery
@@ -35,6 +36,7 @@ Check celery does not pull in `main.env` values:
             app.kubernetes.io/component: celery
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app-celery
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app-celery
@@ -101,6 +103,7 @@ Check default env behavior:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -125,6 +128,7 @@ Check default env behavior:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -213,6 +217,7 @@ Check main container combines default env and `main.env` values:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -237,6 +242,7 @@ Check main container combines default env and `main.env` values:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -10,6 +10,7 @@ Has a pod template that uses the host network:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -34,6 +35,7 @@ Has a pod template that uses the host network:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
@@ -10,6 +10,7 @@ Check custom python otel extraEnv vars are added:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -34,6 +35,7 @@ Check custom python otel extraEnv vars are added:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -140,6 +142,7 @@ Check custom sampler settings:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -164,6 +167,7 @@ Check custom sampler settings:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -270,6 +274,7 @@ Check default python otel envars are added:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -294,6 +299,7 @@ Check default python otel envars are added:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -398,6 +404,7 @@ Check global otel extraEnv vars are added:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -422,6 +429,7 @@ Check global otel extraEnv vars are added:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_labels_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_labels_test.yaml.snap
@@ -1,17 +1,19 @@
-Check Memcached envfrom secretRef is present:
+Check default label behavior:
   1: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
-        secret.reloader.stakater.com/reload: test-app-memcached
+        secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
-        app.mintel.com/application: test-app
+        app.mintel.com/application: test-app-different-from-name
+        app.mintel.com/component: backend
         app.mintel.com/env: qa
+        app.mintel.com/owner: sre
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
       name: test-app
@@ -35,8 +37,10 @@ Check Memcached envfrom secretRef is present:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
-            app.mintel.com/application: test-app
+            app.mintel.com/application: test-app-different-from-name
+            app.mintel.com/component: backend
             app.mintel.com/env: qa
+            app.mintel.com/owner: sre
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
         spec:
@@ -54,7 +58,7 @@ Check Memcached envfrom secretRef is present:
                   value: kubernetes
               envFrom:
                 - secretRef:
-                    name: test-app-memcached
+                    name: test-app-app
               image: registry.gitlab.com/test:v0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -110,130 +114,21 @@ Check Memcached envfrom secretRef is present:
               maxSkew: 1
               topologyKey: topology.kubernetes.io/zone
               whenUnsatisfiable: DoNotSchedule
-Check Memcached envfrom secretRef is present for local environment:
+Check empty application defaults to name:
   1: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
-        secret.reloader.stakater.com/reload: test-app-memcached
-      labels:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/application: test-app
-        app.mintel.com/env: local
-        app.mintel.com/region: local
-        name: test-app
-      name: test-app
-      namespace: test-namespace
-    spec:
-      minReadySeconds: 10
-      replicas: 2
-      selector:
-        matchLabels:
-          app.kubernetes.io/component: app
-          app.kubernetes.io/name: test-app
-      strategy:
-        rollingUpdate:
-          maxSurge: 15%
-          maxUnavailable: 10%
-        type: RollingUpdate
-      template:
-        metadata:
-          annotations: null
-          labels:
-            app.kubernetes.io/component: app
-            app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: test-app
-            app.mintel.com/application: test-app
-            app.mintel.com/env: local
-            app.mintel.com/region: local
-            name: test-app
-        spec:
-          containers:
-            - command:
-                - /app/docker-entrypoint.sh
-              env:
-                - name: KUBERNETES_POD_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.namespace
-                - name: INIT_DB
-                  value: "1"
-                - name: SENTRY_DONT_SEND_EVENTS
-                  value: "1"
-                - name: DEBUG
-                  value: "1"
-                - name: APP_ENVIRONMENT
-                  value: local
-                - name: RUNTIME_ENVIRONMENT
-                  value: kubernetes
-              envFrom:
-                - secretRef:
-                    name: test-app-memcached
-              image: k3d-default.localhost:5000/test:v0.1.0
-              imagePullPolicy: IfNotPresent
-              livenessProbe:
-                httpGet:
-                  path: /healthz
-                  port: http
-                  scheme: HTTP
-                initialDelaySeconds: 0
-                periodSeconds: 10
-                timeoutSeconds: 1
-              name: main
-              ports:
-                - containerPort: 8000
-                  name: http
-              readinessProbe:
-                httpGet:
-                  path: /readiness
-                  port: http
-                  scheme: HTTP
-                initialDelaySeconds: 0
-                periodSeconds: 10
-                timeoutSeconds: 1
-              resources:
-                limits: {}
-                requests: {}
-              securityContext:
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop:
-                    - ALL
-                runAsNonRoot: true
-                runAsUser: 1000
-              startupProbe:
-                failureThreshold: 60
-                httpGet:
-                  path: /healthz
-                  port: http
-                  scheme: HTTP
-                periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-          serviceAccountName: test-app
-          terminationGracePeriodSeconds: 30
-Check Memcached secretName Override:
-  1: |
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      annotations:
-        app.mintel.com/placeholder: placeholder
-        secret.reloader.stakater.com/reload: overrideName
+        secret.reloader.stakater.com/reload: test-app-app
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
         app.mintel.com/env: qa
+        app.mintel.com/owner: sre
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
       name: test-app
@@ -259,6 +154,7 @@ Check Memcached secretName Override:
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
             app.mintel.com/env: qa
+            app.mintel.com/owner: sre
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
         spec:
@@ -276,7 +172,7 @@ Check Memcached secretName Override:
                   value: kubernetes
               envFrom:
                 - secretRef:
-                    name: overrideName
+                    name: test-app-app
               image: registry.gitlab.com/test:v0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -10,6 +10,7 @@ Check AWS ALB lifecycle rule applied:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -35,6 +36,7 @@ Check AWS ALB lifecycle rule applied:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -133,6 +135,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -158,6 +161,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -256,6 +260,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -281,6 +286,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -372,6 +378,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -396,6 +403,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -482,6 +490,7 @@ Check lifecycle rules:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -506,6 +515,7 @@ Check lifecycle rules:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -10,6 +10,7 @@ Check MariaDB envfrom secretRef is present:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -34,6 +35,7 @@ Check MariaDB envfrom secretRef is present:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -120,6 +122,7 @@ Check MariaDB envfrom secretRef is present for local environment:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -144,6 +147,7 @@ Check MariaDB envfrom secretRef is present for local environment:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: local
             app.mintel.com/region: local
             name: test-app
@@ -228,6 +232,7 @@ Check MariaDB secretName Override:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -252,6 +257,7 @@ Check MariaDB secretName Override:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -10,6 +10,7 @@ Check container extraPorts:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -34,6 +35,7 @@ Check container extraPorts:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -124,6 +126,7 @@ Check container extraPorts are validated:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -148,6 +151,7 @@ Check container extraPorts are validated:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -240,6 +244,7 @@ Check container extraPorts protocol:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -264,6 +269,7 @@ Check container extraPorts protocol:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -355,6 +361,7 @@ Check container hybrid cloud ports:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -380,6 +387,7 @@ Check container hybrid cloud ports:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -470,6 +478,7 @@ Check default container main port:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -494,6 +503,7 @@ Check default container main port:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -580,6 +590,7 @@ Check overridden container main port:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -604,6 +615,7 @@ Check overridden container main port:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -11,6 +11,7 @@ Check allowSingleReplica doesn't alter strategy:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -35,6 +36,7 @@ Check allowSingleReplica doesn't alter strategy:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -122,6 +124,7 @@ Check allowSingleReplica set annotations:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -146,6 +149,7 @@ Check allowSingleReplica set annotations:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -232,6 +236,7 @@ Check replicas unset when autoscaling is enabled:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -255,6 +260,7 @@ Check replicas unset when autoscaling is enabled:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -342,6 +348,7 @@ Check singleReplicaOnly applied:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -363,6 +370,7 @@ Check singleReplicaOnly applied:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -450,6 +458,7 @@ Check singleReplicaOnly ignore replicas value:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -471,6 +480,7 @@ Check singleReplicaOnly ignore replicas value:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -10,6 +10,7 @@ Check S3 envfrom secretRef is present:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -34,6 +35,7 @@ Check S3 envfrom secretRef is present:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -120,6 +122,7 @@ Check S3 envfrom secretRef is present for local environment:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -144,6 +147,7 @@ Check S3 envfrom secretRef is present for local environment:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: local
             app.mintel.com/region: local
             name: test-app
@@ -229,6 +233,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.kubernetes.io/part-of: test-project
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/owner: sre
         app.mintel.com/region: eu-west-1
@@ -256,6 +261,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.kubernetes.io/part-of: test-project
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/owner: sre
             app.mintel.com/region: eu-west-1
@@ -346,6 +352,7 @@ Check S3 secretName Override:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -370,6 +377,7 @@ Check S3 secretName Override:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -457,6 +465,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.kubernetes.io/part-of: test-project
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/owner: sre
         app.mintel.com/region: eu-west-1
@@ -484,6 +493,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.kubernetes.io/part-of: test-project
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/owner: sre
             app.mintel.com/region: eu-west-1

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
@@ -10,6 +10,7 @@ Check stateful set is rendered with volumeClaimTemplates:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -29,6 +30,7 @@ Check stateful set is rendered with volumeClaimTemplates:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -28,6 +28,7 @@ Check ALB HTTP2 default settings:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -76,6 +77,7 @@ Check ALB className set by default:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -124,6 +126,7 @@ Check ALB custom health-check port:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -172,6 +175,7 @@ Check ALB default health-check port:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -220,6 +224,7 @@ Check ALB gRPC custom settings:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -268,6 +273,7 @@ Check ALB gRPC default settings:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -316,6 +322,7 @@ Check ALB health-check port with oauthProxy enabled:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -346,6 +353,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -371,6 +379,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
+            app.mintel.com/application: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -475,6 +484,7 @@ Check HAProxy className set if ALB is disabled:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -523,6 +533,7 @@ Check TLS set if ingressTLSSecrets is not empty:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -575,6 +586,7 @@ Check extraHosts:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: AppyMcAppface
+        app.mintel.com/application: AppyMcAppface
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: AppyMcAppface
@@ -633,6 +645,7 @@ Check extraHosts with TLS:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -696,6 +709,7 @@ Check extraHosts with TLS and oauthProxy.ingressHost (different):
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -770,6 +784,7 @@ Check extraHosts with TLS and oauthProxy.ingressHost (same as extra host):
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -834,6 +849,7 @@ Check extraHosts with oauthProxy.ingressHost (different):
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -902,6 +918,7 @@ Check extraHosts with oauthProxy.ingressHost (same as extra host):
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -960,6 +977,7 @@ Check ingress name override:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-override
+        app.mintel.com/application: ingress-override
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: ingress-override
@@ -1008,6 +1026,7 @@ Check ingress name suffix setting:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-suffix
+        app.mintel.com/application: example-app-suffix
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-suffix
@@ -1056,6 +1075,7 @@ Check no TLS set if ingressTLSSecrets and specificTlsHostsYaml is empty:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -1104,6 +1124,7 @@ Default ingress with path based routing:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -1159,6 +1180,7 @@ allows extraIngresses to override default values:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: image-service-media
+        app.mintel.com/application: image-service-media
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: image-service-media
@@ -1194,6 +1216,7 @@ allows extraIngresses to override default values:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: image-service-ops-media
+        app.mintel.com/application: image-service-ops-media
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: image-service-ops-media

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -12,6 +12,7 @@ Check all .job.* values can be set correctly, without overriding from main deplo
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-testName
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-testName
@@ -78,6 +79,7 @@ Check all overrides/additions from main deployment work if enabled:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-testName
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-testName
@@ -144,6 +146,7 @@ Check default values are correct with minimal configuration:
         app.kubernetes.io/component: testName
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-testName
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-testName

--- a/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_test.yaml.snap
@@ -7,6 +7,7 @@ Check utilization takes precedence over average value when both specified:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -43,6 +44,7 @@ Creates a ScaledObject for a Deployment:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -70,6 +72,7 @@ Creates a ScaledObject for a StatefulSet:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -97,6 +100,7 @@ Creates a ScaledObject for a custom scaleTargetRef:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -124,6 +128,7 @@ Creates a ScaledObject with advanced settings:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -161,6 +166,7 @@ Creates a ScaledObject with both targetCPUAverageValue and targetMemoryAverageVa
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -197,6 +203,7 @@ Creates a ScaledObject with both targetCPUAverageValue trigger:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -229,6 +236,7 @@ Creates a ScaledObject with both targetCPUUtilizationPercentage and targetMemory
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -265,6 +273,7 @@ Creates a ScaledObject with custom triggers:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -305,6 +314,7 @@ Creates a ScaledObject with fallback settings:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -332,6 +342,7 @@ Creates a ScaledObject with targetCPUUtilizationPercentage trigger:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -364,6 +375,7 @@ Creates a ScaledObject with targetMemoryAverageValue trigger:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -396,6 +408,7 @@ Creates a ScaledObject with targetMemoryUtilizationPercentage trigger:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/mariadb_py_dba_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/mariadb_py_dba_test.yaml.snap
@@ -9,6 +9,7 @@ adds correct config to configmap:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -80,6 +81,7 @@ adds correct config to configmap:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -96,6 +98,7 @@ extraUsers adds job and configmap:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -167,6 +170,7 @@ extraUsers adds job and configmap:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/networkpolicy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/networkpolicy_test.yaml.snap
@@ -9,6 +9,7 @@ Check ALB NetworkPolicy created if enabled:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -40,6 +41,7 @@ Check ALB NetworkPolicy created if internal alb selected:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -71,6 +73,7 @@ Check ALB NetworkPolicy ports are unique:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -102,6 +105,7 @@ Check ALB NetworkPolicy ports set for default conatiner:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -133,6 +137,7 @@ Check ALB NetworkPolicy ports set with oauth2proxy:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -164,6 +169,7 @@ Check ALB NetworkPolicy ports set with oauth2proxy and healthcheck:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -10,6 +10,7 @@ Check default container args:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -34,6 +35,7 @@ Check default container args:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -177,6 +179,7 @@ Check setting skip-auth-regex from extra passed in values:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -201,6 +204,7 @@ Check setting skip-auth-regex from extra passed in values:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -345,6 +349,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -369,6 +374,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -513,6 +519,7 @@ Check setting skip-auth-regex from overridden health-check values:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -537,6 +544,7 @@ Check setting skip-auth-regex from overridden health-check values:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -680,6 +688,7 @@ Check sidecar present if enabled:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -704,6 +713,7 @@ Check sidecar present if enabled:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/opensearch_aws_es_proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/opensearch_aws_es_proxy_test.yaml.snap
@@ -25,6 +25,7 @@ Check awsEsProxy Ingress is created if enabled:
         app.kubernetes.io/component: aws-es-proxy
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-aws-es-proxy
+        app.mintel.com/application: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: example-app-aws-es-proxy
@@ -54,6 +55,7 @@ Check awsEsProxy NetworkPolicy is created if enabled:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: example-app
@@ -85,6 +87,7 @@ Check awsEsProxy aws-load-balancer-controller okta role binding is created if en
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -109,6 +112,7 @@ Check awsEsProxy aws-load-balancer-controller okta role is created if enabled:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -138,6 +142,7 @@ Check awsEsProxy deployment is created if enabled:
         app.kubernetes.io/component: aws-es-proxy
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-aws-es-proxy
+        app.mintel.com/application: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: example-app-aws-es-proxy
@@ -157,6 +162,7 @@ Check awsEsProxy deployment is created if enabled:
             app.kubernetes.io/component: aws-es-proxy
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app-aws-es-proxy
+            app.mintel.com/application: example-app
             app.mintel.com/env: local
             app.mintel.com/region: local
             name: example-app-aws-es-proxy
@@ -232,6 +238,7 @@ Check awsEsProxy service is created if enabled:
         app.kubernetes.io/component: aws-es-proxy
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-aws-es-proxy
+        app.mintel.com/application: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: example-app-aws-es-proxy

--- a/charts/standard-application-stack/tests/__snapshot__/pdb_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pdb_test.yaml.snap
@@ -9,6 +9,7 @@ Creates a PDB when autoscaling is disabled and autoscaling.minReplicaCount is se
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -31,6 +32,7 @@ Creates a PDB when replicas > 1:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -10,6 +10,7 @@ Check additional PodMonitor resources:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -51,6 +52,7 @@ Check additional PodMonitor resources:
         app.kubernetes.io/component: metrics-2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-2
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-metrics-2
@@ -92,6 +94,7 @@ Check additional PodMonitor resources:
         app.kubernetes.io/component: metrics-3
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-3
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-metrics-3
@@ -134,6 +137,7 @@ Check basic-auth:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -183,6 +187,7 @@ Check combined template defaults:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -207,6 +212,7 @@ Check combined template defaults:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: prod
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -299,6 +305,7 @@ Check combined template defaults:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -341,6 +348,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -365,6 +373,7 @@ Check combined template with extra ports and monitors:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: prod
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -461,6 +470,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -502,6 +512,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/component: metrics-2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-2
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-metrics-2
@@ -543,6 +554,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/component: metrics-3
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-3
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-metrics-3
@@ -585,6 +597,7 @@ Check default endpoints:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -627,6 +640,7 @@ Check default targetLabels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -669,6 +683,7 @@ Check metric overrides:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -711,6 +726,7 @@ Check name, namespace and labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/postgresql_py_dba_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/postgresql_py_dba_test.yaml.snap
@@ -9,6 +9,7 @@ adds correct config to configmap:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -80,6 +81,7 @@ adds correct config to configmap:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -96,6 +98,7 @@ extraUsers adds job and configmap:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -167,6 +170,7 @@ extraUsers adds job and configmap:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/secret_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_dynamodb_enabled_test.yaml.snap
@@ -10,6 +10,7 @@ Check DynamoDB Secret Store Override:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -40,6 +41,7 @@ Check DynamoDB Secret is present for local environment:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -58,6 +60,7 @@ Check DynamoDB refresh interval override:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -87,6 +90,7 @@ Check DynamoDB remoteRef key is present:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -116,6 +120,7 @@ Check DynamoDB secretPath override:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/secret_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_s3_enabled_test.yaml.snap
@@ -10,6 +10,7 @@ Check S3 Secret Store Override:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -40,6 +41,7 @@ Check S3 Secret is present for local environment:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -58,6 +60,7 @@ Check S3 refresh interval override:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -87,6 +90,7 @@ Check S3 remoteRef key is present:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -116,6 +120,7 @@ Check S3 secretPath override:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
@@ -10,6 +10,7 @@ Extra secrets with output secret map:
         app.kubernetes.io/component: extra-secret
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-extra-secret
+        app.mintel.com/application: example-app
         app.mintel.com/env: test
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-extra-secret
@@ -42,6 +43,7 @@ ensures ArgoCD annotations are populated:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: test
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/service_account_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_account_test.yaml.snap
@@ -14,6 +14,7 @@ ensures annotations are populated:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -9,6 +9,7 @@ Check Service defaults:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -35,6 +36,7 @@ Check additional ServiceMonitor resources:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -67,6 +69,8 @@ Check additional ServiceMonitor resources:
           app.kubernetes.io/component: app
           app.kubernetes.io/name: test-app
       targetLabels:
+        - app.mintel.com/application
+        - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
   2: |
@@ -80,6 +84,7 @@ Check additional ServiceMonitor resources:
         app.kubernetes.io/component: metrics-2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-2
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app-metrics-2
@@ -112,6 +117,8 @@ Check additional ServiceMonitor resources:
           app.kubernetes.io/component: metrics-2
           app.kubernetes.io/name: test-app-metrics-2
       targetLabels:
+        - app.mintel.com/application
+        - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
   3: |
@@ -125,6 +132,7 @@ Check additional ServiceMonitor resources:
         app.kubernetes.io/component: metrics-3
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-3
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app-metrics-3
@@ -157,6 +165,8 @@ Check additional ServiceMonitor resources:
           app.kubernetes.io/component: metrics-3
           app.kubernetes.io/name: test-app-metrics-3
       targetLabels:
+        - app.mintel.com/application
+        - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
 Check basic-auth:
@@ -171,6 +181,7 @@ Check basic-auth:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -210,6 +221,8 @@ Check basic-auth:
           app.kubernetes.io/component: app
           app.kubernetes.io/name: test-app
       targetLabels:
+        - app.mintel.com/application
+        - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
 Check combined template defaults:
@@ -224,6 +237,7 @@ Check combined template defaults:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -248,6 +262,7 @@ Check combined template defaults:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: prod
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -330,6 +345,31 @@ Check combined template defaults:
               topologyKey: kubernetes.io/hostname
               whenUnsatisfiable: DoNotSchedule
   2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        app.mintel.com/placeholder: placeholder
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
+        app.mintel.com/env: prod
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: test-app
+      name: test-app
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: main-http
+          port: 8000
+          targetPort: 8000
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: test-app
+      type: ClusterIP
+  3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -340,6 +380,7 @@ Check combined template defaults:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -372,32 +413,10 @@ Check combined template defaults:
           app.kubernetes.io/component: app
           app.kubernetes.io/name: test-app
       targetLabels:
+        - app.mintel.com/application
+        - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  3: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations:
-        app.mintel.com/placeholder: placeholder
-      labels:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/env: prod
-        app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
-      namespace: test-namespace
-    spec:
-      ports:
-        - name: main-http
-          port: 8000
-          targetPort: 8000
-      selector:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/name: test-app
-      type: ClusterIP
 Check combined template with extra ports and monitors:
   1: |
     apiVersion: apps/v1
@@ -410,6 +429,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -434,6 +454,7 @@ Check combined template with extra ports and monitors:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
+            app.mintel.com/application: test-app
             app.mintel.com/env: prod
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -520,6 +541,37 @@ Check combined template with extra ports and monitors:
               topologyKey: kubernetes.io/hostname
               whenUnsatisfiable: DoNotSchedule
   2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        app.mintel.com/placeholder: placeholder
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
+        app.mintel.com/env: prod
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: test-app
+      name: test-app
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: main-http
+          port: 8000
+          targetPort: 8000
+        - name: main-metrics-2
+          port: 9002
+          targetPort: 9002
+        - name: main-metrics-3
+          port: 9003
+          targetPort: 9003
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: test-app
+      type: ClusterIP
+  3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -530,6 +582,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -562,9 +615,11 @@ Check combined template with extra ports and monitors:
           app.kubernetes.io/component: app
           app.kubernetes.io/name: test-app
       targetLabels:
+        - app.mintel.com/application
+        - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  3: |
+  4: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -575,6 +630,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/component: metrics-2
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-2
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app-metrics-2
@@ -607,9 +663,11 @@ Check combined template with extra ports and monitors:
           app.kubernetes.io/component: metrics-2
           app.kubernetes.io/name: test-app-metrics-2
       targetLabels:
+        - app.mintel.com/application
+        - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  4: |
+  5: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -620,6 +678,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/component: metrics-3
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-3
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app-metrics-3
@@ -652,38 +711,10 @@ Check combined template with extra ports and monitors:
           app.kubernetes.io/component: metrics-3
           app.kubernetes.io/name: test-app-metrics-3
       targetLabels:
+        - app.mintel.com/application
+        - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  5: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations:
-        app.mintel.com/placeholder: placeholder
-      labels:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/env: prod
-        app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
-      namespace: test-namespace
-    spec:
-      ports:
-        - name: main-http
-          port: 8000
-          targetPort: 8000
-        - name: main-metrics-2
-          port: 9002
-          targetPort: 9002
-        - name: main-metrics-3
-          port: 9003
-          targetPort: 9003
-      selector:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/name: test-app
-      type: ClusterIP
 Check default endpoints:
   1: |
     apiVersion: monitoring.coreos.com/v1
@@ -696,6 +727,7 @@ Check default endpoints:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -728,6 +760,8 @@ Check default endpoints:
           app.kubernetes.io/component: app
           app.kubernetes.io/name: test-app
       targetLabels:
+        - app.mintel.com/application
+        - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
 Check default targetLabels:
@@ -742,6 +776,7 @@ Check default targetLabels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -774,6 +809,8 @@ Check default targetLabels:
           app.kubernetes.io/component: app
           app.kubernetes.io/name: test-app
       targetLabels:
+        - app.mintel.com/application
+        - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
 Check metric overrides:
@@ -788,6 +825,7 @@ Check metric overrides:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -820,6 +858,8 @@ Check metric overrides:
           app.kubernetes.io/component: app
           app.kubernetes.io/name: test-app
       targetLabels:
+        - app.mintel.com/application
+        - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
 Check name, namespace and labels:
@@ -834,6 +874,7 @@ Check name, namespace and labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -866,5 +907,7 @@ Check name, namespace and labels:
           app.kubernetes.io/component: app
           app.kubernetes.io/name: test-app
       targetLabels:
+        - app.mintel.com/application
+        - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -345,31 +345,6 @@ Check combined template defaults:
               topologyKey: kubernetes.io/hostname
               whenUnsatisfiable: DoNotSchedule
   2: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations:
-        app.mintel.com/placeholder: placeholder
-      labels:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/application: test-app
-        app.mintel.com/env: prod
-        app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
-      namespace: test-namespace
-    spec:
-      ports:
-        - name: main-http
-          port: 8000
-          targetPort: 8000
-      selector:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/name: test-app
-      type: ClusterIP
-  3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -417,6 +392,31 @@ Check combined template defaults:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+  3: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        app.mintel.com/placeholder: placeholder
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
+        app.mintel.com/env: prod
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: test-app
+      name: test-app
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: main-http
+          port: 8000
+          targetPort: 8000
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: test-app
+      type: ClusterIP
 Check combined template with extra ports and monitors:
   1: |
     apiVersion: apps/v1
@@ -541,37 +541,6 @@ Check combined template with extra ports and monitors:
               topologyKey: kubernetes.io/hostname
               whenUnsatisfiable: DoNotSchedule
   2: |
-    apiVersion: v1
-    kind: Service
-    metadata:
-      annotations:
-        app.mintel.com/placeholder: placeholder
-      labels:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/application: test-app
-        app.mintel.com/env: prod
-        app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
-      namespace: test-namespace
-    spec:
-      ports:
-        - name: main-http
-          port: 8000
-          targetPort: 8000
-        - name: main-metrics-2
-          port: 9002
-          targetPort: 9002
-        - name: main-metrics-3
-          port: 9003
-          targetPort: 9003
-      selector:
-        app.kubernetes.io/component: app
-        app.kubernetes.io/name: test-app
-      type: ClusterIP
-  3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -619,7 +588,7 @@ Check combined template with extra ports and monitors:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  4: |
+  3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -667,7 +636,7 @@ Check combined template with extra ports and monitors:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
-  5: |
+  4: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
     metadata:
@@ -715,6 +684,37 @@ Check combined template with extra ports and monitors:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+  5: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        app.mintel.com/placeholder: placeholder
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
+        app.mintel.com/env: prod
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: test-app
+      name: test-app
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: main-http
+          port: 8000
+          targetPort: 8000
+        - name: main-metrics-2
+          port: 9002
+          targetPort: 9002
+        - name: main-metrics-3
+          port: 9003
+          targetPort: 9003
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: test-app
+      type: ClusterIP
 Check default endpoints:
   1: |
     apiVersion: monitoring.coreos.com/v1

--- a/charts/standard-application-stack/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_test.yaml.snap
@@ -10,6 +10,7 @@ Check ALB annotation can be set when enabled:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: qa
         app.mintel.com/owner: my-team
         app.mintel.com/region: ${CLUSTER_REGION}
@@ -37,6 +38,7 @@ Check ALB annotation not set when ALB Ingress is disabled:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/owner: my-team
         app.mintel.com/region: local
@@ -64,6 +66,7 @@ Check ALB annotation not set when when Owner missing:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -89,6 +92,7 @@ Check default port set:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -114,6 +118,7 @@ Check extraPorts:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -151,6 +156,7 @@ Check name, namespace and labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -176,6 +182,7 @@ Check port and targetPort can be set from Service:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -201,6 +208,7 @@ Check port can be overridden:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/vpa_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/vpa_test.yaml.snap
@@ -9,6 +9,7 @@ Creates a VerticalPodAutoscaler for a Deployment:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -32,6 +33,7 @@ Creates a VerticalPodAutoscaler for a StatefulSet:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -55,6 +57,7 @@ Only creates VerticalPodAutoscaler for CronJobs if cronjobsOnly is true:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-daily
+        app.mintel.com/application: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-daily

--- a/charts/standard-application-stack/tests/deployment_labels_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_labels_test.yaml
@@ -1,0 +1,46 @@
+suite: Test Deployment Labels
+release:
+  namespace: test-namespace
+tests:
+  - it: Check default label behavior
+    template: deployment.yaml
+    set:
+      global.name: test-app
+      global.owner: sre
+      global.application: test-app-different-from-name
+      global.component: backend
+      global.clusterEnv: qa
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - equal:
+          path: metadata.name
+          value: test-app
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: test-app
+      - equal:
+          path: metadata.labels["app.mintel.com/owner"]
+          value: sre
+      - equal:
+          path: metadata.labels["app.mintel.com/application"]
+          value: test-app-different-from-name
+      - equal:
+          path: metadata.labels["app.mintel.com/component"]
+          value: backend
+  - it: Check empty application defaults to name
+    template: deployment.yaml
+    set:
+      global.name: test-app
+      global.owner: sre
+      global.clusterEnv: qa
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - equal:
+          path: metadata.name
+          value: test-app
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: test-app
+      - equal:
+          path: metadata.labels["app.mintel.com/application"]
+          value: test-app

--- a/charts/standard-application-stack/tests/service_monitor_test.yaml
+++ b/charts/standard-application-stack/tests/service_monitor_test.yaml
@@ -43,6 +43,8 @@ tests:
       - equal:
           path: spec.targetLabels
           value:
+            - app.mintel.com/application
+            - app.mintel.com/component
             - app.mintel.com/owner
             - app.mintel.com/ignore_alerts
       - equal:

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -5,8 +5,15 @@
 global:
   # -- Name of the application
   name: "example-app"
+
+  # Labels for alerting and reporting
   # -- Team which "owns" the application
   owner: ""
+  # -- Name of the application (defaults to global.name)
+  application: ""
+   # -- Name of the application (defaults to global.partOf)
+  component: ""
+
   # -- Top level application each deployment is a part of
   partOf: ""
   # -- Additional labels to apply to all resources

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -11,7 +11,7 @@ global:
   owner: ""
   # -- Name of the application (defaults to global.name)
   application: ""
-   # -- Name of the application (defaults to global.partOf)
+  # -- Component of the application
   component: ""
 
   # -- Top level application each deployment is a part of


### PR DESCRIPTION
Adds the following tags which are used for cost reporting

- `app.mintel.com/application` 
- `app.mintel.com/component` (optional)

Note that `application` will be derived from the app-catalog and enforced at CI time. It may potentially be different to `app.kubernetes.io/name`.  If not supplied, it will default to the app name (as set by `globals.name`)