### PR TITLE
INFRA-34065: Add support for karpenter `do-not-disrupt` annotation on CronJobs/Jobs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
-helm 3.13.3
+#helm 3.13.3
+helm 3.14.3
 helm-docs 1.12.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,2 @@
-#helm 3.13.3
-helm 3.14.3
+helm 3.13.3
 helm-docs 1.12.0

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v6.4.0] - 2024-03-21
+### Added
+- Added `enableDoNotDisrupt` flag to CronJobs and Jobs. Sets the `karpenter.sh/do-not-disrupt` annotation.
+
 ## [v6.3.0] - 2024-03-14
 ### Removed
 - Removed `metricName` from Keda prometheus scaler (not used and removed upstream)

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v6.4.0] - 2024-03-21
 ### Added
 - Added `enableDoNotDisrupt` flag to CronJobs and Jobs. Sets the `karpenter.sh/do-not-disrupt` annotation.
+### Fixed
+- Use of `documentSelector` in test cases now need to specify `templates` in latest version of `helm-unittest`
 
 ## [v6.3.0] - 2024-03-14
 ### Removed

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.7.0
+version: 6.4.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 6.3.0
+version: 6.7.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 6.3.0](https://img.shields.io/badge/Version-6.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 6.7.0](https://img.shields.io/badge/Version-6.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -61,9 +61,10 @@ A generic chart to support most common application requirements
 | celeryBeat.resources.requests | object | `{}` | The requested resources for the container |
 | command | list | `["/app/docker-entrypoint.sh"]` | Optional command to the container |
 | configMaps | list | `[]` | A list of configuration maps for this application |
-| cronjobs | object | `{"defaults":{"concurrencyPolicy":"Forbid","restartPolicy":"Never","suspend":false,"timezone":null,"ttlSecondsAfterFinished":60},"jobs":[]}` | Define and Configure CronJob's Defaults to same image as main deployment but with defined arguments |
-| cronjobs.defaults | object | `{"concurrencyPolicy":"Forbid","restartPolicy":"Never","suspend":false,"timezone":null,"ttlSecondsAfterFinished":60}` | Defaults for all CronJob's |
+| cronjobs | object | `{"defaults":{"concurrencyPolicy":"Forbid","enableDoNotDisrupt":true,"restartPolicy":"Never","suspend":false,"timezone":null,"ttlSecondsAfterFinished":60},"jobs":[]}` | Define and Configure CronJob's Defaults to same image as main deployment but with defined arguments |
+| cronjobs.defaults | object | `{"concurrencyPolicy":"Forbid","enableDoNotDisrupt":true,"restartPolicy":"Never","suspend":false,"timezone":null,"ttlSecondsAfterFinished":60}` | Defaults for all CronJob's |
 | cronjobs.defaults.concurrencyPolicy | string | `"Forbid"` | Tells controller how to handle concurrent executions of a CronJob ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec |
+| cronjobs.defaults.enableDoNotDisrupt | bool | `true` | Whether to set the `karpenter.sh/do-not-disrupt`annotation on the CronJob |
 | cronjobs.defaults.restartPolicy | string | `"Never"` | Configure CronJob pod restart Policy ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy |
 | cronjobs.defaults.suspend | bool | `false` | Tells controller to suspend future executions ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/cron-job-v1/#CronJobSpec |
 | cronjobs.defaults.timezone | string | `nil` | CronJob schedule will run relative to this timezone. ref: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones |
@@ -165,6 +166,7 @@ A generic chart to support most common application requirements
 | jobDefaults.argo.syncWave | string | `nil` | Sync Wave in which ArgoCD should apply the manifest. ref: https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/. |
 | jobDefaults.args | string | `nil` | The command arguments for the main Job container. |
 | jobDefaults.command | string | `nil` | The command the main Job container will run. |
+| jobDefaults.enableDoNotDisrupt | bool | `true` | Whether to set the `karpenter.sh/do-not-disrupt`annotation on the Job |
 | jobDefaults.env | list | `[]` | Any env entries you want to add. See includeBaseEnv to add all from main container. ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/ |
 | jobDefaults.envFrom | list | `[]` | Any envFrom entries you want to add. See includeBaseEnv to add all from main container. ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/ |
 | jobDefaults.extraInitContainers | list | `[]` | A list of initContainers you want to add to the Job. |

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 6.7.0](https://img.shields.io/badge/Version-6.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 6.4.0](https://img.shields.io/badge/Version-6.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/cronjobs.yaml
+++ b/charts/standard-application-stack/templates/cronjobs.yaml
@@ -29,6 +29,10 @@ spec:
       template:
         metadata:
           labels: {{ include "mintel_common.labels" $data | nindent 12 }}
+          {{- if ($.Values.cronjobs.defaults.enableDoNotDisrupt) }}
+          annotations:
+            karpenter.sh/do-not-disrupt: "true"
+          {{- end }}
         spec:
           {{- include "mintel_common.imagePullSecrets" $ | nindent 10 }}
           {{- with .podSecurityContext | default $.Values.podSecurityContext }}

--- a/charts/standard-application-stack/templates/jobs.yaml
+++ b/charts/standard-application-stack/templates/jobs.yaml
@@ -22,6 +22,11 @@ spec:
   ttlSecondsAfterFinished: {{ $ttl}}
   {{- end }}
   template:
+    {{- if (.enableDoNotDisrupt) }}
+    metadata:
+      annotations:
+        karpenter.sh/do-not-disrupt: "true"
+    {{- end }}
     spec:
       {{- include "mintel_common.imagePullSecrets" $ | nindent 6 }}
       {{- if (or .includeBasePodSecurityContext .podSecurityContext) }}

--- a/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
@@ -93,6 +93,8 @@ Check CronJob Defaults:
         spec:
           template:
             metadata:
+              annotations:
+                karpenter.sh/do-not-disrupt: "true"
               labels:
                 app.kubernetes.io/component: daily
                 app.kubernetes.io/managed-by: Helm
@@ -164,6 +166,8 @@ Check CronJob Job Overrides:
         spec:
           template:
             metadata:
+              annotations:
+                karpenter.sh/do-not-disrupt: "true"
               labels:
                 app.kubernetes.io/component: daily
                 app.kubernetes.io/managed-by: Helm
@@ -235,6 +239,8 @@ Check CronJob ttlSecondsAfterFinished zero value:
         spec:
           template:
             metadata:
+              annotations:
+                karpenter.sh/do-not-disrupt: "true"
               labels:
                 app.kubernetes.io/component: daily
                 app.kubernetes.io/managed-by: Helm
@@ -305,6 +311,8 @@ CronJob can have a timezone:
         spec:
           template:
             metadata:
+              annotations:
+                karpenter.sh/do-not-disrupt: "true"
               labels:
                 app.kubernetes.io/component: daily
                 app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -89,6 +89,9 @@ Check all overrides/additions from main deployment work if enabled:
       namespace: testNamespace
     spec:
       template:
+        metadata:
+          annotations:
+            karpenter.sh/do-not-disrupt: "true"
         spec:
           containers:
             - env:
@@ -185,6 +188,9 @@ Check default values are correct with minimal configuration:
       namespace: testNamespace
     spec:
       template:
+        metadata:
+          annotations:
+            karpenter.sh/do-not-disrupt: "true"
         spec:
           containers:
             - env:
@@ -220,7 +226,7 @@ Check default values are correct with minimal configuration:
           restartPolicy: Never
           serviceAccountName: testGlobalName-testJobName
       ttlSecondsAfterFinished: 60
-checks that rbac is set up correctly for kubelock:
+Checks that RBAC is set up correctly for kubelock:
   1: |
     apiVersion: batch/v1
     kind: Job
@@ -240,6 +246,9 @@ checks that rbac is set up correctly for kubelock:
       namespace: testNamespace
     spec:
       template:
+        metadata:
+          annotations:
+            karpenter.sh/do-not-disrupt: "true"
         spec:
           containers:
             - env:

--- a/charts/standard-application-stack/tests/cronjob_test.yaml
+++ b/charts/standard-application-stack/tests/cronjob_test.yaml
@@ -43,6 +43,10 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.ttlSecondsAfterFinished
           value: 60
+      - equal:
+          path: spec.jobTemplate.spec.template.metadata.annotations["karpenter.sh/do-not-disrupt"]
+          value: "true"
+
   - it: Check CronJob Default Overrides
     set:
       global.clusterEnv: qa
@@ -52,6 +56,7 @@ tests:
           suspend: true
           restartPolicy: OnFailure
           ttlSecondsAfterFinished: 120
+          enableDoNotDisrupt: false
       cronjobs.jobs:
         - name: daily
           schedule: "0 1 * * *"
@@ -87,6 +92,9 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.ttlSecondsAfterFinished
           value: 120
+      - isNull:
+          path: spec.jobTemplate.spec.template.metadata.annotations["karpenter.sh/do-not-disrupt"]
+
   - it: Check CronJob Job Overrides
     set:
       global.clusterEnv: qa

--- a/charts/standard-application-stack/tests/jobs_test.yaml
+++ b/charts/standard-application-stack/tests/jobs_test.yaml
@@ -37,6 +37,10 @@ tests:
       - equal:
           path: spec.ttlSecondsAfterFinished
           value: 60
+      - equal:
+          path: spec.template.metadata.annotations["karpenter.sh/do-not-disrupt"]
+          value: "true"
+
   - it: Check all .job.* values can be set correctly, without overriding from main deployment
     set:
       global.clusterEnv: testClusterEnv
@@ -52,6 +56,7 @@ tests:
             syncWave: '-1'
           restartPolicy: OnFailure
           ttlSecondsAfterFinished: 120
+          enableDoNotDisrupt: false
           image: registry.example.com/another/image/repo:anotherTag
           command:
             - echo
@@ -142,6 +147,9 @@ tests:
       - equal:
           path: spec.ttlSecondsAfterFinished
           value: 120
+      - isNull:
+          path: spec.template.metadata.annotations["karpenter.sh/do-not-disrupt"]
+
   - it: Check all overrides/additions from main deployment work if enabled
     set:
       global.clusterEnv: testClusterEnv
@@ -228,7 +236,7 @@ tests:
             - secretRef:
                 name: another-secret-ref
         documentIndex: 0
-  - it: checks that rbac is set up correctly for kubelock
+  - it: Checks that RBAC is set up correctly for kubelock
     set:
       global.clusterEnv: testClusterEnv
       global.name: testGlobalName

--- a/charts/standard-application-stack/tests/vpa_test.yaml
+++ b/charts/standard-application-stack/tests/vpa_test.yaml
@@ -171,6 +171,8 @@ tests:
       cronjobsOnly: false
       opensearch.enabled: true
       opensearch.awsEsProxy.enabled: true
+    templates:
+      - vpa.yaml
     documentSelector:
       path: metadata.name
       value: deployment-example-app-aws-es-proxy
@@ -206,6 +208,8 @@ tests:
       verticalPodAutoscaler.enabled: true
       cronjobsOnly: false
       celery.enabled: true
+    templates:
+      - vpa.yaml
     documentSelector:
       path: metadata.name
       value: deployment-example-app-celery
@@ -242,6 +246,8 @@ tests:
       cronjobsOnly: false
       celery.enabled: true
       celeryBeat.enabled: true
+    templates:
+      - vpa.yaml
     documentSelector:
       path: metadata.name
       value: deployment-example-app-celery-beat
@@ -279,6 +285,8 @@ tests:
       celery.enabled: true
       redis.enabled: true
       celery.metrics.enabled: true
+    templates:
+      - vpa.yaml
     documentSelector:
       path: metadata.name
       value: deployment-example-app-celery-exporter
@@ -315,6 +323,8 @@ tests:
       cronjobsOnly: false
       mariadb.enabled: true
       mariadb.client.enabled: true
+    templates:
+      - vpa.yaml
     documentSelector:
       path: metadata.name
       value: deployment-example-app-mysqlclient
@@ -351,6 +361,8 @@ tests:
       cronjobsOnly: false
       mariadb.enabled: true
       mariadb.metrics.enabled: true
+    templates:
+      - vpa.yaml
     documentSelector:
       path: metadata.name
       value: deployment-example-app-mysqldexporter
@@ -387,6 +399,8 @@ tests:
       cronjobsOnly: false
       postgresql.enabled: true
       postgresql.metrics.enabled: true
+    templates:
+      - vpa.yaml
     documentSelector:
       path: metadata.name
       value: deployment-example-app-postgresqlexporter
@@ -423,6 +437,8 @@ tests:
       cronjobsOnly: false
       postgresql.enabled: true
       postgresql.metrics.enabled: true
+    templates:
+      - vpa.yaml
     documentSelector:
       path: metadata.name
       value: deployment-example-app-postgresqlclient

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -897,6 +897,9 @@ cronjobs:
     # ref: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
     timezone: null
 
+    # -- Whether to set the `karpenter.sh/do-not-disrupt`annotation on the CronJob
+    enableDoNotDisrupt: true
+
   # -- List of Cronjob configurations to be defined
   jobs:
     []
@@ -941,6 +944,7 @@ cronjobs:
     #   includeElasticsearchSecret: false
     #   includeOpensearchSecret: false
 
+
 # -- Configure default values for all jobs as defined in `$.Values.jobs`
 # @default -- See below.
 jobDefaults:
@@ -954,6 +958,8 @@ jobDefaults:
   includeBaseEnv: false
   # -- Whether you want the securityContext used by the main app workload to be the same in the Job
   includeBasePodSecurityContext: false
+  # -- Whether to set the `karpenter.sh/do-not-disrupt`annotation on the Job
+  enableDoNotDisrupt: true
   # -- Whether the pod should be restarted on failure
   # ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy)
   restartPolicy: Never


### PR DESCRIPTION
Long(ish) running Jobs are getting evicted frequently with karpenter - this mitigates against that.

Also required fix to work with latest `helm-unittest` (updates to `vpa_test.yaml`) - see https://github.com/helm-unittest/helm-unittest/releases/tag/v0.4.3 