### PR TITLE
INFRA-37205: Allow Application tag to be set on Service

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v7.4.0] - 2024-08-27
 ### Added
-- Set the `Application` annotation on the Service resource. This propogates to the AWS TargetGroup as a tag.
+- Set the `Application` ALB annotation tag on the Service resource. This propagates to the AWS TargetGroup as a tag.
 
 ## [v7.3.0] - 2024-07-24
 ### Changed

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -5,12 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v7.4.0] - 2024-08-27
+### Added
+- Set the `Application` annotation on the Service resource. This propogates to the AWS TargetGroup as a tag.
+
 ## [v7.3.0] - 2024-07-24
-### Changes
+### Changed
 - Make `matchLabelKeys: pod-template-hash` in topologySpreadConstraints optional
 
 ## [v7.2.0] - 2024-07-24
-### Changes
+### Changed
 - Updated the logic of initialDelaySeconds to not be set if no value given
 
 ## [v7.1.0] - 2024-07-19

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 7.3.0
+version: 7.4.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 7.3.0](https://img.shields.io/badge/Version-7.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 7.4.0](https://img.shields.io/badge/Version-7.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/service.yaml
+++ b/charts/standard-application-stack/templates/service.yaml
@@ -10,8 +10,17 @@ metadata:
     {{- if .Values.service.annotations }}
     {{ toYaml .Values.service.annotations | nindent 4 }}
     {{- end }}
-    {{- if (and .Values.global.owner .Values.ingress.enabled ) }}
-    'alb.ingress.kubernetes.io/tags': 'Owner={{ .Values.global.owner }}'
+    {{- if .Values.ingress.enabled }}
+    {{ $alb_tags := list }}
+    {{- if .Values.global.owner }}
+    {{ $alb_tags = append $alb_tags (printf "Owner=%s" .Values.global.owner) }}
+    {{- end }}
+    {{- if .Values.global.application }}
+    {{ $alb_tags = append $alb_tags (printf "Application=%s" .Values.global.application ) }}
+    {{- end }}
+    {{- if $alb_tags }}
+    'alb.ingress.kubernetes.io/tags':  "{{ join "," $alb_tags }}"
+    {{- end }}
     {{- end }}
     {{- if .Values.nlb.enabled }}
     {{ include "mintel_common.nlb.annotations" . | nindent 4 }}

--- a/charts/standard-application-stack/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_test.yaml.snap
@@ -4,13 +4,13 @@ Check ALB annotation can be set when enabled:
     kind: Service
     metadata:
       annotations:
-        alb.ingress.kubernetes.io/tags: Owner=my-team
+        alb.ingress.kubernetes.io/tags: Owner=my-team,Application=my-app
         app.mintel.com/placeholder: placeholder
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: test-app
-        app.mintel.com/application: test-app
+        app.mintel.com/application: my-app
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/owner: my-team
@@ -27,7 +27,66 @@ Check ALB annotation can be set when enabled:
         app.kubernetes.io/component: app
         app.kubernetes.io/name: test-app
       type: ClusterIP
-Check ALB annotation not set when when Owner missing:
+Check ALB annotation can set Application without Owner:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        alb.ingress.kubernetes.io/tags: Application=my-app
+        app.mintel.com/placeholder: placeholder
+        k: v
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: test-app
+        app.mintel.com/application: my-app
+        app.mintel.com/component: test-app
+        app.mintel.com/env: local
+        app.mintel.com/region: local
+        name: test-app
+      name: test-app
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: main-http
+          port: 8000
+          targetPort: 8000
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: test-app
+      type: ClusterIP
+Check ALB annotation can set Owner without Application:
+  1: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        alb.ingress.kubernetes.io/tags: Owner=my-team
+        app.mintel.com/placeholder: placeholder
+        k: v
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: test-app
+        app.mintel.com/application: test-app
+        app.mintel.com/component: test-app
+        app.mintel.com/env: local
+        app.mintel.com/owner: my-team
+        app.mintel.com/region: local
+        name: test-app
+      name: test-app
+      namespace: test-namespace
+    spec:
+      ports:
+        - name: main-http
+          port: 8000
+          targetPort: 8000
+      selector:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/name: test-app
+      type: ClusterIP
+Check ALB annotation not set when Owner and Application missing:
   1: |
     apiVersion: v1
     kind: Service

--- a/charts/standard-application-stack/tests/service_test.yaml
+++ b/charts/standard-application-stack/tests/service_test.yaml
@@ -117,6 +117,7 @@ tests:
     set:
       global.name: test-app
       global.owner: my-team
+      global.application: my-app
       global.clusterEnv: qa
       ingress.enabled: true
     asserts:
@@ -125,9 +126,9 @@ tests:
           of: Service
       - equal:
           path: metadata.annotations["alb.ingress.kubernetes.io/tags"]
-          value: Owner=my-team
+          value: Owner=my-team,Application=my-app
 
-  - it: Check ALB annotation not set when when Owner missing
+  - it: Check ALB annotation not set when Owner and Application missing
     set:
       global.name: test-app
       ingress.enabled: true
@@ -140,3 +141,35 @@ tests:
           of: Service
       - isNull:
           path: metadata.annotations["alb.ingress.kubernetes.io/tags"]
+
+  - it: Check ALB annotation can set Application without Owner
+    set:
+      global.name: test-app
+      ingress.enabled: true
+      global.application: my-app
+      # Add annotations to allow for isNull check
+      service.annotations:
+        k: v
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.annotations["alb.ingress.kubernetes.io/tags"]
+          value: Application=my-app
+
+  - it: Check ALB annotation can set Owner without Application
+    set:
+      global.name: test-app
+      ingress.enabled: true
+      global.owner: my-team
+      # Add annotations to allow for isNull check
+      service.annotations:
+        k: v
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.annotations["alb.ingress.kubernetes.io/tags"]
+          value: Owner=my-team


### PR DESCRIPTION
Allow the Application tag to be set on the underlying AWS TargetGroup resource.

I've made this optional a little more flexible since it will make the migration smoother (i.e. as we phase out Owner).