### PR TITLE
INFRA-33706: Keda should fallback to minReplicaCount 

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v6.2.0] - 2024-03-06
+### Changed
+- Update keda to set `fallback.replicas` based on `minReplicaCount` (unless otherwise set)
+
 ## [v6.1.0] - 2024-03-05
 ### Added
 - Added support for the API gateway.

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.1.0
+version: 6.2.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 6.1.0](https://img.shields.io/badge/Version-6.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -29,7 +29,7 @@ A generic chart to support most common application requirements
 | affinity.podAntiAffinity.zone | string | `"hard"` | Toggle whether zone affinity should be required (hard) or preferred (soft) |
 | allowSingleReplica | bool | `false` | Explicitly allow the number of replicas to equal 1 Useful for backend event based services where we may only want a single replica but still want rolling updates etc |
 | args | list | `[]` | Optional arguments to the container |
-| autoscaling | object | `{"advanced":{},"cooldownPeriod":300,"enableZeroReplicas":false,"enabled":false,"fallback":{"failureThreshold":3,"replicas":2},"maxReplicaCount":5,"minReplicaCount":2,"pollingInterval":30,"scaleTargetRef":{"apiVersion":"apps/v1","envSourceContainerName":"","kind":"Deployment"},"triggers":{}}` | Handle autoscaling via https://keda.sh Creates a ScaledObject for the workload ref: https://keda.sh/docs/2.8/concepts/scaling-deployments/ |
+| autoscaling | object | `{"advanced":{},"cooldownPeriod":300,"enableZeroReplicas":false,"enabled":false,"fallback":{"failureThreshold":3},"maxReplicaCount":5,"minReplicaCount":2,"pollingInterval":30,"scaleTargetRef":{"apiVersion":"apps/v1","envSourceContainerName":"","kind":"Deployment"},"triggers":{}}` | Handle autoscaling via https://keda.sh Creates a ScaledObject for the workload ref: https://keda.sh/docs/2.8/concepts/scaling-deployments/ |
 | celery | object | `{"args":["celery"],"enabled":false,"liveness":{"enabled":false},"metrics":{"enabled":true,"port":"metrics"},"podDisruptionBudget":{"enabled":true,"minAvailable":"50%"},"readiness":{"enabled":false},"replicas":2,"resources":{"limits":{},"requests":{}},"startup":{"failureThreshold":60,"methodOverride":{},"periodSeconds":5}}` | Configure celery deployment Defaults to same image as main deployment but with the "celery" argument |
 | celery.args | list | `["celery"]` | Arguments to the celery container |
 | celery.enabled | bool | `false` | Set to true to enable a celery deployment |

--- a/charts/standard-application-stack/templates/keda-scaled-object.yaml
+++ b/charts/standard-application-stack/templates/keda-scaled-object.yaml
@@ -30,7 +30,7 @@ spec:
     {{- toYaml .advanced | nindent 4 }}
   fallback:
     failureThreshold: {{ .fallback.failureThreshold }}
-    replicas: {{ .fallback.replicas }}
+    replicas: {{ .fallback.replicas | default (include "mintel_common.keda.scaledObject.minReplicaCount" .) }}
   {{- with .triggers }}
   triggers:
   {{- if .targetCPUUtilizationPercentage }}

--- a/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_test.yaml.snap
@@ -314,7 +314,36 @@ Creates a ScaledObject with custom triggers:
             serverAddress: http://prometheus-k8s.monitoring.svc:9090
             threshold: "10"
           type: prometheus
-Creates a ScaledObject with fallback settings:
+Creates a ScaledObject with default fallback based on minReplicaCount:
+  1: |
+    apiVersion: keda.sh/v1alpha1
+    kind: ScaledObject
+    metadata:
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: example-app
+        app.mintel.com/application: example-app
+        app.mintel.com/component: example-app
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: example-app
+      name: example-app
+      namespace: test-namespace
+    spec:
+      advanced: {}
+      cooldownPeriod: 300
+      fallback:
+        failureThreshold: 1
+        replicas: 3
+      maxReplicaCount: 5
+      minReplicaCount: 3
+      pollingInterval: 30
+      scaleTargetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: example-app
+Creates a ScaledObject with explicit fallback settings:
   1: |
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject

--- a/charts/standard-application-stack/tests/keda_scaled_object_test.yaml
+++ b/charts/standard-application-stack/tests/keda_scaled_object_test.yaml
@@ -147,7 +147,7 @@ tests:
                 serverAddress: 'http://prometheus-k8s.monitoring.svc:9090'
                 threshold: '10'
 
-  - it: Creates a ScaledObject with fallback settings
+  - it: Creates a ScaledObject with explicit fallback settings
     set:
       global.clusterEnv: qa
       autoscaling.enabled: true
@@ -172,6 +172,33 @@ tests:
           value:
             failureThreshold: 1
             replicas: 10
+
+  - it: Creates a ScaledObject with default fallback based on minReplicaCount
+    set:
+      global.clusterEnv: qa
+      autoscaling.enabled: true
+      autoscaling.minReplicaCount: 3
+      autoscaling.fallback:
+        failureThreshold: 1
+        ignoredValue: true
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - isKind:
+          of: ScaledObject
+      - equal:
+          path: metadata.namespace
+          value: test-namespace
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: example-app
+      - equal:
+          path: spec.fallback
+          value:
+            failureThreshold: 1
+            replicas: 3
+
 
   - it: Creates a ScaledObject with advanced settings
     set:

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -146,7 +146,8 @@ autoscaling:
   # ref: https://keda.sh/docs/2.8/concepts/scaling-deployments/#fallback
   fallback:
     failureThreshold: 3
-    replicas: 2
+     # fallback.replicas will default to minReplicaCount unless explicitly set
+     # replicas: 2
 
   # ref: https://keda.sh/docs/2.8/concepts/scaling-deployments/#advanced
   advanced: {}


### PR DESCRIPTION
Our default value for keda `fallback.replicas` might be too low for some apps.

It's safer to use `minReplicaCount` since that should be set on the min number of replicas that the site needs to meet it's SLA.