### PR TITLE
INFRA-35503: argocd support v2 tfc operator both versions

### DIFF
--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 

--- a/charts/terraform-cloud/templates/irsa-workspace.yaml
+++ b/charts/terraform-cloud/templates/irsa-workspace.yaml
@@ -47,6 +47,11 @@
     {{- $_ := set $irsaConfig "k8s_namespace" $.Release.Namespace }}
   {{- end }}
   # Create the CRD
+{{- if eq $global.terraform.operatorVersion "migrate" }}
+  {{- include "mintel_common.terraform_cloud.workspace_v1" (list $ . $irsaConfig "irsa" $moduleSource $moduleVersion $tfVersion $irsa $notifications) }}
+---
+  {{- include "mintel_common.terraform_cloud.module_v2" (list $ . $irsaConfig "irsa" $moduleSource $moduleVersion $tfVersion $irsa $notifications) }}
+{{- end }}
 {{- if eq $global.terraform.operatorVersion "v1" }}
   {{- include "mintel_common.terraform_cloud.workspace_v1" (list $ . $irsaConfig "irsa" $moduleSource $moduleVersion $tfVersion $irsa $notifications) }}
 {{- end }}

--- a/charts/terraform-cloud/templates/workspace.yaml
+++ b/charts/terraform-cloud/templates/workspace.yaml
@@ -73,6 +73,11 @@
       {{- $instanceConfig = mergeOverwrite (include "mintel_common.terraform_cloud.defaultVarValues" $instanceDict | fromJson ) $instanceConfig }}
       # Create the CRD
 ---
+{{- if eq $global.terraform.operatorVersion "migrate" }}
+      {{- include "mintel_common.terraform_cloud.workspace_v1" (list $ . $instanceConfig $resourceType $moduleSource $moduleVersion $tfVersion $resourceConfig "") }}
+---
+      {{- include "mintel_common.terraform_cloud.module_v2" (list $ . $instanceConfig $resourceType $moduleSource $moduleVersion $tfVersion $resourceConfig "") }}
+{{- end }}
 {{- if eq $global.terraform.operatorVersion "v1" }}
       {{- include "mintel_common.terraform_cloud.workspace_v1" (list $ . $instanceConfig $resourceType $moduleSource $moduleVersion $tfVersion $resourceConfig "") }}
 {{- end }}


### PR DESCRIPTION
Support a temporary `operatorVersion: "migrate"` mode.

This will deploy the existing v1 Workspace resource along with the v2 Module resource.

This is currently being used to test whether we can simplify the migration process.