### PR TITLE
Add TerraformCloudWorkspace default AWS tag to all workspaces

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.15.1] - 2025-03-12
+### Added
+- Add environment variable to set AWS default tag `TerraformCloudWorkspace`
+
 ## [v1.15.0] - 2024-09-17
 ### Added
 - INFRA-36982: Support for S3 multi-region access point and replication rules modules.

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.15.0
+version: 1.15.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 1.15.0](https://img.shields.io/badge/Version-1.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.15.1](https://img.shields.io/badge/Version-1.15.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 

--- a/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
@@ -67,6 +67,11 @@ spec:
   runTriggers:
   {{ include "mintel_common.terraform_cloud.irsaRunTriggers_v2" $| indent 4 }}
   {{- end }}
+  environmentVariables:
+    - name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+      value: {{ $instanceCfg.workspaceNameOverride | default (include "mintel_common.terraform_cloud.workspaceName" $workspaceDict) | trim | quote }}
+      hcl: false
+      sensitive: false
   terraformVariables:
   {{- $instanceCfgCopy := omit $instanceCfg "workspaceNameOverride" }}
   {{- $instanceCfgCopy = omit $instanceCfgCopy "workspaceAllowDestroy" }}

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace-v2_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace-v2_test.yaml.snap
@@ -21,6 +21,11 @@ IRSA created explicitly:
         id: ""
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
       executionMode: agent
       name: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
       notifications:
@@ -148,6 +153,11 @@ IRSA created for Dev S3 module workspace:
         id: ""
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
       executionMode: agent
       name: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
       notifications:
@@ -276,6 +286,11 @@ IRSA created with default (0) syncWave:
         id: ""
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
       executionMode: agent
       name: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
       notifications:
@@ -403,6 +418,11 @@ IRSA created with modified syncWave:
         id: ""
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
       executionMode: agent
       name: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
       notifications:

--- a/charts/terraform-cloud/tests/__snapshot__/module-v2_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/module-v2_test.yaml.snap
@@ -21,6 +21,11 @@ Test module defaults:
         id: test-agent-pool
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       executionMode: agent
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       organization: Mintel
@@ -144,6 +149,11 @@ Test module overrides:
         id: test-agent-pool
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       executionMode: agent
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       organization: Mintel
@@ -267,6 +277,11 @@ Test module restartedAt disabled:
         id: test-agent-pool
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       executionMode: agent
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       organization: Mintel

--- a/charts/terraform-cloud/tests/__snapshot__/workspace-v2_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/workspace-v2_test.yaml.snap
@@ -21,6 +21,11 @@ Test tags:
         id: ""
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: prod-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       executionMode: agent
       name: prod-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       organization: Mintel
@@ -139,6 +144,11 @@ Test tags with env/allow-destroy flags changed:
         id: ""
       allowDestroyPlan: false
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: logs-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       executionMode: agent
       name: logs-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       organization: Mintel
@@ -257,6 +267,11 @@ Test teamAccess can be configured:
         id: ""
       allowDestroyPlan: false
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: logs-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       executionMode: agent
       name: logs-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       organization: Mintel
@@ -382,6 +397,11 @@ Test workspace allow destroy env:
         id: ""
       allowDestroyPlan: false
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: prod-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       executionMode: agent
       name: prod-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       organization: Mintel
@@ -500,6 +520,11 @@ Test workspace allow destroy env global-override:
         id: ""
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: prod-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       executionMode: agent
       name: prod-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       organization: Mintel
@@ -618,6 +643,11 @@ Test workspace allow destroy env resource-override:
         id: ""
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: prod-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       executionMode: agent
       name: prod-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
       organization: Mintel
@@ -736,6 +766,11 @@ Test workspace defaults:
         id: test-agent-pool
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       executionMode: agent
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       organization: Mintel
@@ -859,6 +894,11 @@ Test workspace defaults in prod-like environment (logs):
         id: test-agent-pool
       allowDestroyPlan: false
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: logs-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       executionMode: remote
       name: logs-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       organization: Mintel
@@ -977,6 +1017,11 @@ Test workspace defaults in prod-like environment (prod):
         id: test-agent-pool
       allowDestroyPlan: false
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       executionMode: remote
       name: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       organization: Mintel
@@ -1095,6 +1140,11 @@ Test workspace instance overrides:
         id: test-agent-pool
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-s3
       executionMode: remote
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-s3
       organization: Mintel
@@ -1217,6 +1267,11 @@ Test workspace instance overrides:
         id: test-agent-pool
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-another-s3
       executionMode: remote
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-bucket-another-s3
       organization: Mintel
@@ -1340,6 +1395,11 @@ Test workspace overrides:
         id: test-agent-pool
       allowDestroyPlan: true
       applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       executionMode: remote
       name: dev-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       organization: Mintel
@@ -1463,6 +1523,11 @@ Test workspace overrides at global-config level:
         id: test-agent-pool
       allowDestroyPlan: true
       applyMethod: manual
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       executionMode: remote
       name: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       organization: Mintel
@@ -1581,6 +1646,11 @@ Test workspace overrides at resource-config level:
         id: test-agent-pool
       allowDestroyPlan: true
       applyMethod: manual
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       executionMode: remote
       name: prod-eu-west-1-cluster1-test-namespace-mntl-test-workspace-s3
       organization: Mintel


### PR DESCRIPTION
This commit adds an environment variable that will instruct the AWS provider to add a default tag named "TerraformCloudWorkspace" to all AWS resources (only in AWS provider >= v5.62.0). This will help us track down the origin of AWS resources since it can be unclear sometimes.