### PR TITLE
INFRA-47106: Fix null runTriggers field

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.21.2] - 2026-05-07
+### Fixed
+- Omit `spec.runTriggers` on IRSA and `extraIAM` Workspace manifests when no run triggers are generated. Previously an empty include produced `runTriggers: null`, which fails OpenAPI validation on the `Workspace` CRD (the field must be an array when set).
+
 ## [v1.21.1] - 2026-05-06
 ### Changed
 - Updated app-iam module version to 3.1.0

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.21.1
+version: 1.21.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 1.21.1](https://img.shields.io/badge/Version-1.21.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.21.2](https://img.shields.io/badge/Version-1.21.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 

--- a/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
@@ -64,8 +64,11 @@ spec:
   {{- end }}
   terraformVersion: {{ $tfVersion | default $global.terraform.terraformVersion | quote }}
   {{- if (has $resourceType (list "irsa" "extraIAM" )) }}
+  {{- $runTriggers := include "mintel_common.terraform_cloud.irsaRunTriggers_v2" $ | trim }}
+  {{- if $runTriggers }}
   runTriggers:
-  {{ include "mintel_common.terraform_cloud.irsaRunTriggers_v2" $| indent 4 }}
+{{ $runTriggers | indent 4 }}
+  {{- end }}
   {{- end }}
   environmentVariables:
     - name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace

--- a/charts/terraform-cloud/tests/__snapshot__/irsa_workspace-v2_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/irsa_workspace-v2_test.yaml.snap
@@ -37,7 +37,6 @@ IRSA created explicitly:
           type: generic
           url: ${TFCLOUD_AUTO_APPROVER_URL}
       organization: Mintel
-      runTriggers: null
       sshKey:
         name: mintel-ssh
       tags:
@@ -302,7 +301,6 @@ IRSA created with default (0) syncWave:
           type: generic
           url: ${TFCLOUD_AUTO_APPROVER_URL}
       organization: Mintel
-      runTriggers: null
       sshKey:
         name: mintel-ssh
       tags:
@@ -434,7 +432,6 @@ IRSA created with modified syncWave:
           type: generic
           url: ${TFCLOUD_AUTO_APPROVER_URL}
       organization: Mintel
-      runTriggers: null
       sshKey:
         name: mintel-ssh
       tags:


### PR DESCRIPTION
Kubernetes will not allow Workspace CRs to be applied with `runTriggers: null`, which the terraform-cloud chart renders when you have an IRSA workspace but no other resources that require IRSA (such as when you just want bedrock model access added to the app IAM and don't need to create any other IRSA-triggering resources).