### PR TITLE
INFRA-31280: Default component reporting label to name label

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.45.0] - 2023-8-22
+### Changed
+- Update `component` reporting label to default to application name (`global.name`)
+
 ## [v0.44.0] - 2023-8-21
 ### Added
 - Added support for new reporting labels `application` and `component`

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.44.0
+version: 0.45.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 0.44.0](https://img.shields.io/badge/Version-0.44.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 0.45.0](https://img.shields.io/badge/Version-0.45.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 

--- a/charts/terraform-cloud/templates/irsa-workspace.yaml
+++ b/charts/terraform-cloud/templates/irsa-workspace.yaml
@@ -8,7 +8,7 @@
   {{- $moduleVersion := $irsa.terraform.module.version }}
   {{- $tfVersion := $irsa.terraform.terraformVersion }}
   {{- $irsaConfig := $irsa.terraform.vars }}
-  {{- $defaultTags := dict "Owner" $global.owner "Project" $global.partOf "Application" ($global.application | default $global.name) "Component" $global.component }}
+  {{- $defaultTags := dict "Owner" $global.owner "Project" $global.partOf "Application" ($global.application | default $global.name) "Component" ($global.component | default $global.name) }}
   {{- if not (hasKey $irsaConfig "name") }}
     {{- $_ := set $irsaConfig "name" (.Values.irsa.nameOverride | default $global.name) }}
   {{- end }}

--- a/charts/terraform-cloud/templates/workspace.yaml
+++ b/charts/terraform-cloud/templates/workspace.yaml
@@ -3,7 +3,7 @@
 {{- range include "mintel_common.terraformCloudResources" $ | split "," }}
   {{- $global := $.Values.global }}
   # define default tags
-  {{- $defaultTags := dict "Owner" $global.owner "Project" $global.partOf "Application" ($global.application | default $global.name) "Component" $global.component }}
+  {{- $defaultTags := dict "Owner" $global.owner "Project" $global.partOf "Application" ($global.application | default $global.name) "Component" ($global.component | default $global.name) }}
   # Get the config for the current resource in the loop (e.g. resourceType = "memcached", resourceConfig = everything
   # inside the memcached dict in values.yaml)
   {{- $resourceType := . }}

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_tags_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_tags_test.yaml.snap
@@ -1,4 +1,4 @@
-Test IRSA application tag defaults to name:
+Test IRSA application and component tags default to name:
   1: |
     apiVersion: app.terraform.io/v1alpha1
     kind: Workspace
@@ -69,86 +69,7 @@ Test IRSA application tag defaults to name:
           value: |-
             {
               Application = "test-app"
-              Component = "backend"
-              Owner = "sre"
-              Project = "test-project"
-            }
-        - environmentVariable: false
-          hcl: false
-          key: tfcloud_agent
-          sensitive: false
-          value: "true"
-Test IRSA component tag can be empty:
-  1: |
-    apiVersion: app.terraform.io/v1alpha1
-    kind: Workspace
-    metadata:
-      annotations:
-        app.mintel.com/altManifestFileSuffix: test-app-irsa
-        app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:irsa
-        app.mintel.com/terraform-owner: sre
-        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
-        argocd.argoproj.io/sync-wave: "-20"
-      labels:
-        app.kubernetes.io/name: test-app-irsa
-        app.mintel.com/env: dev
-        app.mintel.com/owner: sre
-        app.mintel.com/region: eu-west-1
-        name: test-app-irsa
-      name: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
-      namespace: test-namespace
-    spec:
-      agentPoolID: ""
-      module:
-        source: app.terraform.io/Mintel/app-iam/aws
-        version: 2.1.2
-      omitNamespacePrefix: true
-      organization: Mintel
-      runTriggers:
-        - sourceableName: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
-      secretsMountPath: /tmp/secrets
-      sshKeyID: mintel-ssh
-      terraformVersion: 1.0.7
-      variables:
-        - environmentVariable: false
-          hcl: false
-          key: aws_account_name
-          sensitive: false
-          value: dev
-        - environmentVariable: false
-          hcl: false
-          key: aws_region
-          sensitive: false
-          value: eu-west-1
-        - environmentVariable: false
-          hcl: false
-          key: eks_cluster_name
-          sensitive: false
-          value: cluster1
-        - environmentVariable: false
-          hcl: false
-          key: k8s_namespace
-          sensitive: false
-          value: test-namespace
-        - environmentVariable: false
-          hcl: false
-          key: k8s_service_account_name
-          sensitive: false
-          value: test-app
-        - environmentVariable: false
-          hcl: false
-          key: name
-          sensitive: false
-          value: test-app
-        - environmentVariable: false
-          hcl: true
-          key: tags
-          sensitive: false
-          value: |-
-            {
-              Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
@@ -68,6 +68,7 @@ IRSA created explicitly:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -147,6 +148,7 @@ IRSA created for Dev S3 module workspace:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -225,6 +227,7 @@ IRSA created with default (0) syncWave:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -303,6 +306,7 @@ IRSA created with modified syncWave:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }

--- a/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
@@ -72,6 +72,7 @@ Dev S3 module name label override:
           value: |-
             {
               Application = "mntl-test-app"
+              Component = "mntl-test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -154,6 +155,7 @@ Dev S3 module workspace:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -231,6 +233,7 @@ Dev S3 module workspace - tags:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               ExtraTagOne = "testTagValueOne"
               ExtraTagTwo = "testTagValueTwo"
               MintelEventBus = "true"
@@ -316,6 +319,7 @@ Dev S3 module workspace adds correct env override:
           value: |-
             {
               Application = "mntl-test-app"
+              Component = "mntl-test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -398,6 +402,7 @@ Dev S3 module workspace ignores env override when added explicitly:
           value: |-
             {
               Application = "mntl-test-app"
+              Component = "mntl-test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -480,6 +485,7 @@ Dev S3 module workspace name does not repeat mntl-prefix:
           value: |-
             {
               Application = "mntl-test-app"
+              Component = "mntl-test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -562,6 +568,7 @@ Dev S3 module workspace name override:
           value: |-
             {
               Application = "mntl-test-app"
+              Component = "mntl-test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -644,6 +651,7 @@ Dev S3 module workspace with default (0) syncWave:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -726,6 +734,7 @@ Dev S3 module workspace with modified syncWave:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -808,6 +817,7 @@ Dev S3 module workspace with multiple instances:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -889,6 +899,7 @@ Dev S3 module workspace with multiple instances:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -966,6 +977,7 @@ Dev S3 module workspace with multiple instances - tags:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               ExtraTagOne = "testTagValueOne"
               MintelEventBus = "true"
               Owner = "sre"
@@ -1044,6 +1056,7 @@ Dev S3 module workspace with multiple instances - tags:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               ExtraTagOne = "testTagValueOne"
               ExtraTagTwo = "testTagValueTwo"
               MintelEventBus = "true"
@@ -1129,6 +1142,7 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -1210,6 +1224,7 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -1287,6 +1302,7 @@ Test workspace allow destroy env:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -1369,6 +1385,7 @@ Test workspace extra annotations:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }
@@ -1451,6 +1468,7 @@ Test workspace extra annotations override:
           value: |-
             {
               Application = "test-app"
+              Component = "test-app"
               Owner = "sre"
               Project = "test-project"
             }

--- a/charts/terraform-cloud/tests/irsa_workspace_tags_test.yaml
+++ b/charts/terraform-cloud/tests/irsa_workspace_tags_test.yaml
@@ -41,45 +41,7 @@ tests:
                   Owner = "sre"
                   Project = "test-project"
                 }
-  - it: Test IRSA application tag defaults to name
-    set:
-      global.name: test-app
-      global.clusterEnv: dev
-      global.clusterName: cluster1
-      global.clusterRegion: eu-west-1
-      global.component: backend
-      global.owner: sre
-      global.partOf: test-project
-      s3.enabled: true
-    asserts:
-      - matchSnapshot: {} # Check for regressions and unexpected changes.
-      - isKind:
-          of: Workspace
-      - equal:
-          path: metadata.namespace
-          value: test-namespace
-      - equal:
-          path: metadata.name
-          value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
-      - hasDocuments:
-          count: 1
-      - contains:
-          path: spec.variables
-          content:
-            environmentVariable: false
-            hcl: true
-            key: tags
-            sensitive: false
-            value: |-
-                {
-                  Application = "test-app"
-                  Component = "backend"
-                  Owner = "sre"
-                  Project = "test-project"
-                }
-
-
-  - it: Test IRSA component tag can be empty
+  - it: Test IRSA application and component tags default to name
     set:
       global.name: test-app
       global.clusterEnv: dev
@@ -110,6 +72,7 @@ tests:
             value: |-
                 {
                   Application = "test-app"
+                  Component = "test-app"
                   Owner = "sre"
                   Project = "test-project"
                 }

--- a/charts/terraform-cloud/tests/irsa_workspace_test.yaml
+++ b/charts/terraform-cloud/tests/irsa_workspace_test.yaml
@@ -88,6 +88,7 @@ tests:
             value: |-
                 {
                   Application = "test-app"
+                  Component = "test-app"
                   Owner = "sre"
                   Project = "test-project"
                 }

--- a/charts/terraform-cloud/tests/workspace_test.yaml
+++ b/charts/terraform-cloud/tests/workspace_test.yaml
@@ -197,6 +197,7 @@ tests:
             value: |-
               {
                 Application = "test-app"
+                Component = "test-app"
                 Owner = "sre"
                 Project = "test-project"
               }
@@ -425,6 +426,7 @@ tests:
             value: |-
               {
                 Application = "test-app"
+                Component = "test-app"
                 ExtraTagOne = "testTagValueOne"
                 ExtraTagTwo = "testTagValueTwo"
                 MintelEventBus = "true"
@@ -468,6 +470,7 @@ tests:
             value: |-
               {
                 Application = "test-app"
+                Component = "test-app"
                 ExtraTagOne = "testTagValueOne"
                 MintelEventBus = "true"
                 Owner = "sre"
@@ -484,6 +487,7 @@ tests:
             value: |-
               {
                 Application = "test-app"
+                Component = "test-app"
                 ExtraTagOne = "testTagValueOne"
                 ExtraTagTwo = "testTagValueTwo"
                 MintelEventBus = "true"


### PR DESCRIPTION
Initially this will generate duplicate application and component labels (both set to global.name) - but that's ok, as we'll adjust the application label on a per-app basis later.