### PR TITLE
Removed S3 Multi-Region Access Point workspaces from IRSA run trigger…

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.21.0] - 2026-02-19
+### Changed
+- Removed S3 Multi-Region Access Point workspaces from IRSA run triggers in the Helm chart. IRSA workspaces will now run via variable changes instead.
+
 ## [v1.20.0] - 2026-02-06
 ### Added
 - Added Terraform Cloud external secret support for S3 Multi-Region Access Point (MRAP) outputs.

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.20.0
+version: 1.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 1.20.0](https://img.shields.io/badge/Version-1.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.21.0](https://img.shields.io/badge/Version-1.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 

--- a/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
@@ -112,7 +112,7 @@ spec:
   {{- $global := $.Values.global }}
   {{- $resourceType := . }}
   {{- $resourceConfig := (get $.Values .) }}
-  {{- if (and $resourceConfig.enabled (has $resourceType (list "opensearch" "s3" "s3MultiRegionAccessPoint" "dynamodb" "sns" "sqs")))}}
+  {{- if (and $resourceConfig.enabled (has $resourceType (list "opensearch" "s3" "dynamodb" "sns" "sqs")))}}
   {{- range $instanceName, $instanceCfg := $resourceConfig.terraform.instances | default ( dict "default" dict ) }}
       # Set instance.name via helper
       {{- $instanceDict := dict "Global" $global "InstanceCfg" $instanceCfg "InstanceName" $instanceName "ResourceType" $resourceType }}


### PR DESCRIPTION
Removed S3 Multi-Region Access Point workspaces from IRSA run triggers in the Helm chart. 
IRSA workspaces will now run via variable changes instead.