### PR TITLE
Add ArgoCD sync option to custom resources

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,9 +24,9 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTION@users.noreploy.github.com"
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.13
 
       - name: Add repo dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTION@users.noreploy.github.com"
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.13
 
       - name: Add repo dependencies
         run: |

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v7.5.3] - 2024-12-18
+### Changed
+- Add `argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true` to VerticalPodAutoscalers.
+- Add `argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true` to ScaledObjects.
+
 ## [v7.5.2] - 2024-10-07
 ### Changed
 - Reduce default CPU requests

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 7.5.2
+version: 7.5.3
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 7.5.2](https://img.shields.io/badge/Version-7.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 7.5.3](https://img.shields.io/badge/Version-7.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/keda-scaled-object.yaml
+++ b/charts/standard-application-stack/templates/keda-scaled-object.yaml
@@ -6,6 +6,8 @@ metadata:
   name: {{ include "mintel_common.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels: {{ include "mintel_common.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   {{- with .Values.autoscaling }}
   cooldownPeriod: {{ include "mintel_common.keda.scaledObject.cooldownPeriod" .}}

--- a/charts/standard-application-stack/templates/vpa.yaml
+++ b/charts/standard-application-stack/templates/vpa.yaml
@@ -10,6 +10,7 @@ metadata:
   name: {{ if $.Values.statefulset }}statefulset{{ else }}deployment{{ end }}-{{ include "mintel_common.fullname" $app }}
   namespace: {{ $.Release.Namespace }}
   annotations: {{ include "mintel_common.commonAnnotations" $app | nindent 4 }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels: {{ include "mintel_common.labels" $app | nindent 4 }}
 spec:
   targetRef:
@@ -45,6 +46,7 @@ metadata:
   name: cronjob-{{ include "mintel_common.fullname" $app }}
   namespace: {{ $.Release.Namespace }}
   annotations: {{ include "mintel_common.commonAnnotations" $app | nindent 4 }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels: {{ include "mintel_common.labels" $app | nindent 4 }}
 spec:
   targetRef:
@@ -74,6 +76,7 @@ metadata:
   name: deployment-{{ include "mintel_common.fullname" $app }}
   namespace: {{ $.Release.Namespace }}
   annotations: {{ include "mintel_common.commonAnnotations" $app | nindent 4 }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels: {{ include "mintel_common.labels" $app | nindent 4 }}
 spec:
   targetRef:
@@ -103,6 +106,7 @@ metadata:
   name: deployment-{{ include "mintel_common.fullname" $app }}
   namespace: {{ $.Release.Namespace }}
   annotations: {{ include "mintel_common.commonAnnotations" $app | nindent 4 }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels: {{ include "mintel_common.labels" $app | nindent 4 }}
 spec:
   targetRef:
@@ -132,6 +136,7 @@ metadata:
   name: deployment-{{ include "mintel_common.fullname" $app }}
   namespace: {{ $.Release.Namespace }}
   annotations: {{ include "mintel_common.commonAnnotations" $app | nindent 4 }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels: {{ include "mintel_common.labels" $app | nindent 4 }}
 spec:
   targetRef:
@@ -161,6 +166,7 @@ metadata:
   name: deployment-{{ include "mintel_common.fullname" $app }}
   namespace: {{ $.Release.Namespace }}
   annotations: {{ include "mintel_common.commonAnnotations" $app | nindent 4 }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels: {{ include "mintel_common.labels" $app | nindent 4 }}
 spec:
   targetRef:
@@ -190,6 +196,7 @@ metadata:
   name: deployment-{{ include "mintel_common.fullname" $app }}
   namespace: {{ $.Release.Namespace }}
   annotations: {{ include "mintel_common.commonAnnotations" $app | nindent 4 }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels: {{ include "mintel_common.labels" $app | nindent 4 }}
 spec:
   targetRef:
@@ -219,6 +226,7 @@ metadata:
   name: deployment-{{ include "mintel_common.fullname" $app }}
   namespace: {{ $.Release.Namespace }}
   annotations: {{ include "mintel_common.commonAnnotations" $app | nindent 4 }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels: {{ include "mintel_common.labels" $app | nindent 4 }}
 spec:
   targetRef:
@@ -248,6 +256,7 @@ metadata:
   name: deployment-{{ include "mintel_common.fullname" $app }}
   namespace: {{ $.Release.Namespace }}
   annotations: {{ include "mintel_common.commonAnnotations" $app | nindent 4 }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels: {{ include "mintel_common.labels" $app | nindent 4 }}
 spec:
   targetRef:
@@ -277,6 +286,7 @@ metadata:
   name: deployment-{{ include "mintel_common.fullname" $app }}
   namespace: {{ $.Release.Namespace }}
   annotations: {{ include "mintel_common.commonAnnotations" $app | nindent 4 }}
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels: {{ include "mintel_common.labels" $app | nindent 4 }}
 spec:
   targetRef:

--- a/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_constraints_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_constraints_test.yaml.snap
@@ -3,6 +3,8 @@ Check idleReplicaCount is equal to 0 when enableZeroReplicas is set:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -33,6 +35,8 @@ Check trigger vars automatically populated:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -80,6 +84,8 @@ Check trigger vars can be overriden:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -127,6 +133,8 @@ Creates a ScaledObject with constrained settings:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -156,6 +164,8 @@ Creates a ScaledObject with non-constrained settings:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -185,6 +195,8 @@ Ensure minReplicaCount cannot be greater than 10:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_test.yaml.snap
@@ -3,6 +3,8 @@ Check utilization takes precedence over average value when both specified:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -41,6 +43,8 @@ Creates a ScaledObject for a Deployment:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -70,6 +74,8 @@ Creates a ScaledObject for a StatefulSet:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -99,6 +105,8 @@ Creates a ScaledObject for a custom scaleTargetRef:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -128,6 +136,8 @@ Creates a ScaledObject with advanced settings:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -167,6 +177,8 @@ Creates a ScaledObject with both targetCPUAverageValue and targetMemoryAverageVa
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -205,6 +217,8 @@ Creates a ScaledObject with both targetCPUAverageValue trigger:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -239,6 +253,8 @@ Creates a ScaledObject with both targetCPUUtilizationPercentage and targetMemory
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -277,6 +293,8 @@ Creates a ScaledObject with custom triggers:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -317,6 +335,8 @@ Creates a ScaledObject with default fallback based on minReplicaCount:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -346,6 +366,8 @@ Creates a ScaledObject with explicit fallback settings:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -375,6 +397,8 @@ Creates a ScaledObject with targetCPUUtilizationPercentage trigger:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -409,6 +433,8 @@ Creates a ScaledObject with targetMemoryAverageValue trigger:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -443,6 +469,8 @@ Creates a ScaledObject with targetMemoryUtilizationPercentage trigger:
     apiVersion: keda.sh/v1alpha1
     kind: ScaledObject
     metadata:
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm

--- a/charts/standard-application-stack/tests/__snapshot__/vpa_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/vpa_test.yaml.snap
@@ -5,6 +5,7 @@ Can have per-VerticalPodAutoscaler overrides:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -31,6 +32,7 @@ Can set container policies:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -66,6 +68,7 @@ Creates a VerticalPodAutoscaler for a Deployment:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -92,6 +95,7 @@ Creates a VerticalPodAutoscaler for a StatefulSet:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -118,6 +122,7 @@ Creates a VerticalPodAutoscaler for aws-es-proxy:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: aws-es-proxy
         app.kubernetes.io/managed-by: Helm
@@ -144,6 +149,7 @@ Creates a VerticalPodAutoscaler for celery:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: celery
         app.kubernetes.io/managed-by: Helm
@@ -170,6 +176,7 @@ Creates a VerticalPodAutoscaler for celery-beat:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: celery-beat
         app.kubernetes.io/managed-by: Helm
@@ -196,6 +203,7 @@ Creates a VerticalPodAutoscaler for celery-exporter:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: celery-exporter
         app.kubernetes.io/managed-by: Helm
@@ -222,6 +230,7 @@ Creates a VerticalPodAutoscaler for mysqlclient:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: mysqlclient
         app.kubernetes.io/managed-by: Helm
@@ -248,6 +257,7 @@ Creates a VerticalPodAutoscaler for mysqldexporter:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: mysqldexporter
         app.kubernetes.io/managed-by: Helm
@@ -274,6 +284,7 @@ Creates a VerticalPodAutoscaler for postgresqlclient:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: postgresqlclient
         app.kubernetes.io/managed-by: Helm
@@ -300,6 +311,7 @@ Creates a VerticalPodAutoscaler for postgresqlexporter:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: postgresqlexporter
         app.kubernetes.io/managed-by: Helm
@@ -326,6 +338,7 @@ Creates a VerticalPodAutoscaler with autoscaling enabled:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: app
         app.kubernetes.io/managed-by: Helm
@@ -352,6 +365,7 @@ Only creates VerticalPodAutoscaler for CronJobs if cronjobsOnly is true:
     metadata:
       annotations:
         app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       labels:
         app.kubernetes.io/component: daily
         app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
Custom resouces should have the  `argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true` annotation so that ArgoCD will continue syncing other resources if the CRD for the custom resource is missing (such as during cluster bootstrapping).

JIRA: INFRA-38616