### PR TITLE
INFRA-33709: Remove Keda metricName from prometheus scaler (not used)

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [v6.3.0] - 2024-03-14
+### Removed
+- Removed `metricName` from Keda prometheus scaler (not used and removed upstream)
+
 ## [v6.2.0] - 2024-03-06
 ### Changed
 - Update keda to set `fallback.replicas` based on `minReplicaCount` (unless otherwise set)

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.2.0
+version: 6.3.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 6.2.0](https://img.shields.io/badge/Version-6.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 6.3.0](https://img.shields.io/badge/Version-6.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_test.yaml.snap
@@ -303,13 +303,11 @@ Creates a ScaledObject with custom triggers:
         name: example-app
       triggers:
         - metadata:
-            metricName: http_requests_total
             query: sum(rate(http_requests_total{service="podinfo-http"}[2m]))
             serverAddress: http://prometheus-k8s.monitoring.svc:9090
             threshold: "5"
           type: prometheus
         - metadata:
-            metricName: http_requests_total
             query: sum(rate(http_requests_total{service="podinfo-grpc"}[5m]))
             serverAddress: http://prometheus-k8s.monitoring.svc:9090
             threshold: "10"

--- a/charts/standard-application-stack/tests/keda_scaled_object_test.yaml
+++ b/charts/standard-application-stack/tests/keda_scaled_object_test.yaml
@@ -109,13 +109,11 @@ tests:
       autoscaling.triggers.custom:
         - type: 'prometheus'
           metadata:
-            metricName: 'http_requests_total'
             query: 'sum(rate(http_requests_total{service="podinfo-http"}[2m]))'
             serverAddress: 'http://prometheus-k8s.monitoring.svc:9090'
             threshold: '5'
         - type: 'prometheus'
           metadata:
-            metricName: 'http_requests_total'
             query: 'sum(rate(http_requests_total{service="podinfo-grpc"}[5m]))'
             serverAddress: 'http://prometheus-k8s.monitoring.svc:9090'
             threshold: '10'
@@ -136,13 +134,11 @@ tests:
           value:
             - type: 'prometheus'
               metadata:
-                metricName: 'http_requests_total'
                 query: 'sum(rate(http_requests_total{service="podinfo-http"}[2m]))'
                 serverAddress: 'http://prometheus-k8s.monitoring.svc:9090'
                 threshold: '5'
             - type: 'prometheus'
               metadata:
-                metricName: 'http_requests_total'
                 query: 'sum(rate(http_requests_total{service="podinfo-grpc"}[5m]))'
                 serverAddress: 'http://prometheus-k8s.monitoring.svc:9090'
                 threshold: '10'
@@ -602,8 +598,6 @@ tests:
             queueURL: test-queue
             queueLength: 2
         - type: prometheus
-          metadata:
-            metricName: http_requests_total
     asserts:
       - matchSnapshot: {} # Check for regressions and unexpected changes.
       - isKind:
@@ -644,7 +638,6 @@ tests:
               queueLength: "2"
           - type: prometheus
             metadata:
-              metricName: http_requests_total
               serverAddress: http://prometheus-k8s.monitoring.svc:9090
 
   - it: Check trigger vars can be overriden
@@ -669,7 +662,6 @@ tests:
             queueLength: 2
         - type: prometheus
           metadata:
-            metricName: http_requests_total
             serverAddress: http://alt-prometheus-k8s.monitoring.svc:9090
     asserts:
       - matchSnapshot: {} # Check for regressions and unexpected changes.
@@ -711,5 +703,4 @@ tests:
               queueLength: "2"
           - type: prometheus
             metadata:
-              metricName: http_requests_total
               serverAddress: http://alt-prometheus-k8s.monitoring.svc:9090

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -179,7 +179,6 @@ autoscaling:
     #      queueLength: "20"
     #  - type: 'prometheus'
     #    metadata:
-    #      metricName: 'http_requests_total',
     #      query: 'sum(rate(http_requests_total{service="podinfo-http"}[2m]))',
     #      threshold: '5',
 


### PR DESCRIPTION
For prometheus, this is no longer required from upstream. It's an internal to keda regardless.

This MR doesn't actually change functionality since it never validated what was specified under `metadata`... - but it does fix the docs :)