### PR TITLE
Fix secret reference to Entra `clientID` in deployment

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v10.2.1] - 2025-07-04
+### Fixed
+- Fix secret reference to Entra `clientID` in deployment
+
 ## [v10.2.0] - 2025-07-04
 ### Added
 - Add `entra.createIngressRBAC` option to enable/disable Ingress RBAC to read Entra client-secrets (default true)

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 10.2.0
+version: 10.2.1
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 10.2.0](https://img.shields.io/badge/Version-10.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 10.2.1](https://img.shields.io/badge/Version-10.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -571,7 +571,7 @@ topologySpreadConstraints:
   valueFrom:
     secretKeyRef:
       name: {{ include "mintel_common.fullname" .}}-ingress-oidc-credentials
-      key: clientId
+      key: clientID
 - name: AZURE_CLIENT_SECRET
   valueFrom:
     secretKeyRef:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_entra_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_entra_test.yaml.snap
@@ -56,7 +56,7 @@ Check entra client-secrets are added:
                 - name: AZURE_CLIENT_ID
                   valueFrom:
                     secretKeyRef:
-                      key: clientId
+                      key: clientID
                       name: test-app-ingress-oidc-credentials
                 - name: AZURE_CLIENT_SECRET
                   valueFrom:

--- a/charts/standard-application-stack/tests/deployment_entra_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_entra_test.yaml
@@ -33,7 +33,7 @@ tests:
             - name: AZURE_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  key: clientId
+                  key: clientID
                   name: test-app-ingress-oidc-credentials
             - name: AZURE_CLIENT_SECRET
               valueFrom:


### PR DESCRIPTION
This is a typo which meant the container was throwing a configuration-error and could not start.