### PR TITLE
INFRA-41920: Adding new backstage.io/component label

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v10.5.0] - 2025-08-29
+### Added
+- Added support for new Backstage labels
+
 ## [v10.4.1] - 2025-08-19
 ### Fixed
 - Do not allow the rendering of ingresses with empty hosts

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 10.4.1
+version: 10.5.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 10.4.1](https://img.shields.io/badge/Version-10.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 10.5.0](https://img.shields.io/badge/Version-10.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -113,16 +113,17 @@ A generic chart to support most common application requirements
 | filebeatSidecar.resources.requests.memory | string | `"100Mi"` |  |
 | gitSyncSidecar | object | `{"branch":"main","enabled":false,"resources":{"limits":{"memory":"200Mi"},"requests":{"cpu":"50m","memory":"50Mi"}},"root":"/data/git-sync"}` | Helper to sync a local directory with Git ref: https://github.com/kubernetes/git-sync |
 | gitSyncSidecar.branch | string | `"main"` | The git branch to check out |
-| global | object | `{"additionalLabels":{},"application":"","cloudProvider":{"accountId":"","region":""},"clusterDomain":"127.0.0.1.nip.io","clusterEnv":"local","clusterName":"","component":"","ingressTLSSecrets":{},"name":"example-app","owner":"","partOf":"","runtimeEnvironment":"kubernetes","terraform":{"externalSecrets":false,"irsa":false}}` | Global variables for us in all charts and sub charts |
+| global | object | `{"additionalLabels":{},"application":"","backstage":{"component":""},"cloudProvider":{"accountId":"","region":""},"clusterDomain":"127.0.0.1.nip.io","clusterEnv":"local","clusterName":"","component":"","ingressTLSSecrets":{},"name":"example-app","owner":"","partOf":"","runtimeEnvironment":"kubernetes","terraform":{"externalSecrets":false,"irsa":false}}` | Global variables for us in all charts and sub charts |
 | global.additionalLabels | object | `{}` | Additional labels to apply to all resources |
-| global.application | string | `""` | Name of the application (defaults to global.name) |
+| global.application | string | `""` | Deprecated: Name of the application (defaults to global.name) |
+| global.backstage.component | string | `""` | Backstage component (defaults to global.name) |
 | global.cloudProvider | object | `{"accountId":"","region":""}` | Global variables relating to cloud provider |
 | global.cloudProvider.accountId | string | `""` | AWS Account Id |
 | global.cloudProvider.region | string | `""` | AWS region name |
 | global.clusterDomain | string | `"127.0.0.1.nip.io"` | Kubernetes cluster domain |
 | global.clusterEnv | string | `"local"` | Environment (local, dev, qa, prod) |
 | global.clusterName | string | `""` | Kubernetes cluster name |
-| global.component | string | `""` | Component of the application (defaults to global.name) |
+| global.component | string | `""` | Deprecated: Component of the application (defaults to global.name) |
 | global.ingressTLSSecrets | object | `{}` | Global dictionary of TLS secrets |
 | global.name | string | `"example-app"` | Name of the application |
 | global.owner | string | `""` | Team which "owns" the application |

--- a/charts/standard-application-stack/templates/_helpers.tpl
+++ b/charts/standard-application-stack/templates/_helpers.tpl
@@ -65,6 +65,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Values.global.owner }}
 app.mintel.com/owner: {{ .Values.global.owner }}
 {{- end }}
+backstage.io/component: {{ .Values.global.backstage.component | default .Values.global.name }}
 app.mintel.com/application: {{ .Values.global.application | default .Values.global.name }}
 app.mintel.com/component: {{ .Values.global.component | default .Values.global.name }}
 app.mintel.com/env: {{ .Values.global.clusterEnv }}
@@ -116,6 +117,7 @@ app.kubernetes.io/component: app
 - app.kubernetes.io/instance
 - app.mintel.com/application
 - app.mintel.com/owner
+- backstage.io/component
 {{- end -}}
 
 {{/* Target Labels */}}
@@ -124,6 +126,7 @@ app.kubernetes.io/component: app
 - app.mintel.com/component
 - app.mintel.com/owner
 - app.mintel.com/ignore_alerts
+- backstage.io/component
 {{- end -}}
 
 {{/*

--- a/charts/standard-application-stack/tests/__snapshot__/configmaps_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/configmaps_test.yaml.snap
@@ -14,6 +14,7 @@ Empty configmap:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app-config
       name: test-app-config
       namespace: test-namespace
@@ -38,6 +39,7 @@ Mixed singleline and  multiline data entries:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app-config
       name: test-app-config
       namespace: test-namespace
@@ -61,6 +63,7 @@ Single multiline data entry:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app-config
       name: test-app-config
       namespace: test-namespace
@@ -81,6 +84,7 @@ Single singleline data entry:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app-config
       name: test-app-config
       namespace: test-namespace
@@ -103,6 +107,7 @@ ensures ArgoCD annotations are populated:
         app.mintel.com/component: example-app
         app.mintel.com/env: test
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-config
       name: example-app-config
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/cronjob_test.yaml.snap
@@ -13,6 +13,7 @@ Check CronJob Default Overrides:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-daily
       name: example-app-daily
       namespace: test-namespace
@@ -30,6 +31,7 @@ Check CronJob Default Overrides:
                 app.mintel.com/component: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
+                backstage.io/component: example-app
                 name: example-app-daily
             spec:
               containers:
@@ -81,6 +83,7 @@ Check CronJob Defaults:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-daily
       name: example-app-daily
       namespace: test-namespace
@@ -100,6 +103,7 @@ Check CronJob Defaults:
                 app.mintel.com/component: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
+                backstage.io/component: example-app
                 name: example-app-daily
             spec:
               containers:
@@ -151,6 +155,7 @@ Check CronJob Job Overrides:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-daily
       name: example-app-daily
       namespace: test-namespace
@@ -170,6 +175,7 @@ Check CronJob Job Overrides:
                 app.mintel.com/component: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
+                backstage.io/component: example-app
                 name: example-app-daily
             spec:
               containers:
@@ -221,6 +227,7 @@ Check CronJob ttlSecondsAfterFinished zero value:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-daily
       name: example-app-daily
       namespace: test-namespace
@@ -240,6 +247,7 @@ Check CronJob ttlSecondsAfterFinished zero value:
                 app.mintel.com/component: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
+                backstage.io/component: example-app
                 name: example-app-daily
             spec:
               containers:
@@ -290,6 +298,7 @@ CronJob can have a timezone:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-daily
       name: example-app-daily
       namespace: test-namespace
@@ -309,6 +318,7 @@ CronJob can have a timezone:
                 app.mintel.com/component: example-app
                 app.mintel.com/env: qa
                 app.mintel.com/region: ${CLUSTER_REGION}
+                backstage.io/component: example-app
                 name: example-app-daily
             spec:
               containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_dynamodb_enabled_test.yaml.snap
@@ -14,6 +14,7 @@ Check DynamoDB envfrom secretRef is present:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -39,6 +40,7 @@ Check DynamoDB envfrom secretRef is present:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -122,6 +124,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -147,6 +150,7 @@ Check DynamoDB envfrom secretRef is present for local environment:
             app.mintel.com/component: test-app
             app.mintel.com/env: local
             app.mintel.com/region: local
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -228,6 +232,7 @@ Check DynamoDB secretName Override:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -253,6 +258,7 @@ Check DynamoDB secretName Override:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_entra_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_entra_test.yaml.snap
@@ -14,6 +14,7 @@ Check entra client-secrets are added:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -39,6 +40,7 @@ Check entra client-secrets are added:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -132,6 +134,7 @@ Check entra client-secrets are excluded when not enabled:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -157,6 +160,7 @@ Check entra client-secrets are excluded when not enabled:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_env_test.yaml.snap
@@ -16,6 +16,7 @@ Check celery does not pull in `main.env` values:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-celery
       name: example-app-celery
       namespace: test-namespace
@@ -41,6 +42,7 @@ Check celery does not pull in `main.env` values:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app-celery
         spec:
           containers:
@@ -106,6 +108,7 @@ Check default env behavior:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -131,6 +134,7 @@ Check default env behavior:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
         spec:
           containers:
@@ -216,6 +220,7 @@ Check main container combines default env and `main.env` values:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -241,6 +246,7 @@ Check main container combines default env and `main.env` values:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_host_network_test.yaml.snap
@@ -14,6 +14,7 @@ Has a pod template that uses the host network:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -39,6 +40,7 @@ Has a pod template that uses the host network:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_image_pull_secrets_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_image_pull_secrets_test.yaml.snap
@@ -14,6 +14,7 @@ sets imagePullSecrets:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -39,6 +40,7 @@ sets imagePullSecrets:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_instrumentation_test.yaml.snap
@@ -14,6 +14,7 @@ Check custom python otel extraEnv vars are added:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -39,6 +40,7 @@ Check custom python otel extraEnv vars are added:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -142,6 +144,7 @@ Check custom sampler settings:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -167,6 +170,7 @@ Check custom sampler settings:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -270,6 +274,7 @@ Check default python otel envars are added:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -295,6 +300,7 @@ Check default python otel envars are added:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -396,6 +402,7 @@ Check global otel extraEnv vars are added:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -421,6 +428,7 @@ Check global otel extraEnv vars are added:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_labels_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_labels_test.yaml.snap
@@ -15,6 +15,7 @@ Check default label behavior:
         app.mintel.com/env: qa
         app.mintel.com/owner: sre
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: component-name
         name: app
       name: app
       namespace: test-namespace
@@ -41,6 +42,7 @@ Check default label behavior:
             app.mintel.com/env: qa
             app.mintel.com/owner: sre
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: component-name
             name: app
         spec:
           containers:
@@ -125,6 +127,7 @@ Check empty application and component labels both default to name:
         app.mintel.com/env: qa
         app.mintel.com/owner: sre
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: app
         name: app
       name: app
       namespace: test-namespace
@@ -151,6 +154,7 @@ Check empty application and component labels both default to name:
             app.mintel.com/env: qa
             app.mintel.com/owner: sre
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: app
             name: app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_lifecycle_test.yaml.snap
@@ -14,6 +14,7 @@ Check AWS ALB lifecycle rule applied:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
         tier: frontend
       name: example-app
@@ -40,6 +41,7 @@ Check AWS ALB lifecycle rule applied:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
             tier: frontend
         spec:
@@ -135,6 +137,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
         tier: frontend
       name: example-app
@@ -161,6 +164,7 @@ Check AWS ALB lifecycle rules applied with custom delay:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
             tier: frontend
         spec:
@@ -256,6 +260,7 @@ Check lifecycle rules:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -281,6 +286,7 @@ Check lifecycle rules:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_mariadb_enabled_test.yaml.snap
@@ -14,6 +14,7 @@ Check MariaDB envfrom secretRef is present:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -39,6 +40,7 @@ Check MariaDB envfrom secretRef is present:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -122,6 +124,7 @@ Check MariaDB envfrom secretRef is present for local environment:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -147,6 +150,7 @@ Check MariaDB envfrom secretRef is present for local environment:
             app.mintel.com/component: test-app
             app.mintel.com/env: local
             app.mintel.com/region: local
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -228,6 +232,7 @@ Check MariaDB secretName Override:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -253,6 +258,7 @@ Check MariaDB secretName Override:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_memcached_enabled_test.yaml.snap
@@ -14,6 +14,7 @@ Check Memcached envfrom secretRef is present:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -39,6 +40,7 @@ Check Memcached envfrom secretRef is present:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -122,6 +124,7 @@ Check Memcached envfrom secretRef is present for local environment:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -147,6 +150,7 @@ Check Memcached envfrom secretRef is present for local environment:
             app.mintel.com/component: test-app
             app.mintel.com/env: local
             app.mintel.com/region: local
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -228,6 +232,7 @@ Check Memcached secretName Override:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -253,6 +258,7 @@ Check Memcached secretName Override:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_ports_test.yaml.snap
@@ -14,6 +14,7 @@ Check container extraPorts:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -39,6 +40,7 @@ Check container extraPorts:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
         spec:
           containers:
@@ -126,6 +128,7 @@ Check container extraPorts are validated:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -151,6 +154,7 @@ Check container extraPorts are validated:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
         spec:
           containers:
@@ -240,6 +244,7 @@ Check container extraPorts protocol:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -265,6 +270,7 @@ Check container extraPorts protocol:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
         spec:
           containers:
@@ -353,6 +359,7 @@ Check default container main port:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -378,6 +385,7 @@ Check default container main port:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
         spec:
           containers:
@@ -461,6 +469,7 @@ Check overridden container main port:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -486,6 +495,7 @@ Check overridden container main port:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_replicas_test.yaml.snap
@@ -15,6 +15,7 @@ Check allowSingleReplica doesn't alter strategy:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -40,6 +41,7 @@ Check allowSingleReplica doesn't alter strategy:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
         spec:
           containers:
@@ -124,6 +126,7 @@ Check allowSingleReplica set annotations:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -149,6 +152,7 @@ Check allowSingleReplica set annotations:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
         spec:
           containers:
@@ -232,6 +236,7 @@ Check replicas unset when autoscaling is enabled:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -256,6 +261,7 @@ Check replicas unset when autoscaling is enabled:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
         spec:
           containers:
@@ -340,6 +346,7 @@ Check singleReplicaOnly applied:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -362,6 +369,7 @@ Check singleReplicaOnly applied:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
         spec:
           containers:
@@ -446,6 +454,7 @@ Check singleReplicaOnly ignore replicas value:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -468,6 +477,7 @@ Check singleReplicaOnly ignore replicas value:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_s3_enabled_test.yaml.snap
@@ -14,6 +14,7 @@ Check S3 envfrom secretRef is present:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -39,6 +40,7 @@ Check S3 envfrom secretRef is present:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -122,6 +124,7 @@ Check S3 envfrom secretRef is present for local environment:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -147,6 +150,7 @@ Check S3 envfrom secretRef is present for local environment:
             app.mintel.com/component: test-app
             app.mintel.com/env: local
             app.mintel.com/region: local
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -230,6 +234,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
         app.mintel.com/env: qa
         app.mintel.com/owner: sre
         app.mintel.com/region: eu-west-1
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -258,6 +263,7 @@ Check S3 envfrom secretRef is present for multiple instances of TF Cloud helm ch
             app.mintel.com/env: qa
             app.mintel.com/owner: sre
             app.mintel.com/region: eu-west-1
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -344,6 +350,7 @@ Check S3 secretName Override:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -369,6 +376,7 @@ Check S3 secretName Override:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -454,6 +462,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
         app.mintel.com/env: qa
         app.mintel.com/owner: sre
         app.mintel.com/region: eu-west-1
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -482,6 +491,7 @@ Check S3 stakater secret reloader annotation contains correct secrets for multip
             app.mintel.com/env: qa
             app.mintel.com/owner: sre
             app.mintel.com/region: eu-west-1
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/deployment_stateful_set_test.yaml.snap
@@ -14,6 +14,7 @@ Check stateful set is rendered with volumeClaimTemplates:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -34,6 +35,7 @@ Check stateful set is rendered with volumeClaimTemplates:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/entra_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/entra_test.yaml.snap
@@ -13,6 +13,7 @@ Renders with optional fields (owners, groupMembershipClaims, redirectURIs, extra
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/ingress_test.yaml.snap
@@ -29,6 +29,7 @@ Check ALB HTTP2 default settings:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -76,6 +77,7 @@ Check ALB className set by default:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -123,6 +125,7 @@ Check ALB custom health-check port:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -170,6 +173,7 @@ Check ALB default health-check port:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -217,6 +221,7 @@ Check ALB gRPC custom settings:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -264,6 +269,7 @@ Check ALB gRPC default settings:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -311,6 +317,7 @@ Check ALB health-check port with oauthProxy enabled:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -343,6 +350,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
         tier: frontend
       name: example-app
@@ -369,6 +377,7 @@ Check EXTRA_ALLOWED_HOSTS env var extraHosts with extraIngresses:
             app.mintel.com/component: example-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: example-app
             name: example-app
             tier: frontend
         spec:
@@ -479,6 +488,7 @@ Check TLS set if ingressTLSSecrets is not empty:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -530,6 +540,7 @@ Check extraHosts:
         app.mintel.com/component: AppyMcAppface
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: AppyMcAppface
         name: AppyMcAppface
       name: AppyMcAppface
       namespace: test-namespace
@@ -587,6 +598,7 @@ Check extraHosts do not render hosts with an empty value:
         app.mintel.com/component: AppyMcAppface
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: AppyMcAppface
         name: AppyMcAppface
       name: AppyMcAppface
       namespace: test-namespace
@@ -634,6 +646,7 @@ Check extraHosts with TLS:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -696,6 +709,7 @@ Check extraHosts with TLS and oauthProxy.ingressHost (different):
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -769,6 +783,7 @@ Check extraHosts with TLS and oauthProxy.ingressHost (same as extra host):
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -832,6 +847,7 @@ Check extraHosts with oauthProxy.ingressHost (different):
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -899,6 +915,7 @@ Check extraHosts with oauthProxy.ingressHost (same as extra host):
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -956,6 +973,7 @@ Check ingress name override:
         app.mintel.com/component: ingress-override
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: ingress-override
         name: ingress-override
       name: ingress-override
       namespace: test-namespace
@@ -1003,6 +1021,7 @@ Check ingress name suffix setting:
         app.mintel.com/component: example-app-suffix
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app-suffix
         name: example-app-suffix
       name: example-app-suffix
       namespace: test-namespace
@@ -1050,6 +1069,7 @@ Check no TLS set if ingressTLSSecrets and specificTlsHostsYaml is empty:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -1097,6 +1117,7 @@ Default ingress with path based routing:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -1153,6 +1174,7 @@ adds default qa api-gateway ingress:
         app.mintel.com/component: example-app-api-gw
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app-api-gw
         name: example-app-api-gw
       name: example-app-api-gw
       namespace: test-namespace
@@ -1200,6 +1222,7 @@ adds prod api-gateway ingress as an extraIngress with custom fields:
         app.mintel.com/component: example-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -1248,6 +1271,7 @@ adds prod api-gateway ingress as an extraIngress with custom fields:
         app.mintel.com/component: example-app-api-gw
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app-api-gw
         name: example-app-api-gw
       name: example-app-api-gw
       namespace: test-namespace
@@ -1295,6 +1319,7 @@ allows extraIngresses to override default values:
         app.mintel.com/component: image-service-media
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: image-service-media
         name: image-service-media
       name: image-service-media
       namespace: test-namespace
@@ -1341,6 +1366,7 @@ allows extraIngresses to override default values:
         app.mintel.com/component: image-service-ops-media
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: image-service-ops-media
         name: image-service-ops-media
       name: image-service-ops-media
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -16,6 +16,7 @@ Check all .job.* values can be set correctly, without overriding from main deplo
         app.mintel.com/component: testGlobalName
         app.mintel.com/env: testClusterEnv
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: testGlobalName
         name: testGlobalName-testJobName
       name: testGlobalName-testJobName
       namespace: testNamespace
@@ -80,6 +81,7 @@ Check all overrides/additions from main deployment work if enabled:
         app.mintel.com/component: testGlobalName
         app.mintel.com/env: testClusterEnv
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: testGlobalName
         name: testGlobalName-testJobName
       name: testGlobalName-testJobName
       namespace: testNamespace
@@ -155,6 +157,7 @@ Check all overrides/additions from main deployment work if enabled:
         app.mintel.com/component: testGlobalName
         app.mintel.com/env: testClusterEnv
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: testGlobalName
         name: testGlobalName
       name: testGlobalName-testJobName-app
       namespace: testNamespace
@@ -183,6 +186,7 @@ Check default values are correct with minimal configuration:
         app.mintel.com/component: testGlobalName
         app.mintel.com/env: testClusterEnv
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: testGlobalName
         name: testGlobalName-testJobName
       name: testGlobalName-testJobName
       namespace: testNamespace
@@ -237,6 +241,7 @@ Checks that RBAC is set up correctly for kubelock:
         app.mintel.com/component: testGlobalName
         app.mintel.com/env: testClusterEnv
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: testGlobalName
         name: testGlobalName-testJobName
       name: testGlobalName-testJobName
       namespace: testNamespace
@@ -278,6 +283,7 @@ Checks that RBAC is set up correctly for kubelock:
         app.mintel.com/component: testGlobalName
         app.mintel.com/env: testClusterEnv
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: testGlobalName
         name: testGlobalName
       name: testGlobalName-testJobName
       namespace: testNamespace
@@ -295,6 +301,7 @@ Checks that RBAC is set up correctly for kubelock:
         app.mintel.com/component: testGlobalName
         app.mintel.com/env: testClusterEnv
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: testGlobalName
         name: testGlobalName
       name: testGlobalName-testJobName
       namespace: testNamespace
@@ -331,6 +338,7 @@ Checks that RBAC is set up correctly for kubelock:
         app.mintel.com/component: testGlobalName
         app.mintel.com/env: testClusterEnv
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: testGlobalName
         name: testGlobalName
       name: testGlobalName-testJobName
       namespace: testNamespace

--- a/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_constraints_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_constraints_test.yaml.snap
@@ -13,6 +13,7 @@ Check idleReplicaCount is equal to 0 when enableZeroReplicas is set:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -45,6 +46,7 @@ Check trigger vars automatically populated:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: eu-west-2
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -94,6 +96,7 @@ Check trigger vars can be overriden:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: eu-west-2
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -143,6 +146,7 @@ Creates a ScaledObject with constrained settings:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -174,6 +178,7 @@ Creates a ScaledObject with non-constrained settings:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -205,6 +210,7 @@ Ensure minReplicaCount cannot be greater than 10:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/keda_scaled_object_test.yaml.snap
@@ -13,6 +13,7 @@ Check utilization takes precedence over average value when both specified:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -53,6 +54,7 @@ Creates a ScaledObject for a Deployment:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -84,6 +86,7 @@ Creates a ScaledObject for a StatefulSet:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -115,6 +118,7 @@ Creates a ScaledObject for a custom scaleTargetRef:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -146,6 +150,7 @@ Creates a ScaledObject with advanced settings:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -187,6 +192,7 @@ Creates a ScaledObject with both targetCPUAverageValue and targetMemoryAverageVa
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -227,6 +233,7 @@ Creates a ScaledObject with both targetCPUAverageValue trigger:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -263,6 +270,7 @@ Creates a ScaledObject with both targetCPUUtilizationPercentage and targetMemory
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -303,6 +311,7 @@ Creates a ScaledObject with custom triggers:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -345,6 +354,7 @@ Creates a ScaledObject with default fallback based on minReplicaCount:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -376,6 +386,7 @@ Creates a ScaledObject with explicit fallback settings:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -407,6 +418,7 @@ Creates a ScaledObject with targetCPUUtilizationPercentage trigger:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -443,6 +455,7 @@ Creates a ScaledObject with targetMemoryAverageValue trigger:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -479,6 +492,7 @@ Creates a ScaledObject with targetMemoryUtilizationPercentage trigger:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/mariadb_py_dba_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/mariadb_py_dba_test.yaml.snap
@@ -14,6 +14,7 @@ adds correct config to configmap:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: py-dba-test-app-mariadb
       namespace: test-namespace
@@ -85,6 +86,7 @@ adds correct config to configmap:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app-py-dba-config
       namespace: test-namespace
@@ -104,6 +106,7 @@ extraUsers adds job and configmap:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: py-dba-test-app-mariadb
       namespace: test-namespace
@@ -175,6 +178,7 @@ extraUsers adds job and configmap:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app-py-dba-config
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/networkpolicy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/networkpolicy_test.yaml.snap
@@ -13,6 +13,7 @@ Check ALB NetworkPolicy created if enabled:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: allow-aws-alb-internal-to-example-app
       namespace: test-namespace
@@ -46,6 +47,7 @@ Check ALB NetworkPolicy created if internal alb enabled in extraIngresses:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: allow-aws-alb-internal-to-example-app
       namespace: test-namespace
@@ -79,6 +81,7 @@ Check ALB NetworkPolicy ports are unique:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: allow-aws-alb-to-example-app
       namespace: test-namespace
@@ -112,6 +115,7 @@ Check ALB NetworkPolicy ports set for default conatiner:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: allow-aws-alb-to-example-app
       namespace: test-namespace
@@ -145,6 +149,7 @@ Check ALB NetworkPolicy ports set with oauth2proxy:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: allow-aws-alb-to-example-app
       namespace: test-namespace
@@ -178,6 +183,7 @@ Check ALB NetworkPolicy ports set with oauth2proxy and healthcheck:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: allow-aws-alb-to-example-app
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/oauth2proxy_test.yaml.snap
@@ -14,6 +14,7 @@ Check default container args:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -39,6 +40,7 @@ Check default container args:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -178,6 +180,7 @@ Check setting skip-auth-regex from extra passed in values:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -203,6 +206,7 @@ Check setting skip-auth-regex from extra passed in values:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -343,6 +347,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -368,6 +373,7 @@ Check setting skip-auth-regex from extra passed in values when they already cont
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -508,6 +514,7 @@ Check setting skip-auth-regex from overridden health-check values:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -533,6 +540,7 @@ Check setting skip-auth-regex from overridden health-check values:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -672,6 +680,7 @@ Check sidecar present if enabled:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -697,6 +706,7 @@ Check sidecar present if enabled:
             app.mintel.com/component: test-app
             app.mintel.com/env: qa
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:

--- a/charts/standard-application-stack/tests/__snapshot__/opensearch_aws_es_proxy_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/opensearch_aws_es_proxy_test.yaml.snap
@@ -29,6 +29,7 @@ Check awsEsProxy Ingress is created if enabled:
         app.mintel.com/component: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: example-app
         name: example-app-aws-es-proxy
       name: example-app-aws-es-proxy
       namespace: test-namespace
@@ -60,6 +61,7 @@ Check awsEsProxy NetworkPolicy is created if enabled:
         app.mintel.com/component: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: example-app
         name: example-app
       name: allow-aws-alb-to-example-app-opensearch
       namespace: test-namespace
@@ -97,6 +99,7 @@ Check awsEsProxy deployment is created if enabled:
         app.mintel.com/component: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: example-app
         name: example-app-aws-es-proxy
       name: example-app-aws-es-proxy
       namespace: test-namespace
@@ -118,6 +121,7 @@ Check awsEsProxy deployment is created if enabled:
             app.mintel.com/component: example-app
             app.mintel.com/env: local
             app.mintel.com/region: local
+            backstage.io/component: example-app
             name: example-app-aws-es-proxy
         spec:
           containers:
@@ -191,6 +195,7 @@ Check awsEsProxy service is created if enabled:
         app.mintel.com/component: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: example-app
         name: example-app-aws-es-proxy
       name: example-app-aws-es-proxy
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/pdb_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pdb_test.yaml.snap
@@ -13,6 +13,7 @@ Creates a PDB when autoscaling is disabled and autoscaling.minReplicaCount is se
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace
@@ -38,6 +39,7 @@ Creates a PDB when replicas > 1:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/pod_monitor_test.yaml.snap
@@ -14,6 +14,7 @@ Check additional PodMonitor resources:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -39,6 +40,7 @@ Check additional PodMonitor resources:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -58,6 +60,7 @@ Check additional PodMonitor resources:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app-metrics-2
       name: test-app-metrics-2
       namespace: test-namespace
@@ -83,6 +86,7 @@ Check additional PodMonitor resources:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: metrics-2
@@ -102,6 +106,7 @@ Check additional PodMonitor resources:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app-metrics-3
       name: test-app-metrics-3
       namespace: test-namespace
@@ -127,6 +132,7 @@ Check additional PodMonitor resources:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: metrics-3
@@ -147,6 +153,7 @@ Check basic-auth:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -179,6 +186,7 @@ Check basic-auth:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -199,6 +207,7 @@ Check combined template defaults:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -224,6 +233,7 @@ Check combined template defaults:
             app.mintel.com/component: test-app
             app.mintel.com/env: prod
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -313,6 +323,7 @@ Check combined template defaults:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -338,6 +349,7 @@ Check combined template defaults:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -358,6 +370,7 @@ Check combined template with extra ports and monitors:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -383,6 +396,7 @@ Check combined template with extra ports and monitors:
             app.mintel.com/component: test-app
             app.mintel.com/env: prod
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -476,6 +490,7 @@ Check combined template with extra ports and monitors:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -501,6 +516,7 @@ Check combined template with extra ports and monitors:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -520,6 +536,7 @@ Check combined template with extra ports and monitors:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app-metrics-2
       name: test-app-metrics-2
       namespace: test-namespace
@@ -545,6 +562,7 @@ Check combined template with extra ports and monitors:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: metrics-2
@@ -564,6 +582,7 @@ Check combined template with extra ports and monitors:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app-metrics-3
       name: test-app-metrics-3
       namespace: test-namespace
@@ -589,6 +608,7 @@ Check combined template with extra ports and monitors:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: metrics-3
@@ -609,6 +629,7 @@ Check default endpoints:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -634,6 +655,7 @@ Check default endpoints:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -654,6 +676,7 @@ Check default targetLabels:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -679,6 +702,7 @@ Check default targetLabels:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -699,6 +723,7 @@ Check metric overrides:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -724,6 +749,7 @@ Check metric overrides:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -744,6 +770,7 @@ Check name, namespace and labels:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -769,6 +796,7 @@ Check name, namespace and labels:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app

--- a/charts/standard-application-stack/tests/__snapshot__/postgresql_py_dba_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/postgresql_py_dba_test.yaml.snap
@@ -14,6 +14,7 @@ adds correct config to configmap:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: py-dba-test-app-postgresql
       namespace: test-namespace
@@ -85,6 +86,7 @@ adds correct config to configmap:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app-py-dba-config
       namespace: test-namespace
@@ -104,6 +106,7 @@ extraUsers adds job and configmap:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: py-dba-test-app-postgresql
       namespace: test-namespace
@@ -175,6 +178,7 @@ extraUsers adds job and configmap:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app-py-dba-config
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/secret_dynamodb_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_dynamodb_enabled_test.yaml.snap
@@ -14,6 +14,7 @@ Check DynamoDB Secret Store Override:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app-dynamodb
       namespace: test-namespace
@@ -46,6 +47,7 @@ Check DynamoDB Secret is present for local environment:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app-dynamodb
       namespace: test-namespace
@@ -66,6 +68,7 @@ Check DynamoDB refresh interval override:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app-dynamodb
       namespace: test-namespace
@@ -97,6 +100,7 @@ Check DynamoDB remoteRef key is present:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app-dynamodb
       namespace: test-namespace
@@ -128,6 +132,7 @@ Check DynamoDB secretPath override:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app-dynamodb
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/secret_s3_enabled_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_s3_enabled_test.yaml.snap
@@ -14,6 +14,7 @@ Check S3 Secret Store Override:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app-s3
       namespace: test-namespace
@@ -46,6 +47,7 @@ Check S3 Secret is present for local environment:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app-s3
       namespace: test-namespace
@@ -66,6 +68,7 @@ Check S3 refresh interval override:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app-s3
       namespace: test-namespace
@@ -97,6 +100,7 @@ Check S3 remoteRef key is present:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app-s3
       namespace: test-namespace
@@ -128,6 +132,7 @@ Check S3 secretPath override:
         app.mintel.com/component: test-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app-s3
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/secret_test.yaml.snap
@@ -14,6 +14,7 @@ Extra secrets with output secret map:
         app.mintel.com/component: example-app
         app.mintel.com/env: test
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-extra-secret
       name: example-app-extra-secret
       namespace: test-namespace
@@ -48,6 +49,7 @@ ensures ArgoCD annotations are populated:
         app.mintel.com/component: example-app
         app.mintel.com/env: test
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: example-app-app
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/service_account_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_account_test.yaml.snap
@@ -18,6 +18,7 @@ ensures annotations are populated:
         app.mintel.com/component: example-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: example-app
         name: example-app
       name: example-app
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_monitor_test.yaml.snap
@@ -13,6 +13,7 @@ Check Service defaults:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -41,6 +42,7 @@ Check additional ServiceMonitor resources:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         k8s-app: test-app
         name: test-app
       name: test-app
@@ -67,6 +69,7 @@ Check additional ServiceMonitor resources:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -76,6 +79,7 @@ Check additional ServiceMonitor resources:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+        - backstage.io/component
   2: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
@@ -91,6 +95,7 @@ Check additional ServiceMonitor resources:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         k8s-app: test-app-metrics-2
         name: test-app-metrics-2
       name: test-app-metrics-2
@@ -117,6 +122,7 @@ Check additional ServiceMonitor resources:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: metrics-2
@@ -126,6 +132,7 @@ Check additional ServiceMonitor resources:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+        - backstage.io/component
   3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
@@ -141,6 +148,7 @@ Check additional ServiceMonitor resources:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         k8s-app: test-app-metrics-3
         name: test-app-metrics-3
       name: test-app-metrics-3
@@ -167,6 +175,7 @@ Check additional ServiceMonitor resources:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: metrics-3
@@ -176,6 +185,7 @@ Check additional ServiceMonitor resources:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+        - backstage.io/component
 Check basic-auth:
   1: |
     apiVersion: monitoring.coreos.com/v1
@@ -192,6 +202,7 @@ Check basic-auth:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         k8s-app: test-app
         name: test-app
       name: test-app
@@ -225,6 +236,7 @@ Check basic-auth:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -234,6 +246,7 @@ Check basic-auth:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+        - backstage.io/component
 Check combined template defaults:
   1: |
     apiVersion: apps/v1
@@ -250,6 +263,7 @@ Check combined template defaults:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -275,6 +289,7 @@ Check combined template defaults:
             app.mintel.com/component: test-app
             app.mintel.com/env: prod
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -364,6 +379,7 @@ Check combined template defaults:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         k8s-app: test-app
         name: test-app
       name: test-app
@@ -390,6 +406,7 @@ Check combined template defaults:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -399,6 +416,7 @@ Check combined template defaults:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+        - backstage.io/component
   3: |
     apiVersion: v1
     kind: Service
@@ -413,6 +431,7 @@ Check combined template defaults:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -441,6 +460,7 @@ Check combined template with extra ports and monitors:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -466,6 +486,7 @@ Check combined template with extra ports and monitors:
             app.mintel.com/component: test-app
             app.mintel.com/env: prod
             app.mintel.com/region: ${CLUSTER_REGION}
+            backstage.io/component: test-app
             name: test-app
         spec:
           containers:
@@ -559,6 +580,7 @@ Check combined template with extra ports and monitors:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         k8s-app: test-app
         name: test-app
       name: test-app
@@ -585,6 +607,7 @@ Check combined template with extra ports and monitors:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -594,6 +617,7 @@ Check combined template with extra ports and monitors:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+        - backstage.io/component
   3: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
@@ -609,6 +633,7 @@ Check combined template with extra ports and monitors:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         k8s-app: test-app-metrics-2
         name: test-app-metrics-2
       name: test-app-metrics-2
@@ -635,6 +660,7 @@ Check combined template with extra ports and monitors:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: metrics-2
@@ -644,6 +670,7 @@ Check combined template with extra ports and monitors:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+        - backstage.io/component
   4: |
     apiVersion: monitoring.coreos.com/v1
     kind: ServiceMonitor
@@ -659,6 +686,7 @@ Check combined template with extra ports and monitors:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         k8s-app: test-app-metrics-3
         name: test-app-metrics-3
       name: test-app-metrics-3
@@ -685,6 +713,7 @@ Check combined template with extra ports and monitors:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: metrics-3
@@ -694,6 +723,7 @@ Check combined template with extra ports and monitors:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+        - backstage.io/component
   5: |
     apiVersion: v1
     kind: Service
@@ -708,6 +738,7 @@ Check combined template with extra ports and monitors:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -742,6 +773,7 @@ Check default endpoints:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         k8s-app: test-app
         name: test-app
       name: test-app
@@ -768,6 +800,7 @@ Check default endpoints:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -777,6 +810,7 @@ Check default endpoints:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+        - backstage.io/component
 Check default targetLabels:
   1: |
     apiVersion: monitoring.coreos.com/v1
@@ -793,6 +827,7 @@ Check default targetLabels:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         k8s-app: test-app
         name: test-app
       name: test-app
@@ -819,6 +854,7 @@ Check default targetLabels:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -828,6 +864,7 @@ Check default targetLabels:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+        - backstage.io/component
 Check metric overrides:
   1: |
     apiVersion: monitoring.coreos.com/v1
@@ -844,6 +881,7 @@ Check metric overrides:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         k8s-app: test-app
         name: test-app
       name: test-app
@@ -870,6 +908,7 @@ Check metric overrides:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -879,6 +918,7 @@ Check metric overrides:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+        - backstage.io/component
 Check name, namespace and labels:
   1: |
     apiVersion: monitoring.coreos.com/v1
@@ -895,6 +935,7 @@ Check name, namespace and labels:
         app.mintel.com/component: test-app
         app.mintel.com/env: prod
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         k8s-app: test-app
         name: test-app
       name: test-app
@@ -921,6 +962,7 @@ Check name, namespace and labels:
         - app.kubernetes.io/instance
         - app.mintel.com/application
         - app.mintel.com/owner
+        - backstage.io/component
       selector:
         matchLabels:
           app.kubernetes.io/component: app
@@ -930,3 +972,4 @@ Check name, namespace and labels:
         - app.mintel.com/component
         - app.mintel.com/owner
         - app.mintel.com/ignore_alerts
+        - backstage.io/component

--- a/charts/standard-application-stack/tests/__snapshot__/service_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/service_test.yaml.snap
@@ -15,6 +15,7 @@ Check ALB annotation can be set when enabled:
         app.mintel.com/env: qa
         app.mintel.com/owner: my-team
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -44,6 +45,7 @@ Check ALB annotation can set Application without Owner:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -74,6 +76,7 @@ Check ALB annotation can set Owner without Application:
         app.mintel.com/env: local
         app.mintel.com/owner: my-team
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -102,6 +105,7 @@ Check ALB annotation not set when Owner and Application missing:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -129,6 +133,7 @@ Check default port set:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -156,6 +161,7 @@ Check extraPorts:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -195,6 +201,7 @@ Check name, namespace and labels:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -222,6 +229,7 @@ Check port and targetPort can be set from Service:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace
@@ -249,6 +257,7 @@ Check port can be overridden:
         app.mintel.com/component: test-app
         app.mintel.com/env: local
         app.mintel.com/region: local
+        backstage.io/component: test-app
         name: test-app
       name: test-app
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/__snapshot__/vpa_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/vpa_test.yaml.snap
@@ -14,6 +14,7 @@ Can have per-VerticalPodAutoscaler overrides:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: deployment-example-app
       namespace: test-namespace
@@ -41,6 +42,7 @@ Can set container policies:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: deployment-example-app
       namespace: test-namespace
@@ -77,6 +79,7 @@ Creates a VerticalPodAutoscaler for a Deployment:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: deployment-example-app
       namespace: test-namespace
@@ -104,6 +107,7 @@ Creates a VerticalPodAutoscaler for a StatefulSet:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: statefulset-example-app
       namespace: test-namespace
@@ -131,6 +135,7 @@ Creates a VerticalPodAutoscaler for aws-es-proxy:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-aws-es-proxy
       name: deployment-example-app-aws-es-proxy
       namespace: test-namespace
@@ -158,6 +163,7 @@ Creates a VerticalPodAutoscaler for celery:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-celery
       name: deployment-example-app-celery
       namespace: test-namespace
@@ -185,6 +191,7 @@ Creates a VerticalPodAutoscaler for celery-beat:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-celery-beat
       name: deployment-example-app-celery-beat
       namespace: test-namespace
@@ -212,6 +219,7 @@ Creates a VerticalPodAutoscaler for celery-exporter:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-celery-exporter
       name: deployment-example-app-celery-exporter
       namespace: test-namespace
@@ -239,6 +247,7 @@ Creates a VerticalPodAutoscaler for mysqlclient:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-mysqlclient
       name: deployment-example-app-mysqlclient
       namespace: test-namespace
@@ -266,6 +275,7 @@ Creates a VerticalPodAutoscaler for mysqldexporter:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-mysqldexporter
       name: deployment-example-app-mysqldexporter
       namespace: test-namespace
@@ -293,6 +303,7 @@ Creates a VerticalPodAutoscaler for postgresqlclient:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-postgresqlclient
       name: deployment-example-app-postgresqlclient
       namespace: test-namespace
@@ -320,6 +331,7 @@ Creates a VerticalPodAutoscaler for postgresqlexporter:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-postgresqlexporter
       name: deployment-example-app-postgresqlexporter
       namespace: test-namespace
@@ -347,6 +359,7 @@ Creates a VerticalPodAutoscaler with autoscaling enabled:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app
       name: deployment-example-app
       namespace: test-namespace
@@ -374,6 +387,7 @@ Only creates VerticalPodAutoscaler for CronJobs if cronjobsOnly is true:
         app.mintel.com/component: example-app
         app.mintel.com/env: qa
         app.mintel.com/region: ${CLUSTER_REGION}
+        backstage.io/component: example-app
         name: example-app-daily
       name: cronjob-example-app-daily
       namespace: test-namespace

--- a/charts/standard-application-stack/tests/deployment_labels_test.yaml
+++ b/charts/standard-application-stack/tests/deployment_labels_test.yaml
@@ -9,6 +9,7 @@ tests:
       global.owner: sre
       global.application: application-name
       global.component: component-name
+      global.backstage.component: component-name
       global.clusterEnv: qa
     asserts:
       - matchSnapshot: {} # Check for regressions and unexpected changes.
@@ -26,6 +27,9 @@ tests:
           value: application-name
       - equal:
           path: metadata.labels["app.mintel.com/component"]
+          value: component-name
+      - equal:
+          path: metadata.labels["backstage.io/component"]
           value: component-name
   - it: Check empty application and component labels both default to name
     template: deployment.yaml
@@ -45,5 +49,8 @@ tests:
           path: metadata.labels["app.mintel.com/application"]
           value: app
       - equal:
-          path: metadata.labels["app.mintel.com/application"]
+          path: metadata.labels["app.mintel.com/component"]
+          value: app
+      - equal:
+          path: metadata.labels["backstage.io/component"]
           value: app

--- a/charts/standard-application-stack/tests/pod_monitor_test.yaml
+++ b/charts/standard-application-stack/tests/pod_monitor_test.yaml
@@ -48,6 +48,7 @@ tests:
             - app.kubernetes.io/instance
             - app.mintel.com/application
             - app.mintel.com/owner
+            - backstage.io/component
   - it: Check default endpoints
     template: pod-monitor.yaml
     set:

--- a/charts/standard-application-stack/tests/service_monitor_test.yaml
+++ b/charts/standard-application-stack/tests/service_monitor_test.yaml
@@ -47,6 +47,7 @@ tests:
             - app.mintel.com/component
             - app.mintel.com/owner
             - app.mintel.com/ignore_alerts
+            - backstage.io/component
       - equal:
           path: spec.podTargetLabels
           value:
@@ -56,6 +57,7 @@ tests:
             - app.kubernetes.io/instance
             - app.mintel.com/application
             - app.mintel.com/owner
+            - backstage.io/component
   - it: Check default endpoints
     template: service-monitor.yaml
     set:

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -9,10 +9,15 @@ global:
   # Labels for alerting and reporting
   # -- Team which "owns" the application
   owner: ""
-  # -- Name of the application (defaults to global.name)
+  # -- Deprecated: Name of the application (defaults to global.name)
   application: ""
-  # -- Component of the application (defaults to global.name)
+  # -- Deprecated: Component of the application (defaults to global.name)
   component: ""
+
+  backstage:
+    # -- Backstage component (defaults to global.name)
+    component: ""
+
   # -- Top level application each deployment is a part of
   partOf: ""
   # -- Additional labels to apply to all resources


### PR DESCRIPTION
Adds a new `backstage.io/component` label to deployments.

Also makes this available in pod/service monitors