### PR TITLE
INFRA-35677: Update v2 workspace to handle spec.tags

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.7.0] - 2024-06-07
+### Changed
+- Update v2 workspace to configure `spec.tags`
+
+### Removed
+- Remove v2 workspace custom-extension annotations (will be handled by `spec.tags` and `spec.teamAccess`)
+
 ## [v1.6.0] - 2024-06-06
 ### Added
 - Added IRSA tests for workspace-v2 (copied and adjust v1 version)

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 

--- a/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
@@ -21,7 +21,6 @@ metadata:
     app.kubernetes.io/name: {{ printf "%s-%s" ($instanceCfg.name | kebabcase) ($resourceType | kebabcase) | trunc 63 }}
   annotations:
     {{ include "mintel_common.commonAnnotations" $ | nindent 4 }}
-    {{ include "mintel_common.terraform_cloud.tfCloudOperatorExtentionAnnotations" $workspaceDict | nindent 4 }}
     {{- if (eq $resourceType "irsa") }}
     app.mintel.com/altManifestFileSuffix: "{{ $global.name }}-{{ $resourceType | kebabcase }}"
     {{- else }}
@@ -47,6 +46,12 @@ spec:
       key: token
   sshKey:
     name: "mintel-ssh"
+  tags:
+    - env:{{ $global.clusterEnv }}
+    - owner:{{ $global.owner | lower }}
+    - mod:{{ $resourceType }}
+    - allow-destroy:{{ (include "mintel_common.terraform_cloud.allow_destroy" $workspaceDict) }}
+    - kubernetes-managed
   terraformVersion: {{ $tfVersion | default $global.terraform.terraformVersion | quote }}
   {{- if (has $resourceType (list "irsa" "extraIAM" )) }}
   runTriggers:

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace-v2_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace-v2_test.yaml.snap
@@ -6,9 +6,6 @@ IRSA created explicitly:
       annotations:
         app.mintel.com/altManifestFileSuffix: test-app-irsa
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:irsa
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
       labels:
@@ -38,6 +35,12 @@ IRSA created explicitly:
       runTriggers: null
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:irsa
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -130,9 +133,6 @@ IRSA created for Dev S3 module workspace:
       annotations:
         app.mintel.com/altManifestFileSuffix: test-app-irsa
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:irsa
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-20"
       labels:
@@ -163,6 +163,12 @@ IRSA created for Dev S3 module workspace:
         - name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:irsa
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -255,9 +261,6 @@ IRSA created with default (0) syncWave:
       annotations:
         app.mintel.com/altManifestFileSuffix: test-app-irsa
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:irsa
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "0"
       labels:
@@ -287,6 +290,12 @@ IRSA created with default (0) syncWave:
       runTriggers: null
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:irsa
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -379,9 +388,6 @@ IRSA created with modified syncWave:
       annotations:
         app.mintel.com/altManifestFileSuffix: test-app-irsa
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:irsa
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-100"
       labels:
@@ -411,6 +417,12 @@ IRSA created with modified syncWave:
       runTriggers: null
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:irsa
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name

--- a/charts/terraform-cloud/tests/__snapshot__/module-v2_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/module-v2_test.yaml.snap
@@ -6,9 +6,6 @@ Test module defaults:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -29,6 +26,12 @@ Test module defaults:
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -126,9 +129,6 @@ Test module overrides:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -149,6 +149,12 @@ Test module overrides:
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -246,9 +252,6 @@ Test module restartedAt disabled:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -269,6 +272,12 @@ Test module restartedAt disabled:
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name

--- a/charts/terraform-cloud/tests/__snapshot__/workspace-v2_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace-v2_test.yaml.snap
@@ -1,3 +1,239 @@
+Test tags:
+  1: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-app-s3
+        app.mintel.com/env: prod
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-app-s3
+      name: prod-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      namespace: test-namespace
+    spec:
+      agentPool:
+        id: ""
+      allowDestroyPlan: true
+      applyMethod: auto
+      executionMode: agent
+      name: prod-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      organization: Mintel
+      sshKey:
+        name: mintel-ssh
+      tags:
+        - env:prod
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
+      terraformVariables:
+        - hcl: false
+          name: aws_account_name
+          sensitive: false
+          value: prod
+        - hcl: false
+          name: aws_region
+          sensitive: false
+          value: eu-west-1
+        - hcl: false
+          name: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - hcl: false
+          name: name
+          sensitive: false
+          value: mntl-test-app
+        - hcl: false
+          name: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-test-app/s3
+        - hcl: true
+          name: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - hcl: true
+          name: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "test-app"
+              Component = "test-app"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - hcl: false
+          name: tfcloud_agent
+          sensitive: false
+          value: "true"
+      terraformVersion: 1.3.10
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+  2: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Module
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-app-s3
+        app.mintel.com/env: prod
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-app-s3
+      name: prod-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      namespace: test-namespace
+    spec:
+      destroyOnDeletion: true
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 3.0.2
+      name: operator
+      organization: Mintel
+      restartedAt: 6c781edcb3060b66cf8e41e49cb262104c2381bd331c01105f22327bc4ebf08f
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+      variables:
+        - name: aws_account_name
+        - name: aws_region
+        - name: eks_cluster_name
+        - name: name
+        - name: output_secret_name
+        - name: secret_tags
+        - name: tags
+        - name: tfcloud_agent
+      workspace:
+        name: prod-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+Test tags with env/allow-destroy flags changed:
+  1: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-app-s3
+        app.mintel.com/env: logs
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-app-s3
+      name: logs-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      namespace: test-namespace
+    spec:
+      agentPool:
+        id: ""
+      allowDestroyPlan: false
+      applyMethod: auto
+      executionMode: agent
+      name: logs-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      organization: Mintel
+      sshKey:
+        name: mintel-ssh
+      tags:
+        - env:logs
+        - owner:sre
+        - mod:s3
+        - allow-destroy:false
+        - kubernetes-managed
+      terraformVariables:
+        - hcl: false
+          name: aws_account_name
+          sensitive: false
+          value: logs
+        - hcl: false
+          name: aws_region
+          sensitive: false
+          value: eu-west-1
+        - hcl: false
+          name: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - hcl: false
+          name: name
+          sensitive: false
+          value: mntl-test-app
+        - hcl: false
+          name: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-test-app/s3
+        - hcl: true
+          name: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - hcl: true
+          name: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "test-app"
+              Component = "test-app"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - hcl: false
+          name: tfcloud_agent
+          sensitive: false
+          value: "true"
+      terraformVersion: 1.3.10
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+  2: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Module
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-app-s3
+        app.mintel.com/env: logs
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-app-s3
+      name: logs-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      namespace: test-namespace
+    spec:
+      destroyOnDeletion: true
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 3.0.2
+      name: operator
+      organization: Mintel
+      restartedAt: 1b8273d8b2a6e386e56efb1eaaa6f57401e219eddfdb01819449687fb3476b2e
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+      variables:
+        - name: aws_account_name
+        - name: aws_region
+        - name: eks_cluster_name
+        - name: name
+        - name: output_secret_name
+        - name: secret_tags
+        - name: tags
+        - name: tfcloud_agent
+      workspace:
+        name: logs-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
 Test workspace allow destroy env:
   1: |
     apiVersion: app.terraform.io/v1alpha2
@@ -6,9 +242,6 @@ Test workspace allow destroy env:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "false"
-        app.mintel.com/terraform-cloud-tags: env:prod,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -29,6 +262,12 @@ Test workspace allow destroy env:
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:prod
+        - owner:sre
+        - mod:s3
+        - allow-destroy:false
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -121,9 +360,6 @@ Test workspace allow destroy env global-override:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:prod,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -144,6 +380,12 @@ Test workspace allow destroy env global-override:
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:prod
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -236,9 +478,6 @@ Test workspace allow destroy env resource-override:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:prod,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -259,6 +498,12 @@ Test workspace allow destroy env resource-override:
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:prod
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -351,9 +596,6 @@ Test workspace defaults:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -374,6 +616,12 @@ Test workspace defaults:
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -471,9 +719,6 @@ Test workspace defaults in prod-like environment (logs):
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "false"
-        app.mintel.com/terraform-cloud-tags: env:logs,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -494,6 +739,12 @@ Test workspace defaults in prod-like environment (logs):
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:logs
+        - owner:sre
+        - mod:s3
+        - allow-destroy:false
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -586,9 +837,6 @@ Test workspace defaults in prod-like environment (prod):
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "false"
-        app.mintel.com/terraform-cloud-tags: env:prod,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -609,6 +857,12 @@ Test workspace defaults in prod-like environment (prod):
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:prod
+        - owner:sre
+        - mod:s3
+        - allow-destroy:false
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -701,9 +955,6 @@ Test workspace instance overrides:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-bucket-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -724,6 +975,12 @@ Test workspace instance overrides:
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -820,9 +1077,6 @@ Test workspace instance overrides:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-bucket-another-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -843,6 +1097,12 @@ Test workspace instance overrides:
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -940,9 +1200,6 @@ Test workspace overrides:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:dev,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -963,6 +1220,12 @@ Test workspace overrides:
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -1060,9 +1323,6 @@ Test workspace overrides at global-config level:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:prod,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -1083,6 +1343,12 @@ Test workspace overrides at global-config level:
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:prod
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name
@@ -1175,9 +1441,6 @@ Test workspace overrides at resource-config level:
       annotations:
         app.mintel.com/altManifestFileSuffix: mntl-test-workspace-s3
         app.mintel.com/placeholder: placeholder
-        app.mintel.com/terraform-allow-destroy: "true"
-        app.mintel.com/terraform-cloud-tags: env:prod,owner:sre,mod:s3
-        app.mintel.com/terraform-owner: sre
         argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
         argocd.argoproj.io/sync-wave: "-40"
       labels:
@@ -1198,6 +1461,12 @@ Test workspace overrides at resource-config level:
       organization: Mintel
       sshKey:
         name: mintel-ssh
+      tags:
+        - env:prod
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
       terraformVariables:
         - hcl: false
           name: aws_account_name

--- a/charts/terraform-cloud/tests/workspace-v2_test.yaml
+++ b/charts/terraform-cloud/tests/workspace-v2_test.yaml
@@ -235,8 +235,8 @@ tests:
     asserts:
       - matchSnapshot: {} # Check for regressions and unexpected changes.
       - equal:
-          path: metadata.annotations["app.mintel.com/terraform-allow-destroy"]
-          value: "false"
+          path: spec.allowDestroyPlan
+          value: false
         documentIndex: 0
 
   - it: Test workspace allow destroy env resource-override
@@ -256,8 +256,8 @@ tests:
     asserts:
       - matchSnapshot: {} # Check for regressions and unexpected changes.
       - equal:
-          path: metadata.annotations["app.mintel.com/terraform-allow-destroy"]
-          value: "true"
+          path: spec.allowDestroyPlan
+          value: true
         documentIndex: 0
 
   - it: Test workspace allow destroy env global-override
@@ -275,6 +275,53 @@ tests:
     asserts:
       - matchSnapshot: {} # Check for regressions and unexpected changes.
       - equal:
-          path: metadata.annotations["app.mintel.com/terraform-allow-destroy"]
-          value: "true"
+          path: spec.allowDestroyPlan
+          value: true
+        documentIndex: 0
+
+  - it: Test tags
+    set:
+      global.name: test-app
+      global.clusterEnv: prod
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      global.terraform.operatorVersion: v2
+      global.terraform.defaultWorkspaceAllowDestroy: true
+      s3:
+        enabled: true
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - equal:
+          path: spec.tags
+          value:
+            - env:prod
+            - owner:sre
+            - mod:s3
+            - allow-destroy:true
+            - kubernetes-managed
+        documentIndex: 0
+
+  - it: Test tags with env/allow-destroy flags changed
+    set:
+      global.name: test-app
+      global.clusterEnv: logs
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      global.terraform.operatorVersion: v2
+      s3:
+        enabled: true
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - equal:
+          path: spec.tags
+          value:
+            - env:logs
+            - owner:sre
+            - mod:s3
+            - allow-destroy:false
+            - kubernetes-managed
         documentIndex: 0


### PR DESCRIPTION
### Changed
- Update v2 workspace to configure `spec.tags`

### Removed
- Remove v2 workspace custom-extension annotations (will be handled by `spec.tags` and `spec.teamAccess`)