### PR TITLE
Fix basic-config Service selector some more

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,6 @@ repos:
     - id: no-commit-to-branch
       args: [--branch, main]
 - repo: https://github.com/norwoodj/helm-docs
-  rev: v1.11.0
+  rev: v1.12.0
   hooks:
     - id: helm-docs

--- a/charts/basic-config/CHANGELOG.md
+++ b/charts/basic-config/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.3.2] - 2024-01-12
+### Fixed
+- Fix template for Service selector, but better this time!
+
 ## [v0.3.1] - 2024-01-12
 ### Fixed
 - Fix template for Service selector

--- a/charts/basic-config/Chart.yaml
+++ b/charts/basic-config/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.1
+version: 0.3.2

--- a/charts/basic-config/README.md
+++ b/charts/basic-config/README.md
@@ -1,6 +1,6 @@
 # basic-config
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for defining basic k8s configuration res
 

--- a/charts/basic-config/templates/service.yaml
+++ b/charts/basic-config/templates/service.yaml
@@ -15,5 +15,5 @@ spec:
   clusterIP: None
   {{- end }}
   type: {{ .Values.service.type }}
-  selector: {{ toYaml .Values.service.selectorLabelsOverride | default (include "mintel_common.selectorLabels" .) | nindent 6 }}
+  selector: {{ .Values.service.selectorLabelsOverride | default (include "mintel_common.selectorLabels" .) | toYaml | nindent 6 }}
 {{- end }}

--- a/charts/basic-config/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/basic-config/tests/__snapshot__/service_test.yaml.snap
@@ -14,5 +14,7 @@ Renders headless service:
       namespace: test-namespace
     spec:
       clusterIP: None
-      selector: {}
+      selector: |-
+        app.kubernetes.io/name: test-app
+        app.kubernetes.io/component: app
       type: ClusterIP


### PR DESCRIPTION
The default selector doesn't work because `toYaml {} => "{}"`, which is a non-empty string i.e. not a false-y value, so the `default` doesn't kick in.