### PR TITLE
update default standard-app-stack image tag to v0.0.0

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v5.18.0] - 2024-01-16
+### Changed
+- Updated standard-application-stack default image tag from v0.1.0 to v0.0.0
+
 ## [v5.17.0] - 2023-11-14
 ### Added
 - Added `--timeout` option to `celery inspect ping` command (configurable via `celery.pingTimeout`)

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 5.17.0
+version: 5.18.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -123,11 +123,11 @@ A generic chart to support most common application requirements
 | hybridCloud.metrics.enabled | bool | `true` | Enable Prometheus to scrape consul proxy metrics |
 | hybridCloud.proxyPort | int | `20000` | Set port for Envoy proxy public listener (the port consul talks back to envoy on) |
 | hybridCloud.upstreamServices | list | `[]` | Defines list of upstream services to connect to  upstreamServices:    - 'service1:1234'    - 'service2:2345' |
-| image | object | `{"pullPolicy":"IfNotPresent","registry":"","repository":"test","tag":"v0.1.0"}` | Docker image values |
+| image | object | `{"pullPolicy":"IfNotPresent","registry":"","repository":"test","tag":"v0.0.0"}` | Docker image values |
 | image.pullPolicy | string | `"IfNotPresent"` | Optional ImagePullPolicy ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images |
 | image.registry | string | `""` | Docker registry used to pull application image |
 | image.repository | string | `"test"` | Docker repository |
-| image.tag | string | `"v0.1.0"` | Container image tag |
+| image.tag | string | `"v0.0.0"` | Container image tag |
 | imagePullSecrets | list | `[]` | Optional array of imagePullSecrets ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | ingress | object | `{"alb":{"backendProtocol":"HTTP","backendProtocolVersion":"HTTP1","enabled":true,"healthcheck":{"healthyThresholdCount":2,"intervalSeconds":15,"protocol":"HTTP","timeoutSeconds":5,"unhealthyThresholdCount":2},"okta":{"authOnUnauthenticated":"authenticate","enabled":false,"extraRedirectPaths":[],"groups":"","ingressName":"","redirectPath":"","users":""},"preStopDelay":{"delaySeconds":15,"enabled":true},"scheme":"internet-facing","targetGroupAttributes":{"deregistration_delay.timeout_seconds":5,"load_balancing.algorithm.type":"least_outstanding_requests"}},"allowFrontendAccess":false,"allowLivenessUrl":false,"allowReadinessUrl":false,"blackbox":{"enabled":true,"probePath":"/external-health-check","probeScheme":"https"},"enabled":false,"extraAnnotations":{},"extraHosts":[],"extraIngresses":[],"setNoCacheHeaders":false,"setXForwardedForHeaders":false,"specificRulesHostsYaml":{},"specificTlsHostsYaml":{},"tls":true}` | Configure the ingress resource that allows you to access the application from public-internet ref: http://kubernetes.io/docs/user-guide/ingress/ |
 | ingress.alb.backendProtocol | string | `"HTTP"` | Application Version (HTTP / HTTPS) |

--- a/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
@@ -48,7 +48,7 @@ Check CronJob Default Overrides:
                     - name: RUNTIME_ENVIRONMENT
                       value: kubernetes
                   envFrom: null
-                  image: registry.gitlab.com/test:v0.1.0
+                  image: registry.gitlab.com/test:v0.0.0
                   imagePullPolicy: IfNotPresent
                   name: main
                   securityContext:
@@ -119,7 +119,7 @@ Check CronJob Defaults:
                     - name: RUNTIME_ENVIRONMENT
                       value: kubernetes
                   envFrom: null
-                  image: registry.gitlab.com/test:v0.1.0
+                  image: registry.gitlab.com/test:v0.0.0
                   imagePullPolicy: IfNotPresent
                   name: main
                   securityContext:
@@ -190,7 +190,7 @@ Check CronJob Job Overrides:
                     - name: RUNTIME_ENVIRONMENT
                       value: kubernetes
                   envFrom: null
-                  image: registry.gitlab.com/test:v0.1.0
+                  image: registry.gitlab.com/test:v0.0.0
                   imagePullPolicy: IfNotPresent
                   name: main
                   securityContext:
@@ -261,7 +261,7 @@ Check CronJob ttlSecondsAfterFinished zero value:
                     - name: RUNTIME_ENVIRONMENT
                       value: kubernetes
                   envFrom: null
-                  image: registry.gitlab.com/test:v0.1.0
+                  image: registry.gitlab.com/test:v0.0.0
                   imagePullPolicy: IfNotPresent
                   name: main
                   securityContext:
@@ -331,7 +331,7 @@ CronJob can have a timezone:
                     - name: RUNTIME_ENVIRONMENT
                       value: kubernetes
                   envFrom: null
-                  image: registry.gitlab.com/test:v0.1.0
+                  image: registry.gitlab.com/test:v0.0.0
                   imagePullPolicy: IfNotPresent
                   name: main
                   securityContext:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -57,7 +57,7 @@ Check DynamoDB envfrom secretRef is present:
               envFrom:
                 - secretRef:
                     name: test-app-dynamodb
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -177,7 +177,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
               envFrom:
                 - secretRef:
                     name: test-app-dynamodb
-              image: k3d-default.localhost:5000/test:v0.1.0
+              image: k3d-default.localhost:5000/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -283,7 +283,7 @@ Check DynamoDB secretName Override:
               envFrom:
                 - secretRef:
                     name: overrideName
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
@@ -62,7 +62,7 @@ Check celery does not pull in `main.env` values:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               name: main
               ports:
@@ -154,7 +154,7 @@ Check default env behavior:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -272,7 +272,7 @@ Check main container combines default env and `main.env` values:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -57,7 +57,7 @@ Has a pod template that uses the host network:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
@@ -77,7 +77,7 @@ Check custom python otel extraEnv vars are added:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -211,7 +211,7 @@ Check custom sampler settings:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -343,7 +343,7 @@ Check default python otel envars are added:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -477,7 +477,7 @@ Check global otel extraEnv vars are added:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_labels_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_labels_test.yaml.snap
@@ -59,7 +59,7 @@ Check default label behavior:
               envFrom:
                 - secretRef:
                     name: app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -175,7 +175,7 @@ Check empty application and component labels both default to name:
               envFrom:
                 - secretRef:
                     name: app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -63,7 +63,7 @@ Check AWS ALB lifecycle rule applied:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:
@@ -190,7 +190,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:
@@ -317,7 +317,7 @@ Check AWS ALB lifecycle rules are not applied when ALB disabled:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -431,7 +431,7 @@ Check AWS ALB lifecycle rules are not applied when ALB enabled (but Ingress disa
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -545,7 +545,7 @@ Check lifecycle rules:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -57,7 +57,7 @@ Check MariaDB envfrom secretRef is present:
               envFrom:
                 - secretRef:
                     name: test-app-mariadb
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -177,7 +177,7 @@ Check MariaDB envfrom secretRef is present for local environment:
               envFrom:
                 - secretRef:
                     name: test-app-mariadb
-              image: k3d-default.localhost:5000/test:v0.1.0
+              image: k3d-default.localhost:5000/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -283,7 +283,7 @@ Check MariaDB secretName Override:
               envFrom:
                 - secretRef:
                     name: overrideName
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
@@ -57,7 +57,7 @@ Check Memcached envfrom secretRef is present:
               envFrom:
                 - secretRef:
                     name: test-app-memcached
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -177,7 +177,7 @@ Check Memcached envfrom secretRef is present for local environment:
               envFrom:
                 - secretRef:
                     name: test-app-memcached
-              image: k3d-default.localhost:5000/test:v0.1.0
+              image: k3d-default.localhost:5000/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -283,7 +283,7 @@ Check Memcached secretName Override:
               envFrom:
                 - secretRef:
                     name: overrideName
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -57,7 +57,7 @@ Check container extraPorts:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -175,7 +175,7 @@ Check container extraPorts are validated:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -295,7 +295,7 @@ Check container extraPorts protocol:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -415,7 +415,7 @@ Check container hybrid cloud ports:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -533,7 +533,7 @@ Check default container main port:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -647,7 +647,7 @@ Check overridden container main port:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -58,7 +58,7 @@ Check allowSingleReplica doesn't alter strategy:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -173,7 +173,7 @@ Check allowSingleReplica set annotations:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -286,7 +286,7 @@ Check replicas unset when autoscaling is enabled:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -398,7 +398,7 @@ Check singleReplicaOnly applied:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -510,7 +510,7 @@ Check singleReplicaOnly ignore replicas value:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -57,7 +57,7 @@ Check S3 envfrom secretRef is present:
               envFrom:
                 - secretRef:
                     name: test-app-s3
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -177,7 +177,7 @@ Check S3 envfrom secretRef is present for local environment:
               envFrom:
                 - secretRef:
                     name: test-app-s3
-              image: k3d-default.localhost:5000/test:v0.1.0
+              image: k3d-default.localhost:5000/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -290,7 +290,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
                     name: mntl-test-bucket-another-s3
                 - secretRef:
                     name: mntl-test-bucket-s3
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -405,7 +405,7 @@ Check S3 secretName Override:
               envFrom:
                 - secretRef:
                     name: overrideName
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -530,7 +530,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
                     name: mntl-test-bucket-s3
                 - secretRef:
                     name: test-app-extra-secret-1
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
@@ -52,7 +52,7 @@ Check stateful set is rendered with volumeClaimTemplates:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -413,7 +413,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
               envFrom:
                 - secretRef:
                     name: example-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               lifecycle:
                 preStop:

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -197,7 +197,7 @@ Check default values are correct with minimal configuration:
                 - name: RUNTIME_ENVIRONMENT
                   value: kubernetes
               envFrom: null
-              image: registry.example.com/test/image/repo:v0.1.0
+              image: registry.example.com/test/image/repo:v0.0.0
               imagePullPolicy: IfNotPresent
               name: main
               resources:

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -57,7 +57,7 @@ Check default container args:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -228,7 +228,7 @@ Check setting skip-auth-regex from extra passed in values:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -400,7 +400,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -572,7 +572,7 @@ Check setting skip-auth-regex from overridden health-check values:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -743,7 +743,7 @@ Check sidecar present if enabled:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -238,7 +238,7 @@ Check combined template defaults:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -402,7 +402,7 @@ Check combined template with extra ports and monitors:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -289,7 +289,7 @@ Check combined template defaults:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:
@@ -485,7 +485,7 @@ Check combined template with extra ports and monitors:
               envFrom:
                 - secretRef:
                     name: test-app-app
-              image: registry.gitlab.com/test:v0.1.0
+              image: registry.gitlab.com/test:v0.0.0
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 httpGet:

--- a/charts/standard-application-stack/tests/jobs_test.yaml
+++ b/charts/standard-application-stack/tests/jobs_test.yaml
@@ -33,7 +33,7 @@ tests:
           count: 1
       - equal:
           path: spec.template.spec.containers[0].image
-          value: registry.example.com/test/image/repo:v0.1.0
+          value: registry.example.com/test/image/repo:v0.0.0
       - equal:
           path: spec.ttlSecondsAfterFinished
           value: 60

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -68,7 +68,7 @@ image:
   # -- Docker repository
   repository: "test"
   # -- Container image tag
-  tag: "v0.1.0"
+  tag: "v0.0.0"
   # -- Optional ImagePullPolicy
   # ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   pullPolicy: IfNotPresent


### PR DESCRIPTION
We are adding a check to our pipeline to prevent anyone building and publishing an image with tag v0.0.0 so this mr is to simply make that the default.  This will mean that for new apps  argocd-image-updater cant release a new image to an app before a version above v0.0.0 is built.  This will prevent accidental releases.  