### PR TITLE
Add unhealthyPodEvictionPolicy the PDBs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -38,7 +38,7 @@ jobs:
           done
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@v2.7.0
 
       - name: List changed charts
         id: list-changed

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -32,9 +32,9 @@ jobs:
         run: |
           for d in ./charts/*/ ; do
             echo $d
-            cd $d
+            pushd $d
             helm dependency list | grep -v "REPOSITORY" | grep -v -e '^$' | awk '{ system("helm repo add " $1 " " $3)}'
-            cd ../..
+            popd
           done
 
       - name: Set up chart-testing
@@ -44,7 +44,7 @@ jobs:
         id: list-changed
         run: |
           ## If executed with debug this won't work anymore.
-          changed=$(ct list-changed --target-branch main)
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           charts=$(echo "$changed" | tr '\n' ' ' | xargs)
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
@@ -52,7 +52,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch main --validate-maintainers=false
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --validate-maintainers=false
 
       - name: Run unit tests
         uses: mintel/helm-testing-action@master

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v7.9.0] - 2025-01-31
+### Added
+- Add `unhealthyPodEvictionPolicy` to PDBs, defaulting to "AlwaysAllow"
+
 ## [v7.8.0] - 2025-01-09
 ### Changed
 - Use updated image for `aws-es-proxy` and switch to using `mintel` user

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 7.8.0
+version: 7.9.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 7.8.0](https://img.shields.io/badge/Version-7.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 7.9.0](https://img.shields.io/badge/Version-7.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -30,7 +30,7 @@ A generic chart to support most common application requirements
 | allowSingleReplica | bool | `false` | Explicitly allow the number of replicas to equal 1 Useful for backend event based services where we may only want a single replica but still want rolling updates etc |
 | args | list | `[]` | Optional arguments to the container |
 | autoscaling | object | `{"advanced":{},"cooldownPeriod":300,"enableZeroReplicas":false,"enabled":false,"fallback":{"failureThreshold":3},"maxReplicaCount":5,"minReplicaCount":2,"pollingInterval":30,"scaleTargetRef":{"apiVersion":"apps/v1","envSourceContainerName":"","kind":"Deployment"},"triggers":{}}` | Handle autoscaling via https://keda.sh Creates a ScaledObject for the workload ref: https://keda.sh/docs/2.8/concepts/scaling-deployments/ |
-| celery | object | `{"args":["celery"],"enabled":false,"liveness":{"enabled":false},"metrics":{"enabled":true,"port":"metrics"},"podDisruptionBudget":{"enabled":true,"minAvailable":"50%"},"readiness":{"enabled":false},"replicas":2,"resources":{"limits":{},"requests":{}},"startup":{"failureThreshold":60,"methodOverride":{},"periodSeconds":5}}` | Configure celery deployment Defaults to same image as main deployment but with the "celery" argument |
+| celery | object | `{"args":["celery"],"enabled":false,"liveness":{"enabled":false},"metrics":{"enabled":true,"port":"metrics"},"podDisruptionBudget":{"enabled":true,"minAvailable":"50%","unhealthyPodEvictionPolicy":"AlwaysAllow"},"readiness":{"enabled":false},"replicas":2,"resources":{"limits":{},"requests":{}},"startup":{"failureThreshold":60,"methodOverride":{},"periodSeconds":5}}` | Configure celery deployment Defaults to same image as main deployment but with the "celery" argument |
 | celery.args | list | `["celery"]` | Arguments to the celery container |
 | celery.enabled | bool | `false` | Set to true to enable a celery deployment |
 | celery.liveness | object | `{"enabled":false}` | Configure extra options for liveness probe ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes |
@@ -38,7 +38,8 @@ A generic chart to support most common application requirements
 | celery.metrics | object | `{"enabled":true,"port":"metrics"}` | Prometheus Exporter / Metrics |
 | celery.metrics.enabled | bool | `true` | Enable Prometheus to access application metrics endpoints |
 | celery.metrics.port | string | `"metrics"` | Port to collect celery metrics |
-| celery.podDisruptionBudget | object | `{"enabled":true,"minAvailable":"50%"}` | Pod Disruption Budget ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/ |
+| celery.podDisruptionBudget | object | `{"enabled":true,"minAvailable":"50%","unhealthyPodEvictionPolicy":"AlwaysAllow"}` | Pod Disruption Budget ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/ |
+| celery.podDisruptionBudget.unhealthyPodEvictionPolicy | string | `"AlwaysAllow"` | Controls how Pod Disruption Budgets apply to pods that are unhealthy.    The default is to allow them to be terminated. |
 | celery.readiness | object | `{"enabled":false}` | Configure extra options for readiness probe ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes |
 | celery.readiness.enabled | bool | `false` | Enable readiness probe |
 | celery.replicas | int | `2` | Desired number of replicas for celery deployment |
@@ -282,7 +283,8 @@ A generic chart to support most common application requirements
 | otel.sampler.type | string | `"parentbased_always_on"` | Configures OTEL_TRACES_SAMPLER |
 | persistentVolumes | string | `nil` | A list of persistent volume claims to be added to the pod |
 | podAnnotations | object | `{}` | Additional annotations to apply to the pod |
-| podDisruptionBudget | object | `{"enabled":true,"minAvailable":"50%"}` | Pod Disruption Budget ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/ |
+| podDisruptionBudget | object | `{"enabled":true,"minAvailable":"50%","unhealthyPodEvictionPolicy":"AlwaysAllow"}` | Pod Disruption Budget ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/ |
+| podDisruptionBudget.unhealthyPodEvictionPolicy | string | `"AlwaysAllow"` | Controls how Pod Disruption Budgets apply to pods that are unhealthy.    The default is to allow them to be terminated. |
 | podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":1000}` | Pod Security context for the container ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ |
 | port | int | `8000` | Set port to null to skip adding container Ports |
 | postgresql.client.enabled | bool | `true` |  |

--- a/charts/standard-application-stack/templates/pdbs.yaml
+++ b/charts/standard-application-stack/templates/pdbs.yaml
@@ -17,6 +17,9 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{ include "mintel_common.selectorLabels" . | nindent 6 }}
+  {{- if and .Values.podDisruptionBudget.unhealthyPodEvictionPolicy (semverCompare ">=1.31-0" .Capabilities.KubeVersion.GitVersion) }}
+  unhealthyPodEvictionPolicy: {{ .Values.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  {{- end }}
 {{- end }}
 {{- end }}
 
@@ -40,5 +43,8 @@ spec:
   {{- end }}
   selector:
     matchLabels: {{ include "mintel_common.selectorLabels" $data | nindent 6 }}
+  {{- if and .Values.celery.podDisruptionBudget.unhealthyPodEvictionPolicy (semverCompare ">=1.31-0" .Capabilities.KubeVersion.GitVersion) }}
+  unhealthyPodEvictionPolicy: {{ .Values.celery.podDisruptionBudget.unhealthyPodEvictionPolicy }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/standard-application-stack/tests/__snapshot__/pdb_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pdb_test.yaml.snap
@@ -22,6 +22,7 @@ Creates a PDB when autoscaling is disabled and autoscaling.minReplicaCount is se
         matchLabels:
           app.kubernetes.io/component: app
           app.kubernetes.io/name: example-app
+      unhealthyPodEvictionPolicy: AlwaysAllow
 Creates a PDB when replicas > 1:
   1: |
     apiVersion: policy/v1
@@ -46,3 +47,4 @@ Creates a PDB when replicas > 1:
         matchLabels:
           app.kubernetes.io/component: app
           app.kubernetes.io/name: example-app
+      unhealthyPodEvictionPolicy: AlwaysAllow

--- a/charts/standard-application-stack/tests/pdb_test.yaml
+++ b/charts/standard-application-stack/tests/pdb_test.yaml
@@ -1,6 +1,9 @@
 suite: Test Pod Disruption Budgets
 templates:
   - pdbs.yaml
+capabilities:
+  majorVersion: 1
+  minorVersion: 31
 release:
   namespace: test-namespace
 tests:

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -211,7 +211,10 @@ securityContext:
 podDisruptionBudget:
   enabled: true
   minAvailable: 50%
-#  maxUnavailable: 50%
+  #maxUnavailable: 50%
+  # -- Controls how Pod Disruption Budgets apply to pods that are unhealthy.
+  #    The default is to allow them to be terminated.
+  unhealthyPodEvictionPolicy: AlwaysAllow
 
 # -- Kubernetes svc configutarion
 service:
@@ -821,6 +824,9 @@ celery:
   podDisruptionBudget:
     enabled: true
     minAvailable: 50%
+    # -- Controls how Pod Disruption Budgets apply to pods that are unhealthy.
+    #    The default is to allow them to be terminated.
+    unhealthyPodEvictionPolicy: AlwaysAllow
 
 # -- Configure celerybeat deployment
 # Defaults to same image as main deployment but with the "celerybeat" argument

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -211,7 +211,7 @@ securityContext:
 podDisruptionBudget:
   enabled: true
   minAvailable: 50%
-  #maxUnavailable: 50%
+  # maxUnavailable: 50%
   # -- Controls how Pod Disruption Budgets apply to pods that are unhealthy.
   #    The default is to allow them to be terminated.
   unhealthyPodEvictionPolicy: AlwaysAllow


### PR DESCRIPTION
The default value for `unhealthyPodEvictionPolicy` will be "AlwaysAllow", since most of our workloads deployed with this chart are stateless and it will prevent situations where Karpenter can't drain nodes because terminating an unhealthy pod would violate a PDB.

JIRA INFRA-39642