### PR TITLE
Remove default imagePullSecrets

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v8.0.0] - 2025-02-03
+### Removed
+- Removed default `imagePullSecrets`
+
 ## [v7.9.0] - 2025-01-31
 ### Added
 - Add `unhealthyPodEvictionPolicy` to PDBs, defaulting to "AlwaysAllow"

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 7.9.0
+version: 8.0.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 7.9.0](https://img.shields.io/badge/Version-7.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 8.0.0](https://img.shields.io/badge/Version-8.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -251,21 +251,13 @@ Create a default s3 external secret name.
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "mintel_common.imagePullSecrets" -}}
+{{- $names := concat (.Values | merge (dict) | dig "global" "imagePullSecrets" (list)) (.Values | merge (dict) | dig "imagePullSecrets" (list)) | compact | uniq -}}
+{{- if $names -}}
 imagePullSecrets:
-{{- if .Values.global }}
-{{- with .Values.global.imagePullSecrets }}
-{{- range . }}
+{{- range $names }}
   - name: {{ . }}
 {{- end }}
 {{- end }}
-{{- end }}
-{{- with .Values.image.pullSecrets }}
-{{- range . }}
-  - name: {{ . }}
-{{- end }}
-{{- end }}
-  - name: image-pull-gitlab
-  - name: image-pull-docker-hub
 {{- end -}}
 
 {{/*

--- a/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
@@ -58,9 +58,6 @@ Check CronJob Default Overrides:
                         - ALL
                     runAsNonRoot: true
                     runAsUser: 1000
-              imagePullSecrets:
-                - name: image-pull-gitlab
-                - name: image-pull-docker-hub
               restartPolicy: OnFailure
               securityContext:
                 runAsNonRoot: true
@@ -131,9 +128,6 @@ Check CronJob Defaults:
                         - ALL
                     runAsNonRoot: true
                     runAsUser: 1000
-              imagePullSecrets:
-                - name: image-pull-gitlab
-                - name: image-pull-docker-hub
               restartPolicy: Never
               securityContext:
                 runAsNonRoot: true
@@ -204,9 +198,6 @@ Check CronJob Job Overrides:
                         - ALL
                     runAsNonRoot: true
                     runAsUser: 1000
-              imagePullSecrets:
-                - name: image-pull-gitlab
-                - name: image-pull-docker-hub
               restartPolicy: OnFailure
               securityContext:
                 runAsNonRoot: true
@@ -277,9 +268,6 @@ Check CronJob ttlSecondsAfterFinished zero value:
                         - ALL
                     runAsNonRoot: true
                     runAsUser: 1000
-              imagePullSecrets:
-                - name: image-pull-gitlab
-                - name: image-pull-docker-hub
               restartPolicy: Never
               securityContext:
                 runAsNonRoot: true
@@ -349,9 +337,6 @@ CronJob can have a timezone:
                         - ALL
                     runAsNonRoot: true
                     runAsUser: 1000
-              imagePullSecrets:
-                - name: image-pull-gitlab
-                - name: image-pull-docker-hub
               restartPolicy: Never
               securityContext:
                 runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -93,9 +93,6 @@ Check DynamoDB envfrom secretRef is present:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -210,9 +207,6 @@ Check DynamoDB envfrom secretRef is present for local environment:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -313,9 +307,6 @@ Check DynamoDB secretName Override:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
@@ -78,9 +78,6 @@ Check celery does not pull in `main.env` values:
                     - ALL
                 runAsNonRoot: true
                 runAsUser: 1000
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -190,9 +187,6 @@ Check default env behavior:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -305,9 +299,6 @@ Check main container combines default env and `main.env` values:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_image_pull_secrets_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_image_pull_secrets_test.yaml.snap
@@ -1,4 +1,4 @@
-Has a pod template that uses the host network:
+sets imagePullSecrets:
   1: |
     apiVersion: apps/v1
     kind: Deployment
@@ -93,7 +93,9 @@ Has a pod template that uses the host network:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          hostNetwork: true
+          imagePullSecrets:
+            - name: foo
+            - name: bar
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
@@ -113,9 +113,6 @@ Check custom python otel extraEnv vars are added:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -244,9 +241,6 @@ Check custom sampler settings:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -373,9 +367,6 @@ Check default python otel envars are added:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -504,9 +495,6 @@ Check global otel extraEnv vars are added:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_labels_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_labels_test.yaml.snap
@@ -95,9 +95,6 @@ Check default label behavior:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -208,9 +205,6 @@ Check empty application and component labels both default to name:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -106,9 +106,6 @@ Check AWS ALB lifecycle rule applied:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -230,9 +227,6 @@ Check AWS ALB lifecycle rules applied with custom delay:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -346,9 +340,6 @@ Check lifecycle rules:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -93,9 +93,6 @@ Check MariaDB envfrom secretRef is present:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -210,9 +207,6 @@ Check MariaDB envfrom secretRef is present for local environment:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -313,9 +307,6 @@ Check MariaDB secretName Override:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
@@ -93,9 +93,6 @@ Check Memcached envfrom secretRef is present:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -210,9 +207,6 @@ Check Memcached envfrom secretRef is present for local environment:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -313,9 +307,6 @@ Check Memcached secretName Override:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -97,9 +97,6 @@ Check container extraPorts:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -214,9 +211,6 @@ Check container extraPorts are validated:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -330,9 +324,6 @@ Check container extraPorts protocol:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -441,9 +432,6 @@ Check default container main port:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -552,9 +540,6 @@ Check overridden container main port:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -94,9 +94,6 @@ Check allowSingleReplica doesn't alter strategy:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -206,9 +203,6 @@ Check allowSingleReplica set annotations:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -316,9 +310,6 @@ Check replicas unset when autoscaling is enabled:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -425,9 +416,6 @@ Check singleReplicaOnly applied:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -534,9 +522,6 @@ Check singleReplicaOnly ignore replicas value:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -93,9 +93,6 @@ Check S3 envfrom secretRef is present:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -210,9 +207,6 @@ Check S3 envfrom secretRef is present for local environment:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -320,9 +314,6 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -432,9 +423,6 @@ Check S3 secretName Override:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -554,9 +542,6 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
@@ -88,9 +88,6 @@ Check stateful set is rendered with volumeClaimTemplates:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -435,9 +435,6 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -57,9 +57,6 @@ Check all .job.* values can be set correctly, without overriding from main deplo
                     - ALL
                 runAsNonRoot: true
                 runAsUser: 1000
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           initContainers:
             - image: someimage
               name: test-container
@@ -129,9 +126,6 @@ Check all overrides/additions from main deployment work if enabled:
                     - ALL
                 runAsNonRoot: true
                 runAsUser: 1000
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           restartPolicy: Never
           securityContext:
             runAsNonRoot: true
@@ -217,9 +211,6 @@ Check default values are correct with minimal configuration:
                     - ALL
                 runAsNonRoot: true
                 runAsUser: 1000
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           restartPolicy: Never
           serviceAccountName: testGlobalName-testJobName
       ttlSecondsAfterFinished: 60
@@ -261,9 +252,6 @@ Checks that RBAC is set up correctly for kubelock:
               image: registry.example.com/test/image/repo:someTag
               imagePullPolicy: IfNotPresent
               name: main
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           restartPolicy: Never
           serviceAccountName: testGlobalName-testJobName
       ttlSecondsAfterFinished: 60

--- a/charts/standard-application-stack/tests/__snapshot__/mariadb_py_dba_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/mariadb_py_dba_test.yaml.snap
@@ -52,9 +52,6 @@ adds correct config to configmap:
               volumeMounts:
                 - mountPath: /etc/config
                   name: config-volume
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           restartPolicy: Never
           securityContext:
             runAsNonRoot: true
@@ -145,9 +142,6 @@ extraUsers adds job and configmap:
               volumeMounts:
                 - mountPath: /etc/config
                   name: config-volume
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           restartPolicy: Never
           securityContext:
             runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -149,9 +149,6 @@ Check default container args:
                     - ALL
                 runAsNonRoot: true
                 runAsUser: 1000
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -317,9 +314,6 @@ Check setting skip-auth-regex from extra passed in values:
                     - ALL
                 runAsNonRoot: true
                 runAsUser: 1000
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -485,9 +479,6 @@ Check setting skip-auth-regex from extra passed in values when they already cont
                     - ALL
                 runAsNonRoot: true
                 runAsUser: 1000
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -652,9 +643,6 @@ Check setting skip-auth-regex from overridden health-check values:
                     - ALL
                 runAsNonRoot: true
                 runAsUser: 1000
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -819,9 +807,6 @@ Check sidecar present if enabled:
                     - ALL
                 runAsNonRoot: true
                 runAsUser: 1000
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/opensearch_aws_es_proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/opensearch_aws_es_proxy_test.yaml.snap
@@ -225,9 +225,6 @@ Check awsEsProxy deployment is created if enabled:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -278,9 +278,6 @@ Check combined template defaults:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -444,9 +441,6 @@ Check combined template with extra ports and monitors:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/__snapshot__/postgresql_py_dba_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/postgresql_py_dba_test.yaml.snap
@@ -52,9 +52,6 @@ adds correct config to configmap:
               volumeMounts:
                 - mountPath: /etc/config
                   name: config-volume
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           restartPolicy: Never
           securityContext:
             runAsNonRoot: true
@@ -145,9 +142,6 @@ extraUsers adds job and configmap:
               volumeMounts:
                 - mountPath: /etc/config
                   name: config-volume
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           restartPolicy: Never
           securityContext:
             runAsNonRoot: true

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -329,9 +329,6 @@ Check combined template defaults:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000
@@ -527,9 +524,6 @@ Check combined template with extra ports and monitors:
                   port: http
                   scheme: HTTP
                 periodSeconds: 5
-          imagePullSecrets:
-            - name: image-pull-gitlab
-            - name: image-pull-docker-hub
           securityContext:
             runAsNonRoot: true
             runAsUser: 1000

--- a/charts/standard-application-stack/tests/deployment_image_pull_secrets_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_image_pull_secrets_test.yaml
@@ -1,0 +1,23 @@
+suite: Test Deployment imagePullSecrets
+templates:
+  - deployment.yaml
+  - deployment-celery.yaml
+release:
+  namespace: test-namespace
+tests:
+  - it: sets imagePullSecrets
+    template: deployment.yaml
+    set:
+      global.clusterEnv: qa
+      global.name: test-app
+      global.imagePullSecrets:
+        - foo
+      imagePullSecrets:
+        - bar
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - equal:
+         path: spec.template.spec.imagePullSecrets
+         value:
+           - name: foo
+           - name: bar


### PR DESCRIPTION
Our default imagePullSecrets are now injected into pods by Kyverno. Remove them from the Helm chart.

JIRA: INFRA-38407