### PR TITLE
INFRA:5490: Ensure v2 handling of workspace-destroy flag is consistent with v1

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.2.0] - 2024-05-29
+### Changed
+- Update v2 configuration to use same defaults for allowing workspace-destroy in prod/logs account. Also allow overrides at resource-config layer.
+
 ## [v1.1.0] - 2024-05-22
 ### Added
 - Added support for terraform-cloud-operator v2. v1 is still the default and would result in a noop for appliations consuming this chart.

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -77,7 +77,6 @@ A Helm chart for provisioning resources using Terraform Cloud
 | global.owner | string | `""` | Team which "owns" the application |
 | global.partOf | string | `""` | Top level application each deployment is a part of |
 | global.terraform.agentPoolID | string | `""` | ID of the Terraform Cloud Agent Pool to use for the run. Passed in from cluster-env-jsonnet |
-| global.terraform.applyMethod | string | `"manual"` | Define either change will be applied automatically(auto) or require an operator to confirm(manual). |
 | global.terraform.enableRestartedAt | bool | `true` | Adds the restartedAt value (see restartedAt). Ensures that any configuration changes (i.e. input vars) result in the operator attempting a new plan/apply |
 | global.terraform.executionMode | string | `"agent"` | Define where the Terraform code will be executed. |
 | global.terraform.externalSecrets | bool | `true` | Set to true as part of tf cloud migrations. When true, it stops standard-application-stack from creating AWS related external secrets and passes that responsibility to the terraform-cloud chart |

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 
@@ -77,9 +77,7 @@ A Helm chart for provisioning resources using Terraform Cloud
 | global.owner | string | `""` | Team which "owns" the application |
 | global.partOf | string | `""` | Top level application each deployment is a part of |
 | global.terraform.agentPoolID | string | `""` | ID of the Terraform Cloud Agent Pool to use for the run. Passed in from cluster-env-jsonnet |
-| global.terraform.allowDestroyPlan | bool | `false` | Allows a destroy plan to be created and applied. |
 | global.terraform.applyMethod | string | `"manual"` | Define either change will be applied automatically(auto) or require an operator to confirm(manual). |
-| global.terraform.destroyOnDeletion | bool | `false` | Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Note that deletions are also protected by sentinel policy-enforcement rules in non-development environments See https://developer.hashicorp.com/terraform/cloud-docs/policy-enforcement/sentinel |
 | global.terraform.enableRestartedAt | bool | `true` | Adds the restartedAt value (see restartedAt). Ensures that any configuration changes (i.e. input vars) result in the operator attempting a new plan/apply |
 | global.terraform.executionMode | string | `"agent"` | Define where the Terraform code will be executed. |
 | global.terraform.externalSecrets | bool | `true` | Set to true as part of tf cloud migrations. When true, it stops standard-application-stack from creating AWS related external secrets and passes that responsibility to the terraform-cloud chart |

--- a/charts/terraform-cloud/templates/_helpers.tpl
+++ b/charts/terraform-cloud/templates/_helpers.tpl
@@ -90,7 +90,7 @@ app.mintel.com/region: {{ .Values.global.clusterRegion }}
 {{- end }}
 
 {{/* Operator extension Annotations */}}
-{{- define "mintel_common.terraform_cloud.operatorAnnotations" -}}
+{{- define "mintel_common.terraform_cloud.tfCloudOperatorExtentionAnnotations" -}}
 {{/* ternary and hasKey functions are used instead of defaults below due to https://github.com/helm/helm/issues/3308 */}}
 app.mintel.com/terraform-allow-destroy: {{ hasKey .InstanceCfg "workspaceAllowDestroy" | ternary .InstanceCfg.workspaceAllowDestroy (include "mintel_common.terraform_cloud.allow_destroy_default" .) | quote }}
 app.mintel.com/terraform-owner: {{ .InstanceCfg.workspaceOwner | default .Global.owner }}

--- a/charts/terraform-cloud/templates/helpers/_module_v2.yaml
+++ b/charts/terraform-cloud/templates/helpers/_module_v2.yaml
@@ -20,7 +20,6 @@ metadata:
     app.kubernetes.io/name: {{ printf "%s-%s" ($instanceCfg.name | kebabcase) ($resourceType | kebabcase) | trunc 63 }}
   annotations:
     {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}
-    {{ include "mintel_common.terraform_cloud.operatorAnnotations" $workspaceDict | nindent 4 }}
     {{- if (eq $resourceType "irsa") }}
     app.mintel.com/altManifestFileSuffix: "{{ $global.name }}-{{ $resourceType | kebabcase }}"
     {{- else }}

--- a/charts/terraform-cloud/templates/helpers/_module_v2.yaml
+++ b/charts/terraform-cloud/templates/helpers/_module_v2.yaml
@@ -50,7 +50,7 @@ spec:
     secretKeyRef:
       name: terraformrc
       key: token
-  destroyOnDeletion: {{ $global.terraform.destroyOnDeletion }}
+  destroyOnDeletion: {{  $instanceCfg.moduleDestroyOnDeletion| default "true" }}
   variables:
   {{- $_ := unset $instanceCfg "workspaceNameOverride" }}
   {{- $_ := unset $instanceCfg "workspaceAllowDestroy" }}
@@ -58,6 +58,9 @@ spec:
   {{- $_ := unset $instanceCfg "workspaceTags" }}
   {{- $_ := unset $instanceCfg "outputSecretMap" }}
   {{- $_ := unset $instanceCfg "syncWave" }}
+  {{- $_ := unset $instanceCfg "workspaceAllowDestroyPlan" }}
+  {{- $_ := unset $instanceCfg "workspaceApplyMethod" }}
+  {{- $_ := unset $instanceCfg "moduleDestroyOnDeletion" }}
   {{- range $varKey, $varVal := $instanceCfg }}
     {{- if kindIs "map" $varVal }}
       {{- include "mintel_common.terraform_cloud.tf_module_var" (merge (dict "key" $varKey) $varVal) | indent 2 }}

--- a/charts/terraform-cloud/templates/helpers/_workspace-v1.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace-v1.yaml
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/name: {{ printf "%s-%s" ($instanceCfg.name | kebabcase) ($resourceType | kebabcase) | trunc 63 }}
   annotations:
     {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}
-    {{ include "mintel_common.terraform_cloud.operatorAnnotations" $workspaceDict | nindent 4 }}
+    {{ include "mintel_common.terraform_cloud.tfCloudOperatorExtentionAnnotations" $workspaceDict | nindent 4 }}
     {{- if (eq $resourceType "irsa") }}
     app.mintel.com/altManifestFileSuffix: "{{ $global.name }}-{{ $resourceType | kebabcase }}"
     {{- else }}

--- a/charts/terraform-cloud/templates/helpers/_workspace-v1.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace-v1.yaml
@@ -54,6 +54,9 @@ spec:
   {{- $_ := unset $instanceCfg "workspaceTags" }}
   {{- $_ := unset $instanceCfg "outputSecretMap" }}
   {{- $_ := unset $instanceCfg "syncWave" }}
+  {{- $_ := unset $instanceCfg "workspaceAllowDestroyPlan" }}
+  {{- $_ := unset $instanceCfg "workspaceApplyMethod" }}
+  {{- $_ := unset $instanceCfg "moduleDestroyOnDeletion" }}
   {{- range $varKey, $varVal := $instanceCfg }}
     {{- if kindIs "map" $varVal }}
       {{- include "mintel_common.terraform_cloud.tfVar" (merge (dict "key" $varKey) $varVal) | indent 2 }}

--- a/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
@@ -21,7 +21,7 @@ metadata:
     app.kubernetes.io/name: {{ printf "%s-%s" ($instanceCfg.name | kebabcase) ($resourceType | kebabcase) | trunc 63 }}
   annotations:
     {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}
-    {{ include "mintel_common.terraform_cloud.operatorAnnotations" $workspaceDict | nindent 4 }}
+    {{ include "mintel_common.terraform_cloud.tfCloudOperatorExtentionAnnotations" $workspaceDict | nindent 4 }}
     {{- if (eq $resourceType "irsa") }}
     app.mintel.com/altManifestFileSuffix: "{{ $global.name }}-{{ $resourceType | kebabcase }}"
     {{- else }}

--- a/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
@@ -37,8 +37,8 @@ spec:
   name: {{ $instanceCfg.workspaceNameOverride | default (include "mintel_common.terraform_cloud.workspaceName" $workspaceDict) | trim | quote }}
   agentPool:
     id: {{ $global.terraform.agentPoolID | quote }}
-  applyMethod: {{ $global.terraform.applyMethod| quote }}
-  allowDestroyPlan: {{ $global.terraform.allowDestroyPlan }}
+  applyMethod: {{  $instanceCfg.workspaceApplyMethod | default "auto" }}
+  allowDestroyPlan: {{ hasKey $instanceCfg "workspaceAllowDestroy" | ternary $instanceCfg.workspaceAllowDestroy (include "mintel_common.terraform_cloud.allow_destroy_default" $workspaceDict) }}
   executionMode: {{ $global.terraform.executionMode | quote }}
   organization: {{ $global.terraform.organization | quote }}
   token:
@@ -59,6 +59,9 @@ spec:
   {{- $_ := unset $instanceCfg "workspaceTags" }}
   {{- $_ := unset $instanceCfg "outputSecretMap" }}
   {{- $_ := unset $instanceCfg "syncWave" }}
+  {{- $_ := unset $instanceCfg "workspaceAllowDestroyPlan" }}
+  {{- $_ := unset $instanceCfg "workspaceApplyMethod" }}
+  {{- $_ := unset $instanceCfg "moduleDestroyOnDeletion" }}
   {{- range $varKey, $varVal := $instanceCfg }}
     {{- if kindIs "map" $varVal }}
       {{- include "mintel_common.terraform_cloud.tfVar_v2" (merge (dict "key" $varKey) $varVal) | indent 2 }}

--- a/charts/terraform-cloud/tests/__snapshot__/module-v2_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/module-v2_test.yaml.snap
@@ -84,9 +84,6 @@ Test module defaults:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -207,9 +204,6 @@ Test module overrides:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -330,9 +324,6 @@ Test module restartedAt disabled:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:

--- a/charts/terraform-cloud/tests/__snapshot__/module-v2_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/module-v2_test.yaml.snap
@@ -22,8 +22,8 @@ Test module defaults:
     spec:
       agentPool:
         id: test-agent-pool
-      allowDestroyPlan: false
-      applyMethod: manual
+      allowDestroyPlan: true
+      applyMethod: auto
       executionMode: agent
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       organization: Mintel
@@ -95,7 +95,7 @@ Test module defaults:
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       namespace: test-namespace
     spec:
-      destroyOnDeletion: false
+      destroyOnDeletion: true
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
         version: 3.0.2
@@ -142,8 +142,8 @@ Test module overrides:
     spec:
       agentPool:
         id: test-agent-pool
-      allowDestroyPlan: false
-      applyMethod: manual
+      allowDestroyPlan: true
+      applyMethod: auto
       executionMode: agent
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       organization: Mintel
@@ -262,8 +262,8 @@ Test module restartedAt disabled:
     spec:
       agentPool:
         id: test-agent-pool
-      allowDestroyPlan: false
-      applyMethod: manual
+      allowDestroyPlan: true
+      applyMethod: auto
       executionMode: agent
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       organization: Mintel
@@ -335,7 +335,7 @@ Test module restartedAt disabled:
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       namespace: test-namespace
     spec:
-      destroyOnDeletion: false
+      destroyOnDeletion: true
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
         version: 0.0.1

--- a/charts/terraform-cloud/tests/__snapshot__/workspace-v2_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace-v2_test.yaml.snap
@@ -22,8 +22,8 @@ Test workspace defaults:
     spec:
       agentPool:
         id: test-agent-pool
-      allowDestroyPlan: false
-      applyMethod: manual
+      allowDestroyPlan: true
+      applyMethod: auto
       executionMode: agent
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       organization: Mintel
@@ -95,7 +95,7 @@ Test workspace defaults:
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       namespace: test-namespace
     spec:
-      destroyOnDeletion: false
+      destroyOnDeletion: true
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
         version: 3.0.2
@@ -118,6 +118,475 @@ Test workspace defaults:
         - name: tfcloud_agent
       workspace:
         name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
+Test workspace defaults in prod-like environment (logs):
+  1: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
+        app.mintel.com/placeholder: placeholder
+        app.mintel.com/terraform-allow-destroy: "false"
+        app.mintel.com/terraform-cloud-tags: env:logs,owner:sre,mod:s3
+        app.mintel.com/terraform-owner: sre
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-workspace-s3
+        app.mintel.com/env: logs
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-workspace-s3
+      name: logs-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
+      namespace: test-namespace
+    spec:
+      agentPool:
+        id: test-agent-pool
+      allowDestroyPlan: false
+      applyMethod: auto
+      executionMode: remote
+      name: logs-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
+      organization: Mintel
+      sshKey:
+        name: mintel-ssh
+      terraformVariables:
+        - hcl: false
+          name: aws_account_name
+          sensitive: false
+          value: logs
+        - hcl: false
+          name: aws_region
+          sensitive: false
+          value: eu-west-1
+        - hcl: false
+          name: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - hcl: false
+          name: name
+          sensitive: false
+          value: mntl-test-workspace
+        - hcl: false
+          name: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-test-workspace/s3
+        - hcl: true
+          name: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - hcl: true
+          name: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "mntl-test-workspace"
+              Component = "mntl-test-workspace"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - hcl: false
+          name: tfcloud_agent
+          sensitive: false
+          value: "true"
+      terraformVersion: 1.3.10
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+  2: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Module
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-workspace-s3
+        app.mintel.com/env: logs
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-workspace-s3
+      name: logs-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
+      namespace: test-namespace
+    spec:
+      destroyOnDeletion: true
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 3.0.2
+      name: operator
+      organization: Mintel
+      restartedAt: e04defbc4d25286cbf2872afacb2e563a52d79c27bd0bc2862ea7d8e6c442ba3
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+      variables:
+        - name: aws_account_name
+        - name: aws_region
+        - name: eks_cluster_name
+        - name: name
+        - name: output_secret_name
+        - name: secret_tags
+        - name: tags
+        - name: tfcloud_agent
+      workspace:
+        name: logs-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
+Test workspace defaults in prod-like environment (prod):
+  1: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
+        app.mintel.com/placeholder: placeholder
+        app.mintel.com/terraform-allow-destroy: "false"
+        app.mintel.com/terraform-cloud-tags: env:prod,owner:sre,mod:s3
+        app.mintel.com/terraform-owner: sre
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-workspace-s3
+        app.mintel.com/env: prod
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-workspace-s3
+      name: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
+      namespace: test-namespace
+    spec:
+      agentPool:
+        id: test-agent-pool
+      allowDestroyPlan: false
+      applyMethod: auto
+      executionMode: remote
+      name: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
+      organization: Mintel
+      sshKey:
+        name: mintel-ssh
+      terraformVariables:
+        - hcl: false
+          name: aws_account_name
+          sensitive: false
+          value: prod
+        - hcl: false
+          name: aws_region
+          sensitive: false
+          value: eu-west-1
+        - hcl: false
+          name: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - hcl: false
+          name: name
+          sensitive: false
+          value: mntl-test-workspace
+        - hcl: false
+          name: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-test-workspace/s3
+        - hcl: true
+          name: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - hcl: true
+          name: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "mntl-test-workspace"
+              Component = "mntl-test-workspace"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - hcl: false
+          name: tfcloud_agent
+          sensitive: false
+          value: "true"
+      terraformVersion: 1.3.10
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+  2: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Module
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-workspace-s3
+        app.mintel.com/env: prod
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-workspace-s3
+      name: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
+      namespace: test-namespace
+    spec:
+      destroyOnDeletion: true
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 3.0.2
+      name: operator
+      organization: Mintel
+      restartedAt: 2866f1e5d7f6db683ef1bba053adef8766e39314187bc830bc6d97e9a68e73a5
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+      variables:
+        - name: aws_account_name
+        - name: aws_region
+        - name: eks_cluster_name
+        - name: name
+        - name: output_secret_name
+        - name: secret_tags
+        - name: tags
+        - name: tfcloud_agent
+      workspace:
+        name: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
+Test workspace instance overrides:
+  1: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-bucket-s3
+        app.mintel.com/placeholder: placeholder
+        app.mintel.com/terraform-allow-destroy: "true"
+        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
+        app.mintel.com/terraform-owner: sre
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-bucket-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-bucket-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-s3
+      namespace: test-namespace
+    spec:
+      agentPool:
+        id: test-agent-pool
+      allowDestroyPlan: true
+      applyMethod: auto
+      executionMode: remote
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-s3
+      organization: Mintel
+      sshKey:
+        name: mintel-ssh
+      terraformVariables:
+        - hcl: false
+          name: aws_account_name
+          sensitive: false
+          value: dev
+        - hcl: false
+          name: aws_region
+          sensitive: false
+          value: eu-west-1
+        - hcl: false
+          name: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - hcl: false
+          name: enable_versioning
+          sensitive: false
+          value: "false"
+        - hcl: false
+          name: name
+          sensitive: false
+          value: mntl-test-bucket
+        - hcl: false
+          name: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-test-bucket/s3
+        - hcl: true
+          name: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - hcl: true
+          name: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "mntl-test-workspace"
+              Component = "mntl-test-workspace"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - hcl: false
+          name: tfcloud_agent
+          sensitive: false
+          value: "true"
+      terraformVersion: 1.3.10
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+  2: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Module
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-bucket-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-bucket-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-bucket-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-s3
+      namespace: test-namespace
+    spec:
+      destroyOnDeletion: true
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 3.0.2
+      name: operator
+      organization: Mintel
+      restartedAt: 28445a52cf0063a11cbf2152bfbbb2c64a0c4810ac3ddf88c889c6456b4ee1ad
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+      variables:
+        - name: aws_account_name
+        - name: aws_region
+        - name: eks_cluster_name
+        - name: enable_versioning
+        - name: name
+        - name: output_secret_name
+        - name: secret_tags
+        - name: tags
+        - name: tfcloud_agent
+      workspace:
+        name: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-s3
+  3: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-bucket-another-s3
+        app.mintel.com/placeholder: placeholder
+        app.mintel.com/terraform-allow-destroy: "true"
+        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
+        app.mintel.com/terraform-owner: sre
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-bucket-another-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-bucket-another-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-another-s3
+      namespace: test-namespace
+    spec:
+      agentPool:
+        id: test-agent-pool
+      allowDestroyPlan: true
+      applyMethod: auto
+      executionMode: remote
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-another-s3
+      organization: Mintel
+      sshKey:
+        name: mintel-ssh
+      terraformVariables:
+        - hcl: false
+          name: aws_account_name
+          sensitive: false
+          value: dev
+        - hcl: false
+          name: aws_region
+          sensitive: false
+          value: eu-west-1
+        - hcl: false
+          name: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - hcl: false
+          name: enable_versioning
+          sensitive: false
+          value: "false"
+        - hcl: false
+          name: name
+          sensitive: false
+          value: mntl-test-bucket-another
+        - hcl: false
+          name: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-test-bucket-another/s3
+        - hcl: true
+          name: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - hcl: true
+          name: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "mntl-test-workspace"
+              Component = "mntl-test-workspace"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - hcl: false
+          name: tfcloud_agent
+          sensitive: false
+          value: "true"
+      terraformVersion: 1.3.10
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+  4: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Module
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-bucket-another-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-bucket-another-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-bucket-another-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-another-s3
+      namespace: test-namespace
+    spec:
+      destroyOnDeletion: true
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 3.0.2
+      name: operator
+      organization: Mintel
+      restartedAt: 440e5c2917e867e923be925e70e6b10a8b4cb15763758164b3f5424019eb7bbc
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+      variables:
+        - name: aws_account_name
+        - name: aws_region
+        - name: eks_cluster_name
+        - name: enable_versioning
+        - name: name
+        - name: output_secret_name
+        - name: secret_tags
+        - name: tags
+        - name: tfcloud_agent
+      workspace:
+        name: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-another-s3
 Test workspace overrides:
   1: |
     apiVersion: app.terraform.io/v1alpha2
@@ -215,7 +684,7 @@ Test workspace overrides:
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       namespace: test-namespace
     spec:
-      destroyOnDeletion: false
+      destroyOnDeletion: true
       module:
         source: app.terraform.io/Mintel/private-s3-bucket/aws
         version: 3.0.2
@@ -238,3 +707,118 @@ Test workspace overrides:
         - name: tfcloud_agent
       workspace:
         name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
+Test workspace overrides at resource-config level:
+  1: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
+        app.mintel.com/placeholder: placeholder
+        app.mintel.com/terraform-allow-destroy: "true"
+        app.mintel.com/terraform-cloud-tags: env:prod,owner:sre,mod:s3
+        app.mintel.com/terraform-owner: sre
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-workspace-s3
+        app.mintel.com/env: prod
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-workspace-s3
+      name: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
+      namespace: test-namespace
+    spec:
+      agentPool:
+        id: test-agent-pool
+      allowDestroyPlan: true
+      applyMethod: manual
+      executionMode: remote
+      name: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
+      organization: Mintel
+      sshKey:
+        name: mintel-ssh
+      terraformVariables:
+        - hcl: false
+          name: aws_account_name
+          sensitive: false
+          value: prod
+        - hcl: false
+          name: aws_region
+          sensitive: false
+          value: eu-west-1
+        - hcl: false
+          name: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - hcl: false
+          name: name
+          sensitive: false
+          value: mntl-test-workspace
+        - hcl: false
+          name: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-test-workspace/s3
+        - hcl: true
+          name: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - hcl: true
+          name: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "mntl-test-workspace"
+              Component = "mntl-test-workspace"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - hcl: false
+          name: tfcloud_agent
+          sensitive: false
+          value: "true"
+      terraformVersion: 1.3.10
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+  2: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Module
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-workspace-s3
+        app.mintel.com/env: prod
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-workspace-s3
+      name: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
+      namespace: test-namespace
+    spec:
+      destroyOnDeletion: true
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 3.0.2
+      name: operator
+      organization: Mintel
+      restartedAt: 2866f1e5d7f6db683ef1bba053adef8766e39314187bc830bc6d97e9a68e73a5
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+      variables:
+        - name: aws_account_name
+        - name: aws_region
+        - name: eks_cluster_name
+        - name: name
+        - name: output_secret_name
+        - name: secret_tags
+        - name: tags
+        - name: tfcloud_agent
+      workspace:
+        name: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3

--- a/charts/terraform-cloud/tests/__snapshot__/workspace-v2_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace-v2_test.yaml.snap
@@ -84,9 +84,6 @@ Test workspace defaults:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -207,9 +204,6 @@ Test workspace overrides:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:

--- a/charts/terraform-cloud/tests/module-v2_test.yaml
+++ b/charts/terraform-cloud/tests/module-v2_test.yaml
@@ -32,7 +32,7 @@ tests:
         documentIndex: 1
       - equal:
           path: spec.destroyOnDeletion
-          value: false
+          value: true
         documentIndex: 1
       - equal:
           path: spec.module.source
@@ -60,9 +60,9 @@ tests:
       global.partOf: test-project
       global.terraform.agentPoolID: test-agent-pool
       global.terraform.operatorVersion: v2
-      global.terraform.destroyOnDeletion: true
       global.terraform.enableRestartedAt: true
       global.terraform.restartedAt: restarted-at-value
+      global.terraform.destroyOnDeletion: true
       s3:
         enabled: true
         terraform:

--- a/charts/terraform-cloud/tests/workspace-v2_test.yaml
+++ b/charts/terraform-cloud/tests/workspace-v2_test.yaml
@@ -36,11 +36,11 @@ tests:
         documentIndex: 0
       - equal:
           path: spec.applyMethod
-          value: manual
+          value: auto
         documentIndex: 0
       - equal:
           path: spec.allowDestroyPlan
-          value: false
+          value: true 
         documentIndex: 0
       - equal:
           path: spec.agentPool.id
@@ -68,8 +68,6 @@ tests:
       global.partOf: test-project
       global.terraform.operatorVersion: v2
       global.terraform.agentPoolID: test-agent-pool
-      global.terraform.allowDestroyPlan: true
-      global.terraform.applyMethod: auto
       global.terraform.executionMode: remote
       s3:
         enabled: true
@@ -99,3 +97,101 @@ tests:
           path: spec.allowDestroyPlan
           value: true
         documentIndex: 0
+
+  - it: Test workspace defaults in prod-like environment (prod)
+    set:
+      global.name: mntl-test-workspace
+      global.clusterEnv: prod
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      global.terraform.operatorVersion: v2
+      global.terraform.agentPoolID: test-agent-pool
+      global.terraform.executionMode: remote
+      s3:
+        enabled: true
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - equal:
+          path: spec.allowDestroyPlan
+          value: false
+        documentIndex: 0
+
+  - it: Test workspace defaults in prod-like environment (logs)
+    set:
+      global.name: mntl-test-workspace
+      global.clusterEnv: logs
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      global.terraform.operatorVersion: v2
+      global.terraform.agentPoolID: test-agent-pool
+      global.terraform.executionMode: remote
+      s3:
+        enabled: true
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - equal:
+          path: spec.allowDestroyPlan
+          value: false
+        documentIndex: 0
+ 
+  - it: Test workspace overrides at resource-config level
+    set:
+      global.name: mntl-test-workspace
+      global.clusterEnv: prod
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      global.terraform.operatorVersion: v2
+      global.terraform.agentPoolID: test-agent-pool
+      global.terraform.executionMode: remote
+      s3:
+        terraform:
+          defaultVars: 
+            workspaceAllowDestroy: true
+            workspaceApplyMethod: manual
+        enabled: true
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - equal:
+          path: spec.allowDestroyPlan
+          value: true 
+        documentIndex: 0
+      - equal:
+          path: spec.applyMethod
+          value: manual
+        documentIndex: 0
+
+
+  - it: Test workspace instance overrides
+    set:
+      global.name: mntl-test-workspace
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      global.terraform.operatorVersion: v2
+      global.terraform.agentPoolID: test-agent-pool
+      global.terraform.executionMode: remote
+      s3:
+        enabled: true
+        terraform:
+          instances:
+            test-bucket: {}
+            test-bucket-another: {}
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - equal:
+          path: metadata.name
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-s3
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-another-s3
+        documentIndex: 2
+

--- a/charts/terraform-cloud/values.yaml
+++ b/charts/terraform-cloud/values.yaml
@@ -42,12 +42,6 @@ global:
     agentPoolID: ""
     # --  Define where the Terraform code will be executed.
     executionMode: agent
-    # -- Allows a destroy plan to be created and applied.
-    allowDestroyPlan: false
-    # -- Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes.
-    # Note that deletions are also protected by sentinel policy-enforcement rules in non-development environments
-    # See https://developer.hashicorp.com/terraform/cloud-docs/policy-enforcement/sentinel
-    destroyOnDeletion: false
     # -- Allows executing a new Run without changing any Workspace or Module attributes.
     # Defaults to a hash of the instanceCfg specification
     # restartedAt: ""
@@ -83,6 +77,8 @@ activeMQ:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      #### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -114,6 +110,8 @@ apiGatewayHttp:
       ### Boolean which when set to true disables destroy runs on the workspace and vice-versa. It serves as a form of
       ### deletion protection. It defaults to false in prod and logs and true elsewhere
       workspaceAllowDestroy: false
+      #### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Override the generated workspace name, for example if the generated name is above the char limit
       # workspaceNameOverride: string
       ### Comma-separated list of tags to add to workspace. Default: "env:<environment>,owner:<owner>,mod:<module>"
@@ -157,6 +155,8 @@ auroraMySql:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      #### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -204,6 +204,8 @@ auroraPostgresql:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      #### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -240,6 +242,8 @@ cmsBackup:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -268,6 +272,8 @@ datasync:
       ### Boolean which when set to true disables destroy runs on the workspace and vice-versa. It serves as a form of
       ### deletion protection. It defaults to false in prod and logs and true elsewhere
       # workspaceAllowDestroy: false
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Override the generated workspace name, for example if the generated name is above the char limit
       # workspaceNameOverride: string
       ### Comma-separated list of tags to add to workspace. Default: "env:<environment>,owner:<owner>,mod:<module>"
@@ -307,6 +313,8 @@ dynamodb:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -347,6 +355,8 @@ extraIAM:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -382,6 +392,8 @@ irsa:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
     # -- Configure Terraform Cloud notifications. This should not be changed unless you really know what you're doing.
@@ -434,6 +446,8 @@ lambda:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -479,6 +493,8 @@ mariadb:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -522,6 +538,8 @@ memcached:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -554,6 +572,8 @@ opensearch:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -597,6 +617,8 @@ postgresql:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -636,6 +658,8 @@ redis:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -675,6 +699,8 @@ s3:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -713,6 +739,8 @@ sns:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -749,6 +777,8 @@ sqs:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -782,6 +812,8 @@ staticWebsite:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -813,6 +845,8 @@ stepFunctionEks:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>
@@ -843,6 +877,8 @@ sshKeyPairSecret:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
+      # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
       # workspaceOwner: string
       ### Use to map keys from AWS secret manager secrets to new key names. Map values should be in the form <new key>:<module secret key>

--- a/charts/terraform-cloud/values.yaml
+++ b/charts/terraform-cloud/values.yaml
@@ -36,8 +36,6 @@ global:
     irsa: true
     # -- Operator version to use (v1 or v2)
     operatorVersion: "v1"
-    # -- Define either change will be applied automatically(auto) or require an operator to confirm(manual).
-    applyMethod: manual
     # -- ID of the Terraform Cloud Agent Pool to use for the run. Passed in from cluster-env-jsonnet
     agentPoolID: ""
     # --  Define where the Terraform code will be executed.
@@ -77,6 +75,8 @@ activeMQ:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       #### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -110,6 +110,8 @@ apiGatewayHttp:
       ### Boolean which when set to true disables destroy runs on the workspace and vice-versa. It serves as a form of
       ### deletion protection. It defaults to false in prod and logs and true elsewhere
       workspaceAllowDestroy: false
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       #### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Override the generated workspace name, for example if the generated name is above the char limit
@@ -155,6 +157,8 @@ auroraMySql:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       #### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -204,6 +208,8 @@ auroraPostgresql:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       #### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -242,6 +248,8 @@ cmsBackup:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -313,6 +321,8 @@ dynamodb:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -355,6 +365,8 @@ extraIAM:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -392,6 +404,8 @@ irsa:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -446,6 +460,8 @@ lambda:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -493,6 +509,8 @@ mariadb:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -538,6 +556,8 @@ memcached:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -572,6 +592,8 @@ opensearch:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -617,6 +639,8 @@ postgresql:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -658,6 +682,8 @@ redis:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -699,6 +725,8 @@ s3:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -739,6 +767,8 @@ sns:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -777,6 +807,8 @@ sqs:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -812,6 +844,8 @@ staticWebsite:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -845,6 +879,8 @@ stepFunctionEks:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner
@@ -877,6 +913,8 @@ sshKeyPairSecret:
       # workspaceTags: string
       ### Set to true allows destroy runs on the workspace. Default: false in prod/logs, true in non-prod
       # workspaceAllowDestroy: bool
+      ### Define either change will be applied automatically(auto) or require an operator to confirm(manual). Default: auto
+      # workspaceApplyMethod: auto
       ### Specify whether or not to execute a Destroy run when the object is deleted from the Kubernetes. Default: true
       # moduleDestroyOnDeletion: false
       ### Determines team ownership of the workspace. Default: Values.global.owner


### PR DESCRIPTION
The following variables have changed:


`allowDestroyPlan` renamed to `workspaceAllowDestroy` which is now the same as v1. We'll eventually rename this to `workspaceAllowDestroyPlan` which is more in sync with the upstream naming.

This now defaults to false in logs/prod accounts and is also configurable at the resource-config layer.

2. `destroyOnDeletion` renamed to `moduleDestroyOnDeletion` to make it clear it's related to modules. 

This now defaults to `true` which is inline with the `v1` operator.

3. `applyMethod` renamed to `workspaceApplyMethod` and now defaults to `auto` which is inline with v1 operator behavior.

4. Rename annotations helper and remove it from the Module - it only applies to the Workspace.