### PR TITLE
INFRA-42142: Avoid rendering ingresses with empty host values

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v10.4.1] - 2025-08-19
+### Fixed
+- Do not allow the rendering of ingresses with empty hosts
+
 ## [v10.4.0] - 2025-08-19
 ### Added
 - Added `Values.entra.developmentMode` boolean to aid new application development against Entra auth

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 10.4.0
+version: 10.4.1
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 10.4.0](https://img.shields.io/badge/Version-10.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 10.4.1](https://img.shields.io/badge/Version-10.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 

--- a/charts/standard-application-stack/templates/ingress.yaml
+++ b/charts/standard-application-stack/templates/ingress.yaml
@@ -66,7 +66,7 @@ spec:
             {{- include "mintel_common.ingress.ingressPath" $ingressData | nindent 10 }}
           {{- end }}
     {{- range .extraHosts }}
-    {{- if (or (not $.Values.oauthProxy.enabled) (ne $.Values.oauthProxy.ingressHost .name)) }}
+    {{- if ( and .name (or (not $.Values.oauthProxy.enabled) (ne $.Values.oauthProxy.ingressHost .name))) }}
     - host: {{ .name }}
       http:
         paths:
@@ -91,7 +91,6 @@ spec:
                 port:
                   number: 4180
     {{- end }}
-
     {{- with .specificRulesHostsYaml }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -556,6 +556,53 @@ Check extraHosts:
                       number: 8000
                 path: /
                 pathType: Prefix
+Check extraHosts cannot render empty host rule:
+  1: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        alb.ingress.kubernetes.io/backend-protocol: HTTP
+        alb.ingress.kubernetes.io/backend-protocol-version: HTTP1
+        alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
+        alb.ingress.kubernetes.io/healthcheck-path: /readiness
+        alb.ingress.kubernetes.io/healthcheck-port: "8000"
+        alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
+        alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+        alb.ingress.kubernetes.io/healthy-threshold-count: "2"
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
+        alb.ingress.kubernetes.io/ssl-redirect: "443"
+        alb.ingress.kubernetes.io/success-codes: "200"
+        alb.ingress.kubernetes.io/target-group-attributes: deregistration_delay.timeout_seconds=5,load_balancing.algorithm.type=least_outstanding_requests
+        alb.ingress.kubernetes.io/target-type: ip
+        alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
+        app.mintel.com/placeholder: placeholder
+        external-dns.alpha.kubernetes.io/hostname: test.default.com
+        external-dns.alpha.kubernetes.io/ttl: "60"
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: AppyMcAppface
+        app.mintel.com/application: AppyMcAppface
+        app.mintel.com/component: AppyMcAppface
+        app.mintel.com/env: qa
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: AppyMcAppface
+      name: AppyMcAppface
+      namespace: test-namespace
+    spec:
+      ingressClassName: alb-public-apps-default
+      rules:
+        - host: test.default.com
+          http:
+            paths:
+              - backend:
+                  service:
+                    name: AppyMcAppface
+                    port:
+                      number: 8000
+                path: /
+                pathType: Prefix
 Check extraHosts with TLS:
   1: |
     apiVersion: networking.k8s.io/v1

--- a/charts/standard-application-stack/tests/ingress_test.yaml
+++ b/charts/standard-application-stack/tests/ingress_test.yaml
@@ -329,6 +329,25 @@ tests:
           count: 1
         template: deployment.yaml
 
+
+  - it: Check extraHosts do not render hosts with an empty value
+    template: ingress.yaml
+    set:
+      global.name: AppyMcAppface
+      global.clusterEnv: qa
+      ingress.enabled: true
+      ingress.defaultHost: test.default.com
+      ingress.extraHosts:
+        - name:
+    asserts:
+      - matchSnapshot: {} # Check for regressions and unexpected changes.
+      - equal:
+          path: spec.rules[0].host
+          value: test.default.com
+      - lengthEqual:
+          path: spec.rules
+          count: 1
+
   - it: Check ingress name override
     template: ingress.yaml
     set:


### PR DESCRIPTION
Previously an input like 
```
extraHosts: 
- ""
```

could render ingresses that match all hosts - this is dangerous, so restrict that.