### PR TITLE
Infra 31280 add reporting tags to workspace

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.44.0] - 2023-8-21
+### Added
+- Added support for new reporting labels `application` and `component`
+
 ## [v0.43.3] - 2023-8-04
 ### Changed
 - Upgrade external-secrets api version from v1alpha1 to v1beta1.

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.43.3
+version: 0.44.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 0.43.3](https://img.shields.io/badge/Version-0.43.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.44.0](https://img.shields.io/badge/Version-0.44.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 

--- a/charts/terraform-cloud/templates/_helpers.tpl
+++ b/charts/terraform-cloud/templates/_helpers.tpl
@@ -147,6 +147,8 @@ app.mintel.com/terraform-cloud-tags: {{ .InstanceCfg.workspaceTags | default (in
 {{/* Convert dict to hcl */}}
 {{- define "mintel_common.terraform_cloud.dict_to_hcl" -}}
 {{- range $key, $value := . }}
-  {{- printf "  %s = \"%s\"\n" $key $value -}}
-{{ end}}
+{{- if $value -}}
+{{- printf "  %s = \"%s\"\n" $key $value -}}
+{{- end -}}
+{{ end }}
 {{- end -}}

--- a/charts/terraform-cloud/templates/irsa-workspace.yaml
+++ b/charts/terraform-cloud/templates/irsa-workspace.yaml
@@ -8,6 +8,7 @@
   {{- $moduleVersion := $irsa.terraform.module.version }}
   {{- $tfVersion := $irsa.terraform.terraformVersion }}
   {{- $irsaConfig := $irsa.terraform.vars }}
+  {{- $defaultTags := dict "Owner" $global.owner "Project" $global.partOf "Application" ($global.application | default $global.name) "Component" $global.component }}
   {{- if not (hasKey $irsaConfig "name") }}
     {{- $_ := set $irsaConfig "name" (.Values.irsa.nameOverride | default $global.name) }}
   {{- end }}
@@ -21,7 +22,7 @@
     {{- $_ := set $irsaConfig "eks_cluster_name" $global.clusterName }}
   {{ end }}
   {{- if not (hasKey $irsaConfig "tags") }}
-    {{- $_ := set $irsaConfig "tags" (dict "key" "tags" "value" (printf "{\n  Owner       = \"%s\"\n  Project     = \"%s\"\n  Application = \"%s\"\n}" $global.owner $global.partOf $global.name ) "hcl" true) }}
+    {{- $_ := set $irsaConfig "tags" (dict "key" "tags" "value" ( printf "{\n%s}" (include "mintel_common.terraform_cloud.dict_to_hcl" $defaultTags )) "hcl" true) }}
   {{ end }}
   {{- if not (hasKey $irsaConfig "tfcloud_agent") }}
     {{- $_ := set $irsaConfig "tfcloud_agent" "true" }}

--- a/charts/terraform-cloud/templates/workspace.yaml
+++ b/charts/terraform-cloud/templates/workspace.yaml
@@ -3,7 +3,7 @@
 {{- range include "mintel_common.terraformCloudResources" $ | split "," }}
   {{- $global := $.Values.global }}
   # define default tags
-  {{- $defaultTags := dict "Owner" $global.owner "Project" $global.partOf "Application" $global.name }}
+  {{- $defaultTags := dict "Owner" $global.owner "Project" $global.partOf "Application" ($global.application | default $global.name) "Component" $global.component }}
   # Get the config for the current resource in the loop (e.g. resourceType = "memcached", resourceConfig = everything
   # inside the memcached dict in values.yaml)
   {{- $resourceType := . }}

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_tags_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_tags_test.yaml.snap
@@ -1,0 +1,239 @@
+Test IRSA application tag defaults to name:
+  1: |
+    apiVersion: app.terraform.io/v1alpha1
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: test-app-irsa
+        app.mintel.com/placeholder: placeholder
+        app.mintel.com/terraform-allow-destroy: "true"
+        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:irsa
+        app.mintel.com/terraform-owner: sre
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-20"
+      labels:
+        app.kubernetes.io/name: test-app-irsa
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: test-app-irsa
+      name: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
+      namespace: test-namespace
+    spec:
+      agentPoolID: ""
+      module:
+        source: app.terraform.io/Mintel/app-iam/aws
+        version: 2.1.2
+      omitNamespacePrefix: true
+      organization: Mintel
+      runTriggers:
+        - sourceableName: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      secretsMountPath: /tmp/secrets
+      sshKeyID: mintel-ssh
+      terraformVersion: 1.0.7
+      variables:
+        - environmentVariable: false
+          hcl: false
+          key: aws_account_name
+          sensitive: false
+          value: dev
+        - environmentVariable: false
+          hcl: false
+          key: aws_region
+          sensitive: false
+          value: eu-west-1
+        - environmentVariable: false
+          hcl: false
+          key: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - environmentVariable: false
+          hcl: false
+          key: k8s_namespace
+          sensitive: false
+          value: test-namespace
+        - environmentVariable: false
+          hcl: false
+          key: k8s_service_account_name
+          sensitive: false
+          value: test-app
+        - environmentVariable: false
+          hcl: false
+          key: name
+          sensitive: false
+          value: test-app
+        - environmentVariable: false
+          hcl: true
+          key: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "test-app"
+              Component = "backend"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - environmentVariable: false
+          hcl: false
+          key: tfcloud_agent
+          sensitive: false
+          value: "true"
+Test IRSA component tag can be empty:
+  1: |
+    apiVersion: app.terraform.io/v1alpha1
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: test-app-irsa
+        app.mintel.com/placeholder: placeholder
+        app.mintel.com/terraform-allow-destroy: "true"
+        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:irsa
+        app.mintel.com/terraform-owner: sre
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-20"
+      labels:
+        app.kubernetes.io/name: test-app-irsa
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: test-app-irsa
+      name: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
+      namespace: test-namespace
+    spec:
+      agentPoolID: ""
+      module:
+        source: app.terraform.io/Mintel/app-iam/aws
+        version: 2.1.2
+      omitNamespacePrefix: true
+      organization: Mintel
+      runTriggers:
+        - sourceableName: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      secretsMountPath: /tmp/secrets
+      sshKeyID: mintel-ssh
+      terraformVersion: 1.0.7
+      variables:
+        - environmentVariable: false
+          hcl: false
+          key: aws_account_name
+          sensitive: false
+          value: dev
+        - environmentVariable: false
+          hcl: false
+          key: aws_region
+          sensitive: false
+          value: eu-west-1
+        - environmentVariable: false
+          hcl: false
+          key: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - environmentVariable: false
+          hcl: false
+          key: k8s_namespace
+          sensitive: false
+          value: test-namespace
+        - environmentVariable: false
+          hcl: false
+          key: k8s_service_account_name
+          sensitive: false
+          value: test-app
+        - environmentVariable: false
+          hcl: false
+          key: name
+          sensitive: false
+          value: test-app
+        - environmentVariable: false
+          hcl: true
+          key: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "test-app"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - environmentVariable: false
+          hcl: false
+          key: tfcloud_agent
+          sensitive: false
+          value: "true"
+Test IRSA default tags:
+  1: |
+    apiVersion: app.terraform.io/v1alpha1
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: test-app-irsa
+        app.mintel.com/placeholder: placeholder
+        app.mintel.com/terraform-allow-destroy: "true"
+        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:irsa
+        app.mintel.com/terraform-owner: sre
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-20"
+      labels:
+        app.kubernetes.io/name: test-app-irsa
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: test-app-irsa
+      name: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
+      namespace: test-namespace
+    spec:
+      agentPoolID: ""
+      module:
+        source: app.terraform.io/Mintel/app-iam/aws
+        version: 2.1.2
+      omitNamespacePrefix: true
+      organization: Mintel
+      runTriggers:
+        - sourceableName: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      secretsMountPath: /tmp/secrets
+      sshKeyID: mintel-ssh
+      terraformVersion: 1.0.7
+      variables:
+        - environmentVariable: false
+          hcl: false
+          key: aws_account_name
+          sensitive: false
+          value: dev
+        - environmentVariable: false
+          hcl: false
+          key: aws_region
+          sensitive: false
+          value: eu-west-1
+        - environmentVariable: false
+          hcl: false
+          key: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - environmentVariable: false
+          hcl: false
+          key: k8s_namespace
+          sensitive: false
+          value: test-namespace
+        - environmentVariable: false
+          hcl: false
+          key: k8s_service_account_name
+          sensitive: false
+          value: test-app
+        - environmentVariable: false
+          hcl: false
+          key: name
+          sensitive: false
+          value: test-app
+        - environmentVariable: false
+          hcl: true
+          key: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "test-app-override"
+              Component = "backend"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - environmentVariable: false
+          hcl: false
+          key: tfcloud_agent
+          sensitive: false
+          value: "true"

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
@@ -67,9 +67,9 @@ IRSA created explicitly:
           sensitive: false
           value: |-
             {
-              Owner       = "sre"
-              Project     = "test-project"
               Application = "test-app"
+              Owner = "sre"
+              Project = "test-project"
             }
         - environmentVariable: false
           hcl: false
@@ -146,9 +146,9 @@ IRSA created for Dev S3 module workspace:
           sensitive: false
           value: |-
             {
-              Owner       = "sre"
-              Project     = "test-project"
               Application = "test-app"
+              Owner = "sre"
+              Project = "test-project"
             }
         - environmentVariable: false
           hcl: false
@@ -224,9 +224,9 @@ IRSA created with default (0) syncWave:
           sensitive: false
           value: |-
             {
-              Owner       = "sre"
-              Project     = "test-project"
               Application = "test-app"
+              Owner = "sre"
+              Project = "test-project"
             }
         - environmentVariable: false
           hcl: false
@@ -302,9 +302,9 @@ IRSA created with modified syncWave:
           sensitive: false
           value: |-
             {
-              Owner       = "sre"
-              Project     = "test-project"
               Application = "test-app"
+              Owner = "sre"
+              Project = "test-project"
             }
         - environmentVariable: false
           hcl: false

--- a/charts/terraform-cloud/tests/irsa_workspace_tags_test.yaml
+++ b/charts/terraform-cloud/tests/irsa_workspace_tags_test.yaml
@@ -1,0 +1,115 @@
+suite: Test IRSA Tags in Workspaces
+templates:
+  - irsa-workspace.yaml
+release:
+  namespace: test-namespace
+tests:
+  - it: Test IRSA default tags
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.application: test-app-override
+      global.component: backend
+      global.owner: sre
+      global.partOf: test-project
+      s3.enabled: true
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - isKind:
+          of: Workspace
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: metadata.name
+          value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.variables
+          content:
+            environmentVariable: false
+            hcl: true
+            key: tags
+            sensitive: false
+            value: |-
+                {
+                  Application = "test-app-override"
+                  Component = "backend"
+                  Owner = "sre"
+                  Project = "test-project"
+                }
+  - it: Test IRSA application tag defaults to name
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.component: backend
+      global.owner: sre
+      global.partOf: test-project
+      s3.enabled: true
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - isKind:
+          of: Workspace
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: metadata.name
+          value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.variables
+          content:
+            environmentVariable: false
+            hcl: true
+            key: tags
+            sensitive: false
+            value: |-
+                {
+                  Application = "test-app"
+                  Component = "backend"
+                  Owner = "sre"
+                  Project = "test-project"
+                }
+
+
+  - it: Test IRSA component tag can be empty
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      s3.enabled: true
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - isKind:
+          of: Workspace
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - equal:
+          path: metadata.name
+          value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.variables
+          content:
+            environmentVariable: false
+            hcl: true
+            key: tags
+            sensitive: false
+            value: |-
+                {
+                  Application = "test-app"
+                  Owner = "sre"
+                  Project = "test-project"
+                }

--- a/charts/terraform-cloud/tests/irsa_workspace_test.yaml
+++ b/charts/terraform-cloud/tests/irsa_workspace_test.yaml
@@ -87,9 +87,9 @@ tests:
             sensitive: false
             value: |-
                 {
-                  Owner       = "sre"
-                  Project     = "test-project"
                   Application = "test-app"
+                  Owner = "sre"
+                  Project = "test-project"
                 }
   - it: IRSA created explicitly
     set:


### PR DESCRIPTION
- Modifies `Application` tag to be set from `global.application` but default to `global.name`
- Adds optional `Component` tag from `global.component`
- Updates the IRSA tag to use the same helper (means we can check for empty tag values)
- Adds specific unit-tests to test different use-cases around tags
  - `Application` defaults to `global.name` unless set 
  - `Component` is optional
