### PR TITLE
Update healthchecks for celery and support `--timeout` option

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v5.17.0] - 2023-11-14
+### Added
+- Added `--timeout` option to `celery inspect ping` command (configurable via `celery.pingTimeout`)
+
+### Changed
+- Updated `celery` healthchecks to support additional options
+
 ## [v5.16.0] - 2023-10-02
 ### Changed
 - Bumped py-dba to `v0.2.0`

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.16.0
+version: 5.17.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 5.16.0](https://img.shields.io/badge/Version-5.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 5.17.0](https://img.shields.io/badge/Version-5.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/deployment-celery.yaml
+++ b/charts/standard-application-stack/templates/deployment-celery.yaml
@@ -201,7 +201,7 @@ spec:
               command:
               - 'sh'
               - '-c'
-              - 'celery inspect ping -d celery@$(hostname) --timeout {{ coalesce .Values.celery.pingTimeout .Values.celery.liveness.timeoutSeconds 1 }}'
+              - 'celery inspect ping -d celery@$(hostname) --timeout {{ coalesce .Values.celery.pingTimeout .Values.celery.liveness.timeoutSeconds 2 }}'
             {{- end }}
             initialDelaySeconds: {{ .Values.celery.liveness.initialDelaySeconds | default 0 }}
             timeoutSeconds: {{ .Values.celery.liveness.timeoutSeconds | default 2 }}
@@ -220,7 +220,7 @@ spec:
             {{- end }}
             successThreshold: {{ .Values.celery.startup.successThreshold| default 1 }}
             failureThreshold: {{ .Values.celery.startup.failureThreshold | default 60 }}
-            timeoutSeconds: {{ coalesce .Values.celery.startup.timeoutSeconds .Values.celery.liveness.timeoutSeconds 1 }}
+            timeoutSeconds: {{ coalesce .Values.celery.startup.timeoutSeconds .Values.celery.liveness.timeoutSeconds 2 }}
             periodSeconds: {{ coalesce .Values.celery.startup.periodSeconds .Values.celery.liveness.periodSeconds 5 }}
           {{- end }}
           {{- if (and .Values.celery.readiness .Values.celery.readiness.enabled) }}

--- a/charts/standard-application-stack/templates/deployment-celery.yaml
+++ b/charts/standard-application-stack/templates/deployment-celery.yaml
@@ -201,11 +201,13 @@ spec:
               command:
               - 'sh'
               - '-c'
-              - 'celery inspect ping -d celery@$(hostname)'
+              - 'celery inspect ping -d celery@$(hostname) --timeout {{ coalesce .Values.celery.pingTimeout .Values.celery.liveness.timeoutSeconds 1 }}'
             {{- end }}
             initialDelaySeconds: {{ .Values.celery.liveness.initialDelaySeconds | default 0 }}
             timeoutSeconds: {{ .Values.celery.liveness.timeoutSeconds | default 2 }}
             periodSeconds: {{ .Values.celery.liveness.periodSeconds | default 10 }}
+            successThreshold: {{ .Values.celery.liveness.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.celery.liveness.failureThreshold | default 3 }}
           startupProbe:
             {{- if (and .Values.celery.startup .Values.celery.startup.methodOverride) }}
             {{- toYaml .Values.celery.startup.methodOverride | nindent 12 }}
@@ -216,6 +218,7 @@ spec:
               - '-c'
               - 'celery inspect ping -d celery@$(hostname)'
             {{- end }}
+            successThreshold: {{ .Values.celery.startup.successThreshold| default 1 }}
             failureThreshold: {{ .Values.celery.startup.failureThreshold | default 60 }}
             timeoutSeconds: {{ coalesce .Values.celery.startup.timeoutSeconds .Values.celery.liveness.timeoutSeconds 1 }}
             periodSeconds: {{ coalesce .Values.celery.startup.periodSeconds .Values.celery.liveness.periodSeconds 5 }}
@@ -231,8 +234,10 @@ spec:
               scheme: {{ .Values.readiness.scheme | default "HTTP" }}
             {{- end }}
             initialDelaySeconds: {{ .Values.celery.readiness.initialDelaySeconds | default 0 }}
-            timeoutSeconds: {{ .Values.celery.readiness.timeoutSeconds | default 1 }}
+            timeoutSeconds: {{ .Values.celery.readiness.timeoutSeconds | default 2 }}
             periodSeconds: {{ .Values.celery.readiness.periodSeconds | default 10 }}
+            successThreshold: {{ .Values.celery.readiness.successThreshold | default 1 }}
+            failureThreshold: {{ .Values.celery.readiness.failureThreshold | default 3 }}
           {{- end }}
           {{- with .Values.celery.securityContext | default $.Values.securityContext }}
           securityContext: {{ toYaml . | nindent 12 }}

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -794,6 +794,9 @@ celery:
   #  image: ""
   # -- Optional command to the celery container
   #  command: []
+  # -- Optional timeout (seconds) to pass to the 'celery inspect ping' command for health checks
+  #    Defaults to liveness.TimeSeconds
+  # pingTimeout: 1
   # -- Arguments to the celery container
   args:
     - "celery"
@@ -815,7 +818,14 @@ celery:
   liveness:
     # -- Enable liveness probe
     enabled: false
-
+    # -- Period seconds for livenessProbe (frequency)
+    #  periodSeconds: 10
+    # -- Timeout seconds for livenessProbe
+    #  timeoutSeconds: 5
+    # -- Failure threshold for livenessProbe
+    #  failureThreshold: 3
+    # -- Success threshold for livenessProbe
+    #  successThreshold: 1
   # -- Configure extra options for the start-up probe that is enabled when celery.liveness.enabled is set to true
   startup:
     # -- Allows a non-default startup probe implementation
@@ -831,6 +841,16 @@ celery:
   readiness:
     # -- Enable readiness probe
     enabled: false
+    # -- Initial delay seconds for readinessProbe
+    #  initialDelaySeconds: 0
+    # -- Period seconds for readinessProbe (frequency)
+    #  periodSeconds: 10
+    # -- Timeout seconds for readinessProbe
+    #  timeoutSeconds: 5
+    # -- Failure threshold for readinessProbe
+    #  failureThreshold: 3
+    # -- Success threshold for readinessProbe
+    #  successThreshold: 1
   # -- Prometheus Exporter / Metrics
   metrics:
     # -- Enable Prometheus to access application metrics endpoints

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -821,7 +821,7 @@ celery:
     # -- Period seconds for livenessProbe (frequency)
     #  periodSeconds: 10
     # -- Timeout seconds for livenessProbe
-    #  timeoutSeconds: 5
+    #  timeoutSeconds: 2
     # -- Failure threshold for livenessProbe
     #  failureThreshold: 3
     # -- Success threshold for livenessProbe
@@ -846,7 +846,7 @@ celery:
     # -- Period seconds for readinessProbe (frequency)
     #  periodSeconds: 10
     # -- Timeout seconds for readinessProbe
-    #  timeoutSeconds: 5
+    #  timeoutSeconds: 2
     # -- Failure threshold for readinessProbe
     #  failureThreshold: 3
     # -- Success threshold for readinessProbe


### PR DESCRIPTION
Support more timeout related options for celery - this is frequently timing out on some apps causing the health probes to fail.

In particular, the `ping` check supports a `--timeout` option that we should utilize. 