### PR TITLE
tf 1.3 upgrade - bump all module versions in the terraform-cloud chart

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.0] - 2024-04-25
+### Changed
+- Bumped all module versions to the current latest
+
 ## [v0.51.0] - 2024-01-13
 ### Changed
 - Bumped s3 module version to `2.0.5`

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.51.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -81,7 +81,7 @@ A Helm chart for provisioning resources using Terraform Cloud
 | global.terraform.irsa | bool | `true` | Set to true as part of tf cloud migrations. When true, standard-application-stack sets the service account eks annotation to match the new IAM roles created by the app-iam module |
 | global.terraform.organization | string | `"Mintel"` | Name of our Terraform Cloud org |
 | global.terraform.secretsMountPath | string | `"/tmp/secrets"` | Where secrets are mounted inside the Terraform Operator container |
-| global.terraform.terraformVersion | string | `"1.3.0"` | Global Terraform version for all modules |
+| global.terraform.terraformVersion | string | `"1.3.10"` | Global Terraform version for all modules |
 | irsa.enabled | bool | `false` | Set to true to explicitly instantiate this module if there's need to access resources created elsewhere |
 | irsa.terraform | object | `{"module":{"source":"app.terraform.io/Mintel/app-iam/aws","version":"2.5.1"},"notifications":[{"enabled":true,"name":"tfcloud-auto-approver","token":"${TFCLOUD_AUTO_APPROVER_SIGNATURE_KEY}","triggers":["run:needs_attention"],"type":"generic","url":"${TFCLOUD_AUTO_APPROVER_URL}"}],"vars":{}}` | Set ArgoCD syncWave for this resource (default -20) syncWave: -20 |
 | irsa.terraform.module.source | string | `"app.terraform.io/Mintel/app-iam/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/app-iam/aws) |

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 0.51.0](https://img.shields.io/badge/Version-0.51.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 
@@ -10,18 +10,18 @@ A Helm chart for provisioning resources using Terraform Cloud
 |-----|------|---------|-------------|
 | activeMQ.enabled | bool | `false` | Set to true to create an activeMQ AWS amazonMQ instance |
 | activeMQ.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| activeMQ.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/amazonmq/aws","version":"0.0.2"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| activeMQ.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/amazonmq/aws","version":"0.0.3"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | activeMQ.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | activeMQ.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | activeMQ.terraform.module.source | string | `"app.terraform.io/Mintel/amazonmq/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/amazonmq/aws) |
-| activeMQ.terraform.module.version | string | `"0.0.2"` | Module version |
+| activeMQ.terraform.module.version | string | `"0.0.3"` | Module version |
 | apiGatewayHttp.enabled | bool | `false` | Set to true to create an AWS API Gateway |
 | apiGatewayHttp.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| apiGatewayHttp.terraform | object | `{"defaultVars":{"workspaceAllowDestroy":false},"instances":{},"module":{"source":"app.terraform.io/Mintel/api-gateway-http/aws","version":"0.3.2"},"terraformVersion":"1.4"}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| apiGatewayHttp.terraform | object | `{"defaultVars":{"workspaceAllowDestroy":false},"instances":{},"module":{"source":"app.terraform.io/Mintel/api-gateway-http/aws","version":"9.2.0"},"terraformVersion":"1.4"}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | apiGatewayHttp.terraform.defaultVars | object | `{"workspaceAllowDestroy":false}` | Vars to be applied to all instances defined below |
 | apiGatewayHttp.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | apiGatewayHttp.terraform.module.source | string | `"app.terraform.io/Mintel/api-gateway-http/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/amazonmq/aws) |
-| apiGatewayHttp.terraform.module.version | string | `"0.3.2"` | Module version |
+| apiGatewayHttp.terraform.module.version | string | `"9.2.0"` | Module version |
 | auroraMySql.enabled | bool | `false` | Set to true to create a MySQL Aurora RDS cluster |
 | auroraMySql.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
 | auroraMySql.terraform.defaultVars | object | See below | Vars to be applied to all instances defined below |
@@ -30,10 +30,10 @@ A Helm chart for provisioning resources using Terraform Cloud
 | auroraMySql.terraform.defaultVars.port | int | `3306` | Aurora MySQL port |
 | auroraMySql.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | auroraMySql.terraform.module.source | string | `"app.terraform.io/Mintel/rds-aurora/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds-aurora/aws) |
-| auroraMySql.terraform.module.version | string | `"0.0.3"` | Module version |
+| auroraMySql.terraform.module.version | string | `"0.0.4"` | Module version |
 | auroraPostgresql.enabled | bool | `false` | Set to true to create a PostgreSQL Aurora RDS cluster |
 | auroraPostgresql.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| auroraPostgresql.terraform | object | `{"defaultVars":{"engine":"aurora-postgresql","engine_version":"14.3","instance_class":"db.t3.medium","port":5432},"instances":{},"module":{"source":"app.terraform.io/Mintel/rds-aurora/aws","version":"0.0.3"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| auroraPostgresql.terraform | object | `{"defaultVars":{"engine":"aurora-postgresql","engine_version":"14.3","instance_class":"db.t3.medium","port":5432},"instances":{},"module":{"source":"app.terraform.io/Mintel/rds-aurora/aws","version":"0.0.4"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | auroraPostgresql.terraform.defaultVars | object | See below | Vars to be applied to all instances defined below |
 | auroraPostgresql.terraform.defaultVars.engine | string | `"aurora-postgresql"` | Database engine to use (should always be "aurora-postgresql") |
 | auroraPostgresql.terraform.defaultVars.engine_version | string | `"14.3"` | Aurora PostgreSQL version |
@@ -41,34 +41,34 @@ A Helm chart for provisioning resources using Terraform Cloud
 | auroraPostgresql.terraform.defaultVars.port | int | `5432` | Aurora PostgreSQL port |
 | auroraPostgresql.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | auroraPostgresql.terraform.module.source | string | `"app.terraform.io/Mintel/rds-aurora/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds-aurora/aws) |
-| auroraPostgresql.terraform.module.version | string | `"0.0.3"` | Module version |
+| auroraPostgresql.terraform.module.version | string | `"0.0.4"` | Module version |
 | cmsBackup.enabled | bool | `false` | Set to true to create a Step Function to backup an Alfresco CMS |
-| cmsBackup.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/cms-backup/aws","version":"0.1.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| cmsBackup.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/cms-backup/aws","version":"0.1.1"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | cmsBackup.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | cmsBackup.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | cmsBackup.terraform.module.source | string | `"app.terraform.io/Mintel/cms-backup/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/cms-backup/aws) |
-| cmsBackup.terraform.module.version | string | `"0.1.0"` | Module version |
+| cmsBackup.terraform.module.version | string | `"0.1.1"` | Module version |
 | datasync.enabled | bool | `false` | Set to true to create an AWS Datasync instance |
 | datasync.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| datasync.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/datasync/aws","version":"0.2.0"}}` | Set ArgoCD syncWave for this resource (default -20) syncWave: -20 |
+| datasync.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/datasync/aws","version":"0.2.1"}}` | Set ArgoCD syncWave for this resource (default -20) syncWave: -20 |
 | datasync.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | datasync.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | datasync.terraform.module.source | string | `"app.terraform.io/Mintel/datasync/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/amazonmq/aws) |
-| datasync.terraform.module.version | string | `"0.2.0"` | Module version |
+| datasync.terraform.module.version | string | `"0.2.1"` | Module version |
 | dynamodb.enabled | bool | `false` | Set to true to create a DynamoDB instance |
 | dynamodb.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| dynamodb.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/dynamodb/aws","version":"1.0.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| dynamodb.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/dynamodb/aws","version":"1.2.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | dynamodb.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | dynamodb.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | dynamodb.terraform.module.source | string | `"app.terraform.io/Mintel/dynamodb/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/dynamodb/aws) |
-| dynamodb.terraform.module.version | string | `"1.0.0"` | Module version |
+| dynamodb.terraform.module.version | string | `"1.2.0"` | Module version |
 | extraIAM.enabled | bool | `false` | Set to true to create an IAM Role or user aside from IRSA for the application |
 | extraIAM.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| extraIAM.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/app-iam/aws","version":"2.3.0"}}` | Set ArgoCD syncWave for this resource (default -20) syncWave: -20 |
+| extraIAM.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/app-iam/aws","version":"2.5.1"}}` | Set ArgoCD syncWave for this resource (default -20) syncWave: -20 |
 | extraIAM.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | extraIAM.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | extraIAM.terraform.module.source | string | `"app.terraform.io/Mintel/app-iam/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/app-iam/aws) |
-| extraIAM.terraform.module.version | string | `"2.3.0"` | Module version |
+| extraIAM.terraform.module.version | string | `"2.5.1"` | Module version |
 | global.clusterDomain | string | `"127.0.0.1.nip.io"` | Additional labels to apply to all resources |
 | global.clusterEnv | string | `"local"` | Environment (local, dev, qa, prod) |
 | global.clusterName | string | `""` | Kubernetes cluster name |
@@ -81,45 +81,45 @@ A Helm chart for provisioning resources using Terraform Cloud
 | global.terraform.irsa | bool | `true` | Set to true as part of tf cloud migrations. When true, standard-application-stack sets the service account eks annotation to match the new IAM roles created by the app-iam module |
 | global.terraform.organization | string | `"Mintel"` | Name of our Terraform Cloud org |
 | global.terraform.secretsMountPath | string | `"/tmp/secrets"` | Where secrets are mounted inside the Terraform Operator container |
-| global.terraform.terraformVersion | string | `"1.2.9"` | Global Terraform version for all modules |
+| global.terraform.terraformVersion | string | `"1.3"` | Global Terraform version for all modules |
 | irsa.enabled | bool | `false` | Set to true to explicitly instantiate this module if there's need to access resources created elsewhere |
-| irsa.terraform | object | `{"module":{"source":"app.terraform.io/Mintel/app-iam/aws","version":"2.3.1"},"notifications":[{"enabled":true,"name":"tfcloud-auto-approver","token":"${TFCLOUD_AUTO_APPROVER_SIGNATURE_KEY}","triggers":["run:needs_attention"],"type":"generic","url":"${TFCLOUD_AUTO_APPROVER_URL}"}],"vars":{}}` | Set ArgoCD syncWave for this resource (default -20) syncWave: -20 |
+| irsa.terraform | object | `{"module":{"source":"app.terraform.io/Mintel/app-iam/aws","version":"2.5.1"},"notifications":[{"enabled":true,"name":"tfcloud-auto-approver","token":"${TFCLOUD_AUTO_APPROVER_SIGNATURE_KEY}","triggers":["run:needs_attention"],"type":"generic","url":"${TFCLOUD_AUTO_APPROVER_URL}"}],"vars":{}}` | Set ArgoCD syncWave for this resource (default -20) syncWave: -20 |
 | irsa.terraform.module.source | string | `"app.terraform.io/Mintel/app-iam/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/app-iam/aws) |
-| irsa.terraform.module.version | string | `"2.3.1"` | Module version |
+| irsa.terraform.module.version | string | `"2.5.1"` | Module version |
 | irsa.terraform.notifications | list | `[{"enabled":true,"name":"tfcloud-auto-approver","token":"${TFCLOUD_AUTO_APPROVER_SIGNATURE_KEY}","triggers":["run:needs_attention"],"type":"generic","url":"${TFCLOUD_AUTO_APPROVER_URL}"}]` | Configure Terraform Cloud notifications. This should not be changed unless you really know what you're doing. |
 | irsa.terraform.vars | object | See below | Vars to be applied to all instances defined below |
 | lambda.enabled | bool | `false` | Set to true to create a Lambda function |
-| lambda.terraform | object | `{"defaultVars":null,"instances":{},"module":{"source":"app.terraform.io/Mintel/lambda/aws","version":"0.2.0"},"terraformVersion":"1.4.3"}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| lambda.terraform | object | `{"defaultVars":null,"instances":{},"module":{"source":"app.terraform.io/Mintel/lambda/aws","version":"5.0.1"},"terraformVersion":"1.4.3"}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | lambda.terraform.defaultVars | string | See below | Vars to be applied to all instances defined below |
 | lambda.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | lambda.terraform.module.source | string | `"app.terraform.io/Mintel/lambda/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/lambda/aws) |
-| lambda.terraform.module.version | string | `"0.2.0"` | Module version |
+| lambda.terraform.module.version | string | `"5.0.1"` | Module version |
 | mariadb.enabled | bool | `false` | Set to true to create a MariaDB RDS instance |
 | mariadb.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| mariadb.terraform | object | `{"defaultVars":{"engine":"mariadb","engine_version":"10.5","port":3306},"instances":{},"module":{"source":"app.terraform.io/Mintel/rds/aws","version":"1.3.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| mariadb.terraform | object | `{"defaultVars":{"engine":"mariadb","engine_version":"10.5","port":3306},"instances":{},"module":{"source":"app.terraform.io/Mintel/rds/aws","version":"2.0.1"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | mariadb.terraform.defaultVars | object | See below | Vars to be applied to all instances defined below |
 | mariadb.terraform.defaultVars.engine | string | `"mariadb"` | Database engine to use (should always be "mariadb") |
 | mariadb.terraform.defaultVars.engine_version | string | `"10.5"` | MariaDB version |
 | mariadb.terraform.defaultVars.port | int | `3306` | MariaDB port |
 | mariadb.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | mariadb.terraform.module.source | string | `"app.terraform.io/Mintel/rds/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds/aws) |
-| mariadb.terraform.module.version | string | `"1.3.0"` | Module version |
+| mariadb.terraform.module.version | string | `"2.0.1"` | Module version |
 | memcached.enabled | bool | `false` | Set to true to create a memcached Elasticache resource |
 | memcached.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| memcached.terraform | object | `{"defaultVars":{"instance_type":"cache.t4g.micro","num_cache_nodes":1},"instances":{},"module":{"source":"app.terraform.io/Mintel/memcached/aws","version":"1.0.1"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| memcached.terraform | object | `{"defaultVars":{"instance_type":"cache.t4g.micro","num_cache_nodes":1},"instances":{},"module":{"source":"app.terraform.io/Mintel/memcached/aws","version":"1.0.2"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | memcached.terraform.defaultVars | object | See below | Vars to be applied to all instances defined below |
 | memcached.terraform.defaultVars.instance_type | string | `"cache.t4g.micro"` | EC2 instance type to use (https://aws.amazon.com/elasticache/pricing) |
 | memcached.terraform.defaultVars.num_cache_nodes | int | `1` | Number of nodes to create in the cluster |
 | memcached.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | memcached.terraform.module.source | string | `"app.terraform.io/Mintel/memcached/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/memcached/aws) |
-| memcached.terraform.module.version | string | `"1.0.1"` | Module version |
+| memcached.terraform.module.version | string | `"1.0.2"` | Module version |
 | opensearch.enabled | bool | `false` | Set to true to create an Opensearch cluster |
 | opensearch.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| opensearch.terraform | object | `{"defaultVars":null,"instances":{},"module":{"source":"app.terraform.io/Mintel/opensearch/aws","version":"1.2.1"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| opensearch.terraform | object | `{"defaultVars":null,"instances":{},"module":{"source":"app.terraform.io/Mintel/opensearch/aws","version":"1.4.1"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | opensearch.terraform.defaultVars | string | `nil` | Vars to be applied to all instances defined below |
 | opensearch.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | opensearch.terraform.module.source | string | `"app.terraform.io/Mintel/opensearch/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/opensearch/aws) |
-| opensearch.terraform.module.version | string | `"1.2.1"` | Module version |
+| opensearch.terraform.module.version | string | `"1.4.1"` | Module version |
 | postgresql.enabled | bool | `false` | Set to true to create a PostgreSQL RDS instance |
 | postgresql.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
 | postgresql.terraform.defaultVars | object | See below | Vars to be applied to all instances defined below |
@@ -128,56 +128,56 @@ A Helm chart for provisioning resources using Terraform Cloud
 | postgresql.terraform.defaultVars.port | int | `5432` | PostgreSQL port |
 | postgresql.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | postgresql.terraform.module.source | string | `"app.terraform.io/Mintel/rds/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds/aws) |
-| postgresql.terraform.module.version | string | `"1.3.0"` | Module version |
+| postgresql.terraform.module.version | string | `"2.0.1"` | Module version |
 | redis.enabled | bool | `false` | Set to true to create a Redis Elasticache resource |
 | redis.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| redis.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/redis/aws","version":"1.1.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| redis.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/redis/aws","version":"1.1.1"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | redis.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | redis.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | redis.terraform.module.source | string | `"app.terraform.io/Mintel/redis/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/redis/aws) |
-| redis.terraform.module.version | string | `"1.1.0"` | Module version |
+| redis.terraform.module.version | string | `"1.1.1"` | Module version |
 | s3.enabled | bool | `false` | Set to true to create an S3 bucket |
 | s3.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| s3.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/private-s3-bucket/aws","version":"2.0.5"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| s3.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/private-s3-bucket/aws","version":"3.0.2"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | s3.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | s3.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | s3.terraform.module.source | string | `"app.terraform.io/Mintel/private-s3-bucket/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/private-s3-bucket/aws) |
-| s3.terraform.module.version | string | `"2.0.5"` | Module version |
+| s3.terraform.module.version | string | `"3.0.2"` | Module version |
 | sns.enabled | bool | `false` | Set to true to create an SNS resource |
 | sns.eventBus | object | `{"enabled":false}` | Set to true to add the MintelEventBus tag |
 | sns.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| sns.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/sns/aws","version":"1.0.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| sns.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/sns/aws","version":"1.3.1"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | sns.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | sns.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | sns.terraform.module.source | string | `"app.terraform.io/Mintel/sns/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/sns/aws) |
-| sns.terraform.module.version | string | `"1.0.0"` | Module version |
+| sns.terraform.module.version | string | `"1.3.1"` | Module version |
 | sqs.enabled | bool | `false` | Set to true to create an SQS resource |
 | sqs.eventBus | object | `{"enabled":false}` | Set to true to add the MintelEventBus tag |
 | sqs.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| sqs.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/sqs/aws","version":"1.2.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| sqs.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/sqs/aws","version":"1.3.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | sqs.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | sqs.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | sqs.terraform.module.source | string | `"app.terraform.io/Mintel/sqs/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/sqs/aws) |
-| sqs.terraform.module.version | string | `"1.2.0"` | Module version |
+| sqs.terraform.module.version | string | `"1.3.0"` | Module version |
 | sshKeyPairSecret.enabled | bool | `false` | Set to true to create AWS secret manager secrets for an SSH key pair |
-| sshKeyPairSecret.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/ssh-keypair-secret/aws","version":"0.0.7"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| sshKeyPairSecret.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/ssh-keypair-secret/aws","version":"0.1.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | sshKeyPairSecret.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | sshKeyPairSecret.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | sshKeyPairSecret.terraform.module.source | string | `"app.terraform.io/Mintel/ssh-keypair-secret/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/ssh-keypair-secret/aws) |
-| sshKeyPairSecret.terraform.module.version | string | `"0.0.7"` | Module version |
+| sshKeyPairSecret.terraform.module.version | string | `"0.1.0"` | Module version |
 | staticWebsite.enabled | bool | `false` | Set to true to create static website (a public bucket and associated resources) |
 | staticWebsite.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
-| staticWebsite.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/public-static-website/aws","version":"1.1.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
+| staticWebsite.terraform | object | `{"defaultVars":{},"instances":{},"module":{"source":"app.terraform.io/Mintel/public-static-website/aws","version":"1.1.1"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
 | staticWebsite.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | staticWebsite.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | staticWebsite.terraform.module.source | string | `"app.terraform.io/Mintel/public-static-website/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/public-static-website/aws) |
-| staticWebsite.terraform.module.version | string | `"1.1.0"` | Module version |
+| staticWebsite.terraform.module.version | string | `"1.1.1"` | Module version |
 | stepFunctionEks.enabled | bool | `false` | Set to true to create an EKS runtime step function |
 | stepFunctionEks.outputSecret | bool | `false` | Set to true to create an AWS secret manager external secret with outputs |
 | stepFunctionEks.terraform.defaultVars | object | `{}` | Vars to be applied to all instances defined below |
 | stepFunctionEks.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | stepFunctionEks.terraform.module.source | string | `"app.terraform.io/Mintel/step-functions-eks/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/step-function-eks/aws) |
-| stepFunctionEks.terraform.module.version | string | `"1.0.0"` | Module version |
+| stepFunctionEks.terraform.module.version | string | `"1.0.1"` | Module version |
 | stepFunctionEks.terraform.terraformVersion | string | `"1.3.0-alpha20220608"` |  |
 
 ----------------------------------------------

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -81,7 +81,7 @@ A Helm chart for provisioning resources using Terraform Cloud
 | global.terraform.irsa | bool | `true` | Set to true as part of tf cloud migrations. When true, standard-application-stack sets the service account eks annotation to match the new IAM roles created by the app-iam module |
 | global.terraform.organization | string | `"Mintel"` | Name of our Terraform Cloud org |
 | global.terraform.secretsMountPath | string | `"/tmp/secrets"` | Where secrets are mounted inside the Terraform Operator container |
-| global.terraform.terraformVersion | string | `"1.3"` | Global Terraform version for all modules |
+| global.terraform.terraformVersion | string | `"1.3.0"` | Global Terraform version for all modules |
 | irsa.enabled | bool | `false` | Set to true to explicitly instantiate this module if there's need to access resources created elsewhere |
 | irsa.terraform | object | `{"module":{"source":"app.terraform.io/Mintel/app-iam/aws","version":"2.5.1"},"notifications":[{"enabled":true,"name":"tfcloud-auto-approver","token":"${TFCLOUD_AUTO_APPROVER_SIGNATURE_KEY}","triggers":["run:needs_attention"],"type":"generic","url":"${TFCLOUD_AUTO_APPROVER_URL}"}],"vars":{}}` | Set ArgoCD syncWave for this resource (default -20) syncWave: -20 |
 | irsa.terraform.module.source | string | `"app.terraform.io/Mintel/app-iam/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/app-iam/aws) |

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_tags_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_tags_test.yaml.snap
@@ -38,7 +38,7 @@ Test IRSA application and component tags default to name:
         - sourceableName: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -126,7 +126,7 @@ Test IRSA default tags:
         - sourceableName: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_tags_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_tags_test.yaml.snap
@@ -38,7 +38,7 @@ Test IRSA application and component tags default to name:
         - sourceableName: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -126,7 +126,7 @@ Test IRSA default tags:
         - sourceableName: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_tags_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_tags_test.yaml.snap
@@ -23,7 +23,7 @@ Test IRSA application and component tags default to name:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/app-iam/aws
-        version: 2.3.1
+        version: 2.5.1
       notifications:
         - enabled: true
           name: tfcloud-auto-approver
@@ -38,7 +38,7 @@ Test IRSA application and component tags default to name:
         - sourceableName: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -111,7 +111,7 @@ Test IRSA default tags:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/app-iam/aws
-        version: 2.3.1
+        version: 2.5.1
       notifications:
         - enabled: true
           name: tfcloud-auto-approver
@@ -126,7 +126,7 @@ Test IRSA default tags:
         - sourceableName: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
@@ -23,7 +23,7 @@ IRSA created explicitly:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/app-iam/aws
-        version: 2.3.1
+        version: 2.5.1
       notifications:
         - enabled: true
           name: tfcloud-auto-approver
@@ -37,7 +37,7 @@ IRSA created explicitly:
       runTriggers: null
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -110,7 +110,7 @@ IRSA created for Dev S3 module workspace:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/app-iam/aws
-        version: 2.3.1
+        version: 2.5.1
       notifications:
         - enabled: true
           name: tfcloud-auto-approver
@@ -125,7 +125,7 @@ IRSA created for Dev S3 module workspace:
         - sourceableName: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -198,7 +198,7 @@ IRSA created with default (0) syncWave:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/app-iam/aws
-        version: 2.3.1
+        version: 2.5.1
       notifications:
         - enabled: true
           name: tfcloud-auto-approver
@@ -212,7 +212,7 @@ IRSA created with default (0) syncWave:
       runTriggers: null
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -285,7 +285,7 @@ IRSA created with modified syncWave:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/app-iam/aws
-        version: 2.3.1
+        version: 2.5.1
       notifications:
         - enabled: true
           name: tfcloud-auto-approver
@@ -299,7 +299,7 @@ IRSA created with modified syncWave:
       runTriggers: null
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
@@ -37,7 +37,7 @@ IRSA created explicitly:
       runTriggers: null
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -125,7 +125,7 @@ IRSA created for Dev S3 module workspace:
         - sourceableName: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -212,7 +212,7 @@ IRSA created with default (0) syncWave:
       runTriggers: null
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -299,7 +299,7 @@ IRSA created with modified syncWave:
       runTriggers: null
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace_test.yaml.snap
@@ -37,7 +37,7 @@ IRSA created explicitly:
       runTriggers: null
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -125,7 +125,7 @@ IRSA created for Dev S3 module workspace:
         - sourceableName: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -212,7 +212,7 @@ IRSA created with default (0) syncWave:
       runTriggers: null
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -299,7 +299,7 @@ IRSA created with modified syncWave:
       runTriggers: null
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false

--- a/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
@@ -28,7 +28,7 @@ Dev S3 module name label override:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -111,7 +111,7 @@ Dev S3 module workspace:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -194,7 +194,7 @@ Dev S3 module workspace - tags:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -275,7 +275,7 @@ Dev S3 module workspace adds correct env override:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -358,7 +358,7 @@ Dev S3 module workspace ignores env override when added explicitly:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -441,7 +441,7 @@ Dev S3 module workspace name does not repeat mntl-prefix:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -524,7 +524,7 @@ Dev S3 module workspace name override:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -607,7 +607,7 @@ Dev S3 module workspace with default (0) syncWave:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -690,7 +690,7 @@ Dev S3 module workspace with modified syncWave:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -773,7 +773,7 @@ Dev S3 module workspace with multiple instances:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -855,7 +855,7 @@ Dev S3 module workspace with multiple instances:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -938,7 +938,7 @@ Dev S3 module workspace with multiple instances - tags:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -1017,7 +1017,7 @@ Dev S3 module workspace with multiple instances - tags:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -1098,7 +1098,7 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -1180,7 +1180,7 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -1263,7 +1263,7 @@ Test workspace allow destroy env:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -1341,7 +1341,7 @@ Test workspace extra annotations:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false
@@ -1424,7 +1424,7 @@ Test workspace extra annotations override:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.3.0
+      terraformVersion: 1.3.10
       variables:
         - environmentVariable: false
           hcl: false

--- a/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
@@ -23,12 +23,12 @@ Dev S3 module name label override:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -106,12 +106,12 @@ Dev S3 module workspace:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -189,12 +189,12 @@ Dev S3 module workspace - tags:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/sqs/aws
-        version: 1.2.0
+        version: 1.3.0
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -270,12 +270,12 @@ Dev S3 module workspace adds correct env override:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -353,12 +353,12 @@ Dev S3 module workspace ignores env override when added explicitly:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -436,12 +436,12 @@ Dev S3 module workspace name does not repeat mntl-prefix:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -519,12 +519,12 @@ Dev S3 module workspace name override:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -602,12 +602,12 @@ Dev S3 module workspace with default (0) syncWave:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -685,12 +685,12 @@ Dev S3 module workspace with modified syncWave:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -768,12 +768,12 @@ Dev S3 module workspace with multiple instances:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -850,12 +850,12 @@ Dev S3 module workspace with multiple instances:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -933,12 +933,12 @@ Dev S3 module workspace with multiple instances - tags:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/sqs/aws
-        version: 1.2.0
+        version: 1.3.0
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -1012,12 +1012,12 @@ Dev S3 module workspace with multiple instances - tags:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/sqs/aws
-        version: 1.2.0
+        version: 1.3.0
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -1093,12 +1093,12 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -1175,12 +1175,12 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -1258,12 +1258,12 @@ Test workspace allow destroy env:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -1336,12 +1336,12 @@ Test workspace extra annotations:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false
@@ -1419,12 +1419,12 @@ Test workspace extra annotations override:
       agentPoolID: ""
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
-        version: 2.0.5
+        version: 3.0.2
       omitNamespacePrefix: true
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: 1.2.9
+      terraformVersion: "1.3"
       variables:
         - environmentVariable: false
           hcl: false

--- a/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace_test.yaml.snap
@@ -28,7 +28,7 @@ Dev S3 module name label override:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -111,7 +111,7 @@ Dev S3 module workspace:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -194,7 +194,7 @@ Dev S3 module workspace - tags:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -275,7 +275,7 @@ Dev S3 module workspace adds correct env override:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -358,7 +358,7 @@ Dev S3 module workspace ignores env override when added explicitly:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -441,7 +441,7 @@ Dev S3 module workspace name does not repeat mntl-prefix:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -524,7 +524,7 @@ Dev S3 module workspace name override:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -607,7 +607,7 @@ Dev S3 module workspace with default (0) syncWave:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -690,7 +690,7 @@ Dev S3 module workspace with modified syncWave:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -773,7 +773,7 @@ Dev S3 module workspace with multiple instances:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -855,7 +855,7 @@ Dev S3 module workspace with multiple instances:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -938,7 +938,7 @@ Dev S3 module workspace with multiple instances - tags:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -1017,7 +1017,7 @@ Dev S3 module workspace with multiple instances - tags:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -1098,7 +1098,7 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -1180,7 +1180,7 @@ Dev S3 module workspace with multiple instances and syncWave overrides:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -1263,7 +1263,7 @@ Test workspace allow destroy env:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -1341,7 +1341,7 @@ Test workspace extra annotations:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false
@@ -1424,7 +1424,7 @@ Test workspace extra annotations override:
       organization: Mintel
       secretsMountPath: /tmp/secrets
       sshKeyID: mintel-ssh
-      terraformVersion: "1.3"
+      terraformVersion: 1.3.0
       variables:
         - environmentVariable: false
           hcl: false

--- a/charts/terraform-cloud/values.yaml
+++ b/charts/terraform-cloud/values.yaml
@@ -27,7 +27,7 @@ global:
     # -- Where secrets are mounted inside the Terraform Operator container
     secretsMountPath: /tmp/secrets
     # -- Global Terraform version for all modules
-    terraformVersion: "1.3"
+    terraformVersion: 1.3.0
     # -- Set to true as part of tf cloud migrations. When true, it stops standard-application-stack from creating AWS
     # related external secrets and passes that responsibility to the terraform-cloud chart
     externalSecrets: true

--- a/charts/terraform-cloud/values.yaml
+++ b/charts/terraform-cloud/values.yaml
@@ -27,7 +27,7 @@ global:
     # -- Where secrets are mounted inside the Terraform Operator container
     secretsMountPath: /tmp/secrets
     # -- Global Terraform version for all modules
-    terraformVersion: 1.3.0
+    terraformVersion: 1.3.10
     # -- Set to true as part of tf cloud migrations. When true, it stops standard-application-stack from creating AWS
     # related external secrets and passes that responsibility to the terraform-cloud chart
     externalSecrets: true

--- a/charts/terraform-cloud/values.yaml
+++ b/charts/terraform-cloud/values.yaml
@@ -27,7 +27,7 @@ global:
     # -- Where secrets are mounted inside the Terraform Operator container
     secretsMountPath: /tmp/secrets
     # -- Global Terraform version for all modules
-    terraformVersion: "1.2.9"
+    terraformVersion: "1.3"
     # -- Set to true as part of tf cloud migrations. When true, it stops standard-application-stack from creating AWS
     # related external secrets and passes that responsibility to the terraform-cloud chart
     externalSecrets: true
@@ -56,7 +56,7 @@ activeMQ:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/amazonmq/aws)
       source: app.terraform.io/Mintel/amazonmq/aws
       # -- Module version
-      version: "0.0.2"
+      version: "0.0.3"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       {}
@@ -91,7 +91,7 @@ apiGatewayHttp:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/amazonmq/aws)
       source: app.terraform.io/Mintel/api-gateway-http/aws
       # -- Module version
-      version: "0.3.2"
+      version: "9.2.0"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       ### Boolean which when set to true disables destroy runs on the workspace and vice-versa. It serves as a form of
@@ -124,7 +124,7 @@ auroraMySql:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds-aurora/aws)
       source: app.terraform.io/Mintel/rds-aurora/aws
       # -- Module version
-      version: "0.0.3"
+      version: "0.0.4"
     # -- Vars to be applied to all instances defined below
     # @default -- See below
     defaultVars:
@@ -169,7 +169,7 @@ auroraPostgresql:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds-aurora/aws)
       source: app.terraform.io/Mintel/rds-aurora/aws
       # -- Module version
-      version: "0.0.3"
+      version: "0.0.4"
     # -- Vars to be applied to all instances defined below
     # @default -- See below
     defaultVars:
@@ -213,7 +213,7 @@ cmsBackup:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/cms-backup/aws)
       source: app.terraform.io/Mintel/cms-backup/aws
       # -- Module version
-      version: "0.1.0"
+      version: "0.1.1"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       {}
@@ -244,7 +244,7 @@ datasync:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/amazonmq/aws)
       source: app.terraform.io/Mintel/datasync/aws
       # -- Module version
-      version: "0.2.0"
+      version: "0.2.1"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       {}
@@ -280,7 +280,7 @@ dynamodb:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/dynamodb/aws)
       source: app.terraform.io/Mintel/dynamodb/aws
       # -- Module version
-      version: "1.0.0"
+      version: "1.2.0"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       {}
@@ -320,7 +320,7 @@ extraIAM:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/app-iam/aws)
       source: app.terraform.io/Mintel/app-iam/aws
       # -- Module version
-      version: "2.3.0"
+      version: "2.5.1"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       {}
@@ -354,7 +354,7 @@ irsa:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/app-iam/aws)
       source: app.terraform.io/Mintel/app-iam/aws
       # -- Module version
-      version: "2.3.1"
+      version: "2.5.1"
     # -- Vars to be applied to all instances defined below
     # @default -- See below
     vars:
@@ -388,7 +388,7 @@ lambda:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/lambda/aws)
       source: app.terraform.io/Mintel/lambda/aws
       # -- Module version
-      version: 0.2.0
+      version: 5.0.1
     # -- Vars to be applied to all instances defined below
     # @default -- See below
     defaultVars:
@@ -446,7 +446,7 @@ mariadb:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds/aws)
       source: app.terraform.io/Mintel/rds/aws
       # -- Module version
-      version: "1.3.0"
+      version: "2.0.1"
     # -- Vars to be applied to all instances defined below
     # @default -- See below
     defaultVars:
@@ -491,7 +491,7 @@ memcached:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/memcached/aws)
       source: app.terraform.io/Mintel/memcached/aws
       # -- Module version
-      version: "1.0.1"
+      version: "1.0.2"
     # -- Vars to be applied to all instances defined below
     # @default -- See below
     defaultVars:
@@ -528,7 +528,7 @@ opensearch:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/opensearch/aws)
       source: app.terraform.io/Mintel/opensearch/aws
       # -- Module version
-      version: "1.2.1"
+      version: "1.4.1"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       ### Override the generated workspace name, for example if the generated name is above the char limit
@@ -564,7 +564,7 @@ postgresql:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/rds/aws)
       source: app.terraform.io/Mintel/rds/aws
       # -- Module version
-      version: "1.3.0"
+      version: "2.0.1"
     # -- Vars to be applied to all instances defined below
     # @default -- See below
     defaultVars:
@@ -609,7 +609,7 @@ redis:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/redis/aws)
       source: app.terraform.io/Mintel/redis/aws
       # -- Module version
-      version: "1.1.0"
+      version: "1.1.1"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       {}
@@ -648,7 +648,7 @@ s3:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/private-s3-bucket/aws)
       source: app.terraform.io/Mintel/private-s3-bucket/aws
       # -- Module version
-      version: "2.0.5"
+      version: "3.0.2"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       {}
@@ -686,7 +686,7 @@ sns:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/sns/aws)
       source: app.terraform.io/Mintel/sns/aws
       # -- Module version
-      version: "1.0.0"
+      version: "1.3.1"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       {}
@@ -722,7 +722,7 @@ sqs:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/sqs/aws)
       source: app.terraform.io/Mintel/sqs/aws
       # -- Module version
-      version: "1.2.0"
+      version: "1.3.0"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       {}
@@ -755,7 +755,7 @@ staticWebsite:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/public-static-website/aws)
       source: app.terraform.io/Mintel/public-static-website/aws
       # -- Module version
-      version: "1.1.0"
+      version: "1.1.1"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       {}
@@ -786,7 +786,7 @@ stepFunctionEks:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/step-function-eks/aws)
       source: app.terraform.io/Mintel/step-functions-eks/aws
       # -- Module version
-      version: "1.0.0"
+      version: "1.0.1"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       {}
@@ -816,7 +816,7 @@ sshKeyPairSecret:
       # (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/ssh-keypair-secret/aws)
       source: app.terraform.io/Mintel/ssh-keypair-secret/aws
       # -- Module version
-      version: "0.0.7"
+      version: "0.1.0"
     # -- Vars to be applied to all instances defined below
     defaultVars:
       {}


### PR DESCRIPTION
This bumps all the module versions as part of our work to upgrade to tf 1.3