### PR TITLE
INFRA-31280: Default component reporting label to name label

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v5.13.0] - 2023-08-22
+### Changed
+- Update `component` reporting label to default to application name (`global.name`)
 
 ## [v5.12.0] - 2023-08-21
 ### Added

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.12.0
+version: 5.13.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 5.12.0](https://img.shields.io/badge/Version-5.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.13.0](https://img.shields.io/badge/Version-5.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -110,7 +110,7 @@ A generic chart to support most common application requirements
 | global.clusterDomain | string | `"127.0.0.1.nip.io"` | Kubernetes cluster domain |
 | global.clusterEnv | string | `"local"` | Environment (local, dev, qa, prod) |
 | global.clusterName | string | `""` | Kubernetes cluster name |
-| global.component | string | `""` | Component of the application |
+| global.component | string | `""` | Component of the application (defaults to global.name) |
 | global.ingressTLSSecrets | object | `{}` | Global dictionary of TLS secrets |
 | global.name | string | `"example-app"` | Name of the application |
 | global.owner | string | `""` | Team which "owns" the application |

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -66,9 +66,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.mintel.com/owner: {{ .Values.global.owner }}
 {{- end }}
 app.mintel.com/application: {{ .Values.global.application | default .Values.global.name }}
-{{- if .Values.global.component }}
-app.mintel.com/component: {{ .Values.global.component}}
-{{- end }}
+app.mintel.com/component: {{ .Values.global.component | default .Values.global.name }}
 app.mintel.com/env: {{ .Values.global.clusterEnv }}
 {{- if (eq .Values.global.clusterEnv "local") }}
 app.mintel.com/region: {{ $.Values.global.clusterRegion | default "local" }}

--- a/charts/standard-application-stack/tests/__snapshot__/configmaps_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/configmaps_test.yaml.snap
@@ -11,6 +11,7 @@ Empty configmap:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-config
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app-config
@@ -34,6 +35,7 @@ Mixed singleline and  multiline data entries:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-config
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app-config
@@ -56,6 +58,7 @@ Single multiline data entry:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-config
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app-config
@@ -75,6 +78,7 @@ Single singleline data entry:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-config
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app-config
@@ -96,6 +100,7 @@ ensures ArgoCD annotations are populated:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-config
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: test
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-config

--- a/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
@@ -10,6 +10,7 @@ Check CronJob Default Overrides:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-daily
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-daily
@@ -26,6 +27,7 @@ Check CronJob Default Overrides:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: example-app-daily
                 app.mintel.com/application: example-app
+                app.mintel.com/component: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
                 name: example-app-daily
@@ -79,6 +81,7 @@ Check CronJob Defaults:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-daily
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-daily
@@ -95,6 +98,7 @@ Check CronJob Defaults:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: example-app-daily
                 app.mintel.com/application: example-app
+                app.mintel.com/component: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
                 name: example-app-daily
@@ -148,6 +152,7 @@ Check CronJob Job Overrides:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-daily
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-daily
@@ -164,6 +169,7 @@ Check CronJob Job Overrides:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: example-app-daily
                 app.mintel.com/application: example-app
+                app.mintel.com/component: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
                 name: example-app-daily
@@ -217,6 +223,7 @@ Check CronJob ttlSecondsAfterFinished zero value:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-daily
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-daily
@@ -233,6 +240,7 @@ Check CronJob ttlSecondsAfterFinished zero value:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: example-app-daily
                 app.mintel.com/application: example-app
+                app.mintel.com/component: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
                 name: example-app-daily
@@ -285,6 +293,7 @@ CronJob can have a timezone:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-daily
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-daily
@@ -301,6 +310,7 @@ CronJob can have a timezone:
                 app.kubernetes.io/managed-by: Helm
                 app.kubernetes.io/name: example-app-daily
                 app.mintel.com/application: example-app
+                app.mintel.com/component: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
                 name: example-app-daily

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -11,6 +11,7 @@ Check DynamoDB envfrom secretRef is present:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -36,6 +37,7 @@ Check DynamoDB envfrom secretRef is present:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -123,6 +125,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -148,6 +151,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: local
             app.mintel.com/region: local
             name: test-app
@@ -233,6 +237,7 @@ Check DynamoDB secretName Override:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -258,6 +263,7 @@ Check DynamoDB secretName Override:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
@@ -13,6 +13,7 @@ Check celery does not pull in `main.env` values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-celery
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-celery
@@ -37,6 +38,7 @@ Check celery does not pull in `main.env` values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app-celery
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app-celery
@@ -104,6 +106,7 @@ Check default env behavior:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -129,6 +132,7 @@ Check default env behavior:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -218,6 +222,7 @@ Check main container combines default env and `main.env` values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -243,6 +248,7 @@ Check main container combines default env and `main.env` values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -11,6 +11,7 @@ Has a pod template that uses the host network:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -36,6 +37,7 @@ Has a pod template that uses the host network:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
@@ -11,6 +11,7 @@ Check custom python otel extraEnv vars are added:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -36,6 +37,7 @@ Check custom python otel extraEnv vars are added:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -143,6 +145,7 @@ Check custom sampler settings:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -168,6 +171,7 @@ Check custom sampler settings:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -275,6 +279,7 @@ Check default python otel envars are added:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -300,6 +305,7 @@ Check default python otel envars are added:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -405,6 +411,7 @@ Check global otel extraEnv vars are added:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -430,6 +437,7 @@ Check global otel extraEnv vars are added:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_labels_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_labels_test.yaml.snap
@@ -5,18 +5,18 @@ Check default label behavior:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
-        secret.reloader.stakater.com/reload: test-app-app
+        secret.reloader.stakater.com/reload: app-app
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/application: test-app-different-from-name
-        app.mintel.com/component: backend
+        app.kubernetes.io/name: app
+        app.mintel.com/application: application-name
+        app.mintel.com/component: component-name
         app.mintel.com/env: qa
         app.mintel.com/owner: sre
         app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
+        name: app
+      name: app
       namespace: test-namespace
     spec:
       minReadySeconds: 10
@@ -24,7 +24,7 @@ Check default label behavior:
       selector:
         matchLabels:
           app.kubernetes.io/component: app
-          app.kubernetes.io/name: test-app
+          app.kubernetes.io/name: app
       strategy:
         rollingUpdate:
           maxSurge: 15%
@@ -36,13 +36,13 @@ Check default label behavior:
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: test-app
-            app.mintel.com/application: test-app-different-from-name
-            app.mintel.com/component: backend
+            app.kubernetes.io/name: app
+            app.mintel.com/application: application-name
+            app.mintel.com/component: component-name
             app.mintel.com/env: qa
             app.mintel.com/owner: sre
             app.mintel.com/region: ${CLUSTER_REGION}
-            name: test-app
+            name: app
         spec:
           containers:
             - command:
@@ -58,7 +58,7 @@ Check default label behavior:
                   value: kubernetes
               envFrom:
                 - secretRef:
-                    name: test-app-app
+                    name: app-app
               image: registry.gitlab.com/test:v0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -104,34 +104,35 @@ Check default label behavior:
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
-          serviceAccountName: test-app
+          serviceAccountName: app
           terminationGracePeriodSeconds: 30
           topologySpreadConstraints:
             - labelSelector:
                 matchLabels:
                   app.kubernetes.io/component: app
-                  app.kubernetes.io/name: test-app
+                  app.kubernetes.io/name: app
               maxSkew: 1
               topologyKey: topology.kubernetes.io/zone
               whenUnsatisfiable: DoNotSchedule
-Check empty application defaults to name:
+Check empty application and component labels both default to name:
   1: |
     apiVersion: apps/v1
     kind: Deployment
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
-        secret.reloader.stakater.com/reload: test-app-app
+        secret.reloader.stakater.com/reload: app-app
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: test-app
-        app.mintel.com/application: test-app
+        app.kubernetes.io/name: app
+        app.mintel.com/application: app
+        app.mintel.com/component: app
         app.mintel.com/env: qa
         app.mintel.com/owner: sre
         app.mintel.com/region: ${CLUSTER_REGION}
-        name: test-app
-      name: test-app
+        name: app
+      name: app
       namespace: test-namespace
     spec:
       minReadySeconds: 10
@@ -139,7 +140,7 @@ Check empty application defaults to name:
       selector:
         matchLabels:
           app.kubernetes.io/component: app
-          app.kubernetes.io/name: test-app
+          app.kubernetes.io/name: app
       strategy:
         rollingUpdate:
           maxSurge: 15%
@@ -151,12 +152,13 @@ Check empty application defaults to name:
           labels:
             app.kubernetes.io/component: app
             app.kubernetes.io/managed-by: Helm
-            app.kubernetes.io/name: test-app
-            app.mintel.com/application: test-app
+            app.kubernetes.io/name: app
+            app.mintel.com/application: app
+            app.mintel.com/component: app
             app.mintel.com/env: qa
             app.mintel.com/owner: sre
             app.mintel.com/region: ${CLUSTER_REGION}
-            name: test-app
+            name: app
         spec:
           containers:
             - command:
@@ -172,7 +174,7 @@ Check empty application defaults to name:
                   value: kubernetes
               envFrom:
                 - secretRef:
-                    name: test-app-app
+                    name: app-app
               image: registry.gitlab.com/test:v0.1.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
@@ -218,13 +220,13 @@ Check empty application defaults to name:
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
-          serviceAccountName: test-app
+          serviceAccountName: app
           terminationGracePeriodSeconds: 30
           topologySpreadConstraints:
             - labelSelector:
                 matchLabels:
                   app.kubernetes.io/component: app
-                  app.kubernetes.io/name: test-app
+                  app.kubernetes.io/name: app
               maxSkew: 1
               topologyKey: topology.kubernetes.io/zone
               whenUnsatisfiable: DoNotSchedule

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -11,6 +11,7 @@ Check AWS ALB lifecycle rule applied:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -37,6 +38,7 @@ Check AWS ALB lifecycle rule applied:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -136,6 +138,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -162,6 +165,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -261,6 +265,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -287,6 +292,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -379,6 +385,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -404,6 +411,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -491,6 +499,7 @@ Check lifecycle rules:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -516,6 +525,7 @@ Check lifecycle rules:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -11,6 +11,7 @@ Check MariaDB envfrom secretRef is present:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -36,6 +37,7 @@ Check MariaDB envfrom secretRef is present:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -123,6 +125,7 @@ Check MariaDB envfrom secretRef is present for local environment:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -148,6 +151,7 @@ Check MariaDB envfrom secretRef is present for local environment:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: local
             app.mintel.com/region: local
             name: test-app
@@ -233,6 +237,7 @@ Check MariaDB secretName Override:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -258,6 +263,7 @@ Check MariaDB secretName Override:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
@@ -11,6 +11,7 @@ Check Memcached envfrom secretRef is present:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -36,6 +37,7 @@ Check Memcached envfrom secretRef is present:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -123,6 +125,7 @@ Check Memcached envfrom secretRef is present for local environment:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -148,6 +151,7 @@ Check Memcached envfrom secretRef is present for local environment:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: local
             app.mintel.com/region: local
             name: test-app
@@ -233,6 +237,7 @@ Check Memcached secretName Override:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -258,6 +263,7 @@ Check Memcached secretName Override:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -11,6 +11,7 @@ Check container extraPorts:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -36,6 +37,7 @@ Check container extraPorts:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -127,6 +129,7 @@ Check container extraPorts are validated:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -152,6 +155,7 @@ Check container extraPorts are validated:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -245,6 +249,7 @@ Check container extraPorts protocol:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -270,6 +275,7 @@ Check container extraPorts protocol:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -362,6 +368,7 @@ Check container hybrid cloud ports:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -388,6 +395,7 @@ Check container hybrid cloud ports:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -479,6 +487,7 @@ Check default container main port:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -504,6 +513,7 @@ Check default container main port:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -591,6 +601,7 @@ Check overridden container main port:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -616,6 +627,7 @@ Check overridden container main port:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -12,6 +12,7 @@ Check allowSingleReplica doesn't alter strategy:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -37,6 +38,7 @@ Check allowSingleReplica doesn't alter strategy:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -125,6 +127,7 @@ Check allowSingleReplica set annotations:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -150,6 +153,7 @@ Check allowSingleReplica set annotations:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -237,6 +241,7 @@ Check replicas unset when autoscaling is enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -261,6 +266,7 @@ Check replicas unset when autoscaling is enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -349,6 +355,7 @@ Check singleReplicaOnly applied:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -371,6 +378,7 @@ Check singleReplicaOnly applied:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -459,6 +467,7 @@ Check singleReplicaOnly ignore replicas value:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -481,6 +490,7 @@ Check singleReplicaOnly ignore replicas value:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -11,6 +11,7 @@ Check S3 envfrom secretRef is present:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -36,6 +37,7 @@ Check S3 envfrom secretRef is present:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -123,6 +125,7 @@ Check S3 envfrom secretRef is present for local environment:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -148,6 +151,7 @@ Check S3 envfrom secretRef is present for local environment:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: local
             app.mintel.com/region: local
             name: test-app
@@ -234,6 +238,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
         app.kubernetes.io/name: test-app
         app.kubernetes.io/part-of: test-project
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/owner: sre
         app.mintel.com/region: eu-west-1
@@ -262,6 +267,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
             app.kubernetes.io/name: test-app
             app.kubernetes.io/part-of: test-project
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/owner: sre
             app.mintel.com/region: eu-west-1
@@ -353,6 +359,7 @@ Check S3 secretName Override:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -378,6 +385,7 @@ Check S3 secretName Override:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -466,6 +474,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
         app.kubernetes.io/name: test-app
         app.kubernetes.io/part-of: test-project
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/owner: sre
         app.mintel.com/region: eu-west-1
@@ -494,6 +503,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
             app.kubernetes.io/name: test-app
             app.kubernetes.io/part-of: test-project
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/owner: sre
             app.mintel.com/region: eu-west-1

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
@@ -11,6 +11,7 @@ Check stateful set is rendered with volumeClaimTemplates:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -31,6 +32,7 @@ Check stateful set is rendered with volumeClaimTemplates:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -29,6 +29,7 @@ Check ALB HTTP2 default settings:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -78,6 +79,7 @@ Check ALB className set by default:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -127,6 +129,7 @@ Check ALB custom health-check port:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -176,6 +179,7 @@ Check ALB default health-check port:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -225,6 +229,7 @@ Check ALB gRPC custom settings:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -274,6 +279,7 @@ Check ALB gRPC default settings:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -323,6 +329,7 @@ Check ALB health-check port with oauthProxy enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -354,6 +361,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -380,6 +388,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: example-app
@@ -485,6 +494,7 @@ Check HAProxy className set if ALB is disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -534,6 +544,7 @@ Check TLS set if ingressTLSSecrets is not empty:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -587,6 +598,7 @@ Check extraHosts:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: AppyMcAppface
         app.mintel.com/application: AppyMcAppface
+        app.mintel.com/component: AppyMcAppface
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: AppyMcAppface
@@ -646,6 +658,7 @@ Check extraHosts with TLS:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -710,6 +723,7 @@ Check extraHosts with TLS and oauthProxy.ingressHost (different):
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -785,6 +799,7 @@ Check extraHosts with TLS and oauthProxy.ingressHost (same as extra host):
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -850,6 +865,7 @@ Check extraHosts with oauthProxy.ingressHost (different):
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -919,6 +935,7 @@ Check extraHosts with oauthProxy.ingressHost (same as extra host):
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -978,6 +995,7 @@ Check ingress name override:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: ingress-override
         app.mintel.com/application: ingress-override
+        app.mintel.com/component: ingress-override
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: ingress-override
@@ -1027,6 +1045,7 @@ Check ingress name suffix setting:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-suffix
         app.mintel.com/application: example-app-suffix
+        app.mintel.com/component: example-app-suffix
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-suffix
@@ -1076,6 +1095,7 @@ Check no TLS set if ingressTLSSecrets and specificTlsHostsYaml is empty:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -1125,6 +1145,7 @@ Default ingress with path based routing:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -1181,6 +1202,7 @@ allows extraIngresses to override default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: image-service-media
         app.mintel.com/application: image-service-media
+        app.mintel.com/component: image-service-media
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: image-service-media
@@ -1217,6 +1239,7 @@ allows extraIngresses to override default values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: image-service-ops-media
         app.mintel.com/application: image-service-ops-media
+        app.mintel.com/component: image-service-ops-media
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: image-service-ops-media

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -13,6 +13,7 @@ Check all .job.* values can be set correctly, without overriding from main deplo
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-testName
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-testName
@@ -80,6 +81,7 @@ Check all overrides/additions from main deployment work if enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-testName
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-testName
@@ -147,6 +149,7 @@ Check default values are correct with minimal configuration:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-testName
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-testName

--- a/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_test.yaml.snap
@@ -8,6 +8,7 @@ Check utilization takes precedence over average value when both specified:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -45,6 +46,7 @@ Creates a ScaledObject for a Deployment:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -73,6 +75,7 @@ Creates a ScaledObject for a StatefulSet:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -101,6 +104,7 @@ Creates a ScaledObject for a custom scaleTargetRef:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -129,6 +133,7 @@ Creates a ScaledObject with advanced settings:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -167,6 +172,7 @@ Creates a ScaledObject with both targetCPUAverageValue and targetMemoryAverageVa
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -204,6 +210,7 @@ Creates a ScaledObject with both targetCPUAverageValue trigger:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -237,6 +244,7 @@ Creates a ScaledObject with both targetCPUUtilizationPercentage and targetMemory
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -274,6 +282,7 @@ Creates a ScaledObject with custom triggers:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -315,6 +324,7 @@ Creates a ScaledObject with fallback settings:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -343,6 +353,7 @@ Creates a ScaledObject with targetCPUUtilizationPercentage trigger:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -376,6 +387,7 @@ Creates a ScaledObject with targetMemoryAverageValue trigger:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -409,6 +421,7 @@ Creates a ScaledObject with targetMemoryUtilizationPercentage trigger:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/mariadb_py_dba_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/mariadb_py_dba_test.yaml.snap
@@ -10,6 +10,7 @@ adds correct config to configmap:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -82,6 +83,7 @@ adds correct config to configmap:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -99,6 +101,7 @@ extraUsers adds job and configmap:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -171,6 +174,7 @@ extraUsers adds job and configmap:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/networkpolicy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/networkpolicy_test.yaml.snap
@@ -10,6 +10,7 @@ Check ALB NetworkPolicy created if enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -42,6 +43,7 @@ Check ALB NetworkPolicy created if internal alb selected:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -74,6 +76,7 @@ Check ALB NetworkPolicy ports are unique:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -106,6 +109,7 @@ Check ALB NetworkPolicy ports set for default conatiner:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -138,6 +142,7 @@ Check ALB NetworkPolicy ports set with oauth2proxy:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -170,6 +175,7 @@ Check ALB NetworkPolicy ports set with oauth2proxy and healthcheck:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -11,6 +11,7 @@ Check default container args:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -36,6 +37,7 @@ Check default container args:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -180,6 +182,7 @@ Check setting skip-auth-regex from extra passed in values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -205,6 +208,7 @@ Check setting skip-auth-regex from extra passed in values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -350,6 +354,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -375,6 +380,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -520,6 +526,7 @@ Check setting skip-auth-regex from overridden health-check values:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -545,6 +552,7 @@ Check setting skip-auth-regex from overridden health-check values:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -689,6 +697,7 @@ Check sidecar present if enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -714,6 +723,7 @@ Check sidecar present if enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/opensearch_aws_es_proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/opensearch_aws_es_proxy_test.yaml.snap
@@ -26,6 +26,7 @@ Check awsEsProxy Ingress is created if enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-aws-es-proxy
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: example-app-aws-es-proxy
@@ -56,6 +57,7 @@ Check awsEsProxy NetworkPolicy is created if enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: example-app
@@ -88,6 +90,7 @@ Check awsEsProxy aws-load-balancer-controller okta role binding is created if en
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -113,6 +116,7 @@ Check awsEsProxy aws-load-balancer-controller okta role is created if enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -143,6 +147,7 @@ Check awsEsProxy deployment is created if enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-aws-es-proxy
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: example-app-aws-es-proxy
@@ -163,6 +168,7 @@ Check awsEsProxy deployment is created if enabled:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: example-app-aws-es-proxy
             app.mintel.com/application: example-app
+            app.mintel.com/component: example-app
             app.mintel.com/env: local
             app.mintel.com/region: local
             name: example-app-aws-es-proxy
@@ -239,6 +245,7 @@ Check awsEsProxy service is created if enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-aws-es-proxy
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: example-app-aws-es-proxy

--- a/charts/standard-application-stack/tests/__snapshot__/pdb_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pdb_test.yaml.snap
@@ -10,6 +10,7 @@ Creates a PDB when autoscaling is disabled and autoscaling.minReplicaCount is se
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -33,6 +34,7 @@ Creates a PDB when replicas > 1:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -11,6 +11,7 @@ Check additional PodMonitor resources:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -53,6 +54,7 @@ Check additional PodMonitor resources:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-2
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-metrics-2
@@ -95,6 +97,7 @@ Check additional PodMonitor resources:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-3
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-metrics-3
@@ -138,6 +141,7 @@ Check basic-auth:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -188,6 +192,7 @@ Check combined template defaults:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -213,6 +218,7 @@ Check combined template defaults:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: prod
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -306,6 +312,7 @@ Check combined template defaults:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -349,6 +356,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -374,6 +382,7 @@ Check combined template with extra ports and monitors:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: prod
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -471,6 +480,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -513,6 +523,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-2
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-metrics-2
@@ -555,6 +566,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-3
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app-metrics-3
@@ -598,6 +610,7 @@ Check default endpoints:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -641,6 +654,7 @@ Check default targetLabels:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -684,6 +698,7 @@ Check metric overrides:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -727,6 +742,7 @@ Check name, namespace and labels:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/postgresql_py_dba_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/postgresql_py_dba_test.yaml.snap
@@ -10,6 +10,7 @@ adds correct config to configmap:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -82,6 +83,7 @@ adds correct config to configmap:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -99,6 +101,7 @@ extraUsers adds job and configmap:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -171,6 +174,7 @@ extraUsers adds job and configmap:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/secret_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_dynamodb_enabled_test.yaml.snap
@@ -11,6 +11,7 @@ Check DynamoDB Secret Store Override:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -42,6 +43,7 @@ Check DynamoDB Secret is present for local environment:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -61,6 +63,7 @@ Check DynamoDB refresh interval override:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -91,6 +94,7 @@ Check DynamoDB remoteRef key is present:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -121,6 +125,7 @@ Check DynamoDB secretPath override:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/secret_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_s3_enabled_test.yaml.snap
@@ -11,6 +11,7 @@ Check S3 Secret Store Override:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -42,6 +43,7 @@ Check S3 Secret is present for local environment:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -61,6 +63,7 @@ Check S3 refresh interval override:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -91,6 +94,7 @@ Check S3 remoteRef key is present:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -121,6 +125,7 @@ Check S3 secretPath override:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
@@ -11,6 +11,7 @@ Extra secrets with output secret map:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-extra-secret
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: test
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-extra-secret
@@ -44,6 +45,7 @@ ensures ArgoCD annotations are populated:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: test
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/service_account_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_account_test.yaml.snap
@@ -15,6 +15,7 @@ ensures annotations are populated:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: example-app

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -10,6 +10,7 @@ Check Service defaults:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -37,6 +38,7 @@ Check additional ServiceMonitor resources:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -85,6 +87,7 @@ Check additional ServiceMonitor resources:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-2
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app-metrics-2
@@ -133,6 +136,7 @@ Check additional ServiceMonitor resources:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-3
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app-metrics-3
@@ -182,6 +186,7 @@ Check basic-auth:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -238,6 +243,7 @@ Check combined template defaults:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -263,6 +269,7 @@ Check combined template defaults:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: prod
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -356,6 +363,7 @@ Check combined template defaults:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -403,6 +411,7 @@ Check combined template defaults:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -430,6 +439,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -455,6 +465,7 @@ Check combined template with extra ports and monitors:
             app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: test-app
             app.mintel.com/application: test-app
+            app.mintel.com/component: test-app
             app.mintel.com/env: prod
             app.mintel.com/region: ${CLUSTER_REGION}
             name: test-app
@@ -552,6 +563,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -600,6 +612,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-2
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app-metrics-2
@@ -648,6 +661,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app-metrics-3
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app-metrics-3
@@ -695,6 +709,7 @@ Check combined template with extra ports and monitors:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         name: test-app
@@ -728,6 +743,7 @@ Check default endpoints:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -777,6 +793,7 @@ Check default targetLabels:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -826,6 +843,7 @@ Check metric overrides:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app
@@ -875,6 +893,7 @@ Check name, namespace and labels:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
         k8s-app: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_test.yaml.snap
@@ -11,6 +11,7 @@ Check ALB annotation can be set when enabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/owner: my-team
         app.mintel.com/region: ${CLUSTER_REGION}
@@ -39,6 +40,7 @@ Check ALB annotation not set when ALB Ingress is disabled:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/owner: my-team
         app.mintel.com/region: local
@@ -67,6 +69,7 @@ Check ALB annotation not set when when Owner missing:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -93,6 +96,7 @@ Check default port set:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -119,6 +123,7 @@ Check extraPorts:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -157,6 +162,7 @@ Check name, namespace and labels:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -183,6 +189,7 @@ Check port and targetPort can be set from Service:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app
@@ -209,6 +216,7 @@ Check port can be overridden:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
         app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
         name: test-app

--- a/charts/standard-application-stack/tests/__snapshot__/vpa_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/vpa_test.yaml.snap
@@ -10,6 +10,7 @@ Creates a VerticalPodAutoscaler for a Deployment:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -34,6 +35,7 @@ Creates a VerticalPodAutoscaler for a StatefulSet:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app
@@ -58,6 +60,7 @@ Only creates VerticalPodAutoscaler for CronJobs if cronjobsOnly is true:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: example-app-daily
         app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
         name: example-app-daily

--- a/charts/standard-application-stack/tests/deployment_labels_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_labels_test.yaml
@@ -5,42 +5,45 @@ tests:
   - it: Check default label behavior
     template: deployment.yaml
     set:
-      global.name: test-app
+      global.name: app
       global.owner: sre
-      global.application: test-app-different-from-name
-      global.component: backend
+      global.application: application-name
+      global.component: component-name
       global.clusterEnv: qa
     asserts:
       - matchSnapshot: {} # Check for regressions and unexpected changes.
       - equal:
           path: metadata.name
-          value: test-app
+          value: app
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
-          value: test-app
+          value: app
       - equal:
           path: metadata.labels["app.mintel.com/owner"]
           value: sre
       - equal:
           path: metadata.labels["app.mintel.com/application"]
-          value: test-app-different-from-name
+          value: application-name
       - equal:
           path: metadata.labels["app.mintel.com/component"]
-          value: backend
-  - it: Check empty application defaults to name
+          value: component-name
+  - it: Check empty application and component labels both default to name
     template: deployment.yaml
     set:
-      global.name: test-app
+      global.name: app
       global.owner: sre
       global.clusterEnv: qa
     asserts:
       - matchSnapshot: {} # Check for regressions and unexpected changes.
       - equal:
           path: metadata.name
-          value: test-app
+          value: app
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
-          value: test-app
+          value: app
       - equal:
           path: metadata.labels["app.mintel.com/application"]
-          value: test-app
+          value: app
+      - equal:
+          path: metadata.labels["app.mintel.com/application"]
+          value: app

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -11,9 +11,8 @@ global:
   owner: ""
   # -- Name of the application (defaults to global.name)
   application: ""
-  # -- Component of the application
+  # -- Component of the application (defaults to global.name)
   component: ""
-
   # -- Top level application each deployment is a part of
   partOf: ""
   # -- Additional labels to apply to all resources


### PR DESCRIPTION
Initially this will generate duplicate `application` and `component` labels  (both set to `global.name`) - but that's ok, as we'll adjust the application label on a per-app basis later.

