### PR TITLE
terraform-cloud: support pinning workspaces to a TFC project

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.22.0] - 2026-05-22
+### Added
+- `global.terraform.projectName` value, with per-resource (`<resource>.terraform.defaultVars.projectName`) and per-instance (`<resource>.terraform.instances.<name>.projectName`) overrides. When set, the rendered Workspace CR includes `spec.project.name` so the Terraform Cloud Operator places the workspace in the named HCP Terraform project. The project must already exist in the TFC organization. When unset, workspaces continue to land in the org's Default Project.
+
 ## [v1.21.3] - 2026-05-12
 ### Changed
 - Updated app-iam module version to 3.4.0

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.21.3
+version: 1.22.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 1.21.3](https://img.shields.io/badge/Version-1.21.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.22.0](https://img.shields.io/badge/Version-1.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 
@@ -84,8 +84,8 @@ A Helm chart for provisioning resources using Terraform Cloud
 | global.terraform.externalSecrets | bool | `true` | Set to true as part of tf cloud migrations. When true, it stops standard-application-stack from creating AWS related external secrets and passes that responsibility to the terraform-cloud chart |
 | global.terraform.irsa | bool | `true` | Set to true as part of tf cloud migrations. When true, standard-application-stack sets the service account eks annotation to match the new IAM roles created by the app-iam module |
 | global.terraform.organization | string | `"Mintel"` | Name of our Terraform Cloud org |
+| global.terraform.projectName | string | `""` | Optional. HCP Terraform Project name to assign every Workspace this chart renders. The project must already exist in the TFC organization. When empty, workspaces land in the org's Default Project. Can be overridden per-resource via `<resource>.terraform.defaultVars.projectName`, or per-instance via `<resource>.terraform.instances.<name>.projectName`. |
 | global.terraform.secretsMountPath | string | `"/tmp/secrets"` | Where secrets are mounted inside the Terraform Operator container |
-| global.terraform.tags | object | `{"addBackstageComponentTag":true,"addDeprecatedTags":true}` | teamAccess configuration for the workspace teamAccess: [] |
 | global.terraform.tags.addBackstageComponentTag | bool | `true` | Include the "backstage.io/component" tag in default tags |
 | global.terraform.tags.addDeprecatedTags | bool | `true` | Include deprecated default tags (Owner, Project, Application, Component) |
 | global.terraform.terraformVersion | string | `"1.3.10"` | Global Terraform version for all modules |

--- a/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
+++ b/charts/terraform-cloud/templates/helpers/_workspace-v2.yaml
@@ -42,6 +42,11 @@ spec:
   allowDestroyPlan: {{ (include "mintel_common.terraform_cloud.allow_destroy" $workspaceDict) }}
   executionMode: {{ $global.terraform.executionMode | quote }}
   organization: {{ $global.terraform.organization | quote }}
+  {{- $projectName := coalesce $instanceCfg.projectName $global.terraform.projectName "" }}
+  {{- if $projectName }}
+  project:
+    name: {{ $projectName | quote }}
+  {{- end }}
   token:
     secretKeyRef:
       name: terraformrc
@@ -85,6 +90,7 @@ spec:
   {{- $instanceCfgCopy = omit $instanceCfgCopy "workspaceAllowDestroyPlan" }}
   {{- $instanceCfgCopy = omit $instanceCfgCopy "workspaceApplyMethod" }}
   {{- $instanceCfgCopy = omit $instanceCfgCopy "moduleDestroyOnDeletion" }}
+  {{- $instanceCfgCopy = omit $instanceCfgCopy "projectName" }}
 
   {{- range $varKey, $varVal := $instanceCfgCopy }}
     {{- if kindIs "map" $varVal }}

--- a/charts/terraform-cloud/tests/__snapshot__/project_test.yaml.snap
+++ b/charts/terraform-cloud/tests/__snapshot__/project_test.yaml.snap
@@ -1,0 +1,785 @@
+IRSA workspace inherits the global projectName:
+  1: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: test-app-irsa
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-20"
+      labels:
+        app.kubernetes.io/name: test-app-irsa
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: test-app-irsa
+      name: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
+      namespace: test-namespace
+    spec:
+      agentPool:
+        id: ""
+      allowDestroyPlan: true
+      applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
+      executionMode: agent
+      name: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
+      notifications:
+        - enabled: true
+          name: tfcloud-auto-approver
+          token: ${TFCLOUD_AUTO_APPROVER_SIGNATURE_KEY}
+          triggers:
+            - run:needs_attention
+          type: generic
+          url: ${TFCLOUD_AUTO_APPROVER_URL}
+      organization: Mintel
+      project:
+        name: my-tfc-project
+      runTriggers:
+        - name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      sshKey:
+        name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:irsa
+        - allow-destroy:true
+        - kubernetes-managed
+      terraformVariables:
+        - hcl: false
+          name: aws_account_name
+          sensitive: false
+          value: dev
+        - hcl: false
+          name: aws_region
+          sensitive: false
+          value: eu-west-1
+        - hcl: false
+          name: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - hcl: false
+          name: k8s_namespace
+          sensitive: false
+          value: test-namespace
+        - hcl: false
+          name: k8s_service_account_name
+          sensitive: false
+          value: test-app
+        - hcl: false
+          name: name
+          sensitive: false
+          value: test-app
+        - hcl: true
+          name: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "test-app"
+              Component = "test-app"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - hcl: false
+          name: tfcloud_agent
+          sensitive: false
+          value: "true"
+      terraformVersion: 1.3.10
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+  2: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Module
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: test-app-irsa
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-20"
+      labels:
+        app.kubernetes.io/name: test-app-irsa
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: test-app-irsa
+      name: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
+      namespace: test-namespace
+    spec:
+      destroyOnDeletion: true
+      module:
+        source: app.terraform.io/Mintel/app-iam/aws
+        version: 3.4.0
+      name: operator
+      organization: Mintel
+      restartedAt: 77a938f5e67a5feb8645c0a50b19f7d68df333783aaca14c710f173c1f1d88bf
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+      variables:
+        - name: aws_account_name
+        - name: aws_region
+        - name: eks_cluster_name
+        - name: k8s_namespace
+        - name: k8s_service_account_name
+        - name: name
+        - name: tags
+        - name: tfcloud_agent
+      workspace:
+        name: dev-eu-west-1-cluster1-test-namespace-test-app-irsa
+No spec.project rendered when projectName is unset:
+  1: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-app-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-app-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      namespace: test-namespace
+    spec:
+      agentPool:
+        id: ""
+      allowDestroyPlan: true
+      applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      executionMode: agent
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      organization: Mintel
+      sshKey:
+        name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
+      terraformVariables:
+        - hcl: false
+          name: aws_account_name
+          sensitive: false
+          value: dev
+        - hcl: false
+          name: aws_region
+          sensitive: false
+          value: eu-west-1
+        - hcl: false
+          name: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - hcl: false
+          name: enable_versioning
+          sensitive: false
+          value: "false"
+        - hcl: false
+          name: name
+          sensitive: false
+          value: mntl-test-app
+        - hcl: false
+          name: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-test-app/s3
+        - hcl: true
+          name: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - hcl: true
+          name: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "test-app"
+              Component = "test-app"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - hcl: false
+          name: tfcloud_agent
+          sensitive: false
+          value: "true"
+      terraformVersion: 1.3.10
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+  2: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Module
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-app-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-app-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      namespace: test-namespace
+    spec:
+      destroyOnDeletion: true
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 3.0.2
+      name: operator
+      organization: Mintel
+      restartedAt: 9e670d74c67bc9159128b74a2b1804a7a2c1f741c7b8eb2da5bc02702e1fdcbf
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+      variables:
+        - name: aws_account_name
+        - name: aws_region
+        - name: eks_cluster_name
+        - name: enable_versioning
+        - name: name
+        - name: output_secret_name
+        - name: secret_tags
+        - name: tags
+        - name: tfcloud_agent
+      workspace:
+        name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+global.terraform.projectName sets spec.project.name on every workspace:
+  1: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-app-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-app-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      namespace: test-namespace
+    spec:
+      agentPool:
+        id: ""
+      allowDestroyPlan: true
+      applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      executionMode: agent
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      organization: Mintel
+      project:
+        name: my-tfc-project
+      sshKey:
+        name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
+      terraformVariables:
+        - hcl: false
+          name: aws_account_name
+          sensitive: false
+          value: dev
+        - hcl: false
+          name: aws_region
+          sensitive: false
+          value: eu-west-1
+        - hcl: false
+          name: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - hcl: false
+          name: enable_versioning
+          sensitive: false
+          value: "false"
+        - hcl: false
+          name: name
+          sensitive: false
+          value: mntl-test-app
+        - hcl: false
+          name: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-test-app/s3
+        - hcl: true
+          name: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - hcl: true
+          name: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "test-app"
+              Component = "test-app"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - hcl: false
+          name: tfcloud_agent
+          sensitive: false
+          value: "true"
+      terraformVersion: 1.3.10
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+  2: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Module
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-app-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-app-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      namespace: test-namespace
+    spec:
+      destroyOnDeletion: true
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 3.0.2
+      name: operator
+      organization: Mintel
+      restartedAt: 9e670d74c67bc9159128b74a2b1804a7a2c1f741c7b8eb2da5bc02702e1fdcbf
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+      variables:
+        - name: aws_account_name
+        - name: aws_region
+        - name: eks_cluster_name
+        - name: enable_versioning
+        - name: name
+        - name: output_secret_name
+        - name: secret_tags
+        - name: tags
+        - name: tfcloud_agent
+      workspace:
+        name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+instance-level projectName overrides resource and global:
+  1: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-bucket-a-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-bucket-a-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-bucket-a-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-bucket-a-s3
+      namespace: test-namespace
+    spec:
+      agentPool:
+        id: ""
+      allowDestroyPlan: true
+      applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-bucket-a-s3
+      executionMode: agent
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-bucket-a-s3
+      organization: Mintel
+      project:
+        name: s3-project
+      sshKey:
+        name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
+      terraformVariables:
+        - hcl: false
+          name: aws_account_name
+          sensitive: false
+          value: dev
+        - hcl: false
+          name: aws_region
+          sensitive: false
+          value: eu-west-1
+        - hcl: false
+          name: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - hcl: false
+          name: enable_versioning
+          sensitive: false
+          value: "false"
+        - hcl: false
+          name: name
+          sensitive: false
+          value: mntl-bucket-a
+        - hcl: false
+          name: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-bucket-a/s3
+        - hcl: true
+          name: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - hcl: true
+          name: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "test-app"
+              Component = "test-app"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - hcl: false
+          name: tfcloud_agent
+          sensitive: false
+          value: "true"
+      terraformVersion: 1.3.10
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+  2: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Module
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-bucket-a-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-bucket-a-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-bucket-a-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-bucket-a-s3
+      namespace: test-namespace
+    spec:
+      destroyOnDeletion: true
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 3.0.2
+      name: operator
+      organization: Mintel
+      restartedAt: 004369fca77f9558c9d3b1ee9a09e8b9c8bb6c7a2f051dbc99a52c82531d0ab7
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+      variables:
+        - name: aws_account_name
+        - name: aws_region
+        - name: eks_cluster_name
+        - name: enable_versioning
+        - name: name
+        - name: output_secret_name
+        - name: projectName
+        - name: secret_tags
+        - name: tags
+        - name: tfcloud_agent
+      workspace:
+        name: dev-eu-west-1-cluster1-test-namespace-mntl-bucket-a-s3
+  3: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-bucket-b-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-bucket-b-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-bucket-b-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-bucket-b-s3
+      namespace: test-namespace
+    spec:
+      agentPool:
+        id: ""
+      allowDestroyPlan: true
+      applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-bucket-b-s3
+      executionMode: agent
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-bucket-b-s3
+      organization: Mintel
+      project:
+        name: bucket-b-project
+      sshKey:
+        name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
+      terraformVariables:
+        - hcl: false
+          name: aws_account_name
+          sensitive: false
+          value: dev
+        - hcl: false
+          name: aws_region
+          sensitive: false
+          value: eu-west-1
+        - hcl: false
+          name: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - hcl: false
+          name: enable_versioning
+          sensitive: false
+          value: "false"
+        - hcl: false
+          name: name
+          sensitive: false
+          value: mntl-bucket-b
+        - hcl: false
+          name: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-bucket-b/s3
+        - hcl: true
+          name: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - hcl: true
+          name: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "test-app"
+              Component = "test-app"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - hcl: false
+          name: tfcloud_agent
+          sensitive: false
+          value: "true"
+      terraformVersion: 1.3.10
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+  4: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Module
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-bucket-b-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-bucket-b-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-bucket-b-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-bucket-b-s3
+      namespace: test-namespace
+    spec:
+      destroyOnDeletion: true
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 3.0.2
+      name: operator
+      organization: Mintel
+      restartedAt: d0d20225e12befaf2f8397a2b3f9538da2515194187733f1017bca73fd332823
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+      variables:
+        - name: aws_account_name
+        - name: aws_region
+        - name: eks_cluster_name
+        - name: enable_versioning
+        - name: name
+        - name: output_secret_name
+        - name: projectName
+        - name: secret_tags
+        - name: tags
+        - name: tfcloud_agent
+      workspace:
+        name: dev-eu-west-1-cluster1-test-namespace-mntl-bucket-b-s3
+resource-level defaultVars.projectName overrides global:
+  1: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Workspace
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-app-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-app-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      namespace: test-namespace
+    spec:
+      agentPool:
+        id: ""
+      allowDestroyPlan: true
+      applyMethod: auto
+      environmentVariables:
+        - hcl: false
+          name: TF_AWS_DEFAULT_TAGS_TerraformCloudWorkspace
+          sensitive: false
+          value: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      executionMode: agent
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      organization: Mintel
+      project:
+        name: s3-project
+      sshKey:
+        name: mintel-ssh
+      tags:
+        - env:dev
+        - owner:sre
+        - mod:s3
+        - allow-destroy:true
+        - kubernetes-managed
+      terraformVariables:
+        - hcl: false
+          name: aws_account_name
+          sensitive: false
+          value: dev
+        - hcl: false
+          name: aws_region
+          sensitive: false
+          value: eu-west-1
+        - hcl: false
+          name: eks_cluster_name
+          sensitive: false
+          value: cluster1
+        - hcl: false
+          name: enable_versioning
+          sensitive: false
+          value: "false"
+        - hcl: false
+          name: name
+          sensitive: false
+          value: mntl-test-app
+        - hcl: false
+          name: output_secret_name
+          sensitive: false
+          value: test-namespace/mntl-test-app/s3
+        - hcl: true
+          name: secret_tags
+          sensitive: false
+          value: '{access-project = "test-namespace-ops"}'
+        - hcl: true
+          name: tags
+          sensitive: false
+          value: |-
+            {
+              Application = "test-app"
+              Component = "test-app"
+              Owner = "sre"
+              Project = "test-project"
+            }
+        - hcl: false
+          name: tfcloud_agent
+          sensitive: false
+          value: "true"
+      terraformVersion: 1.3.10
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+  2: |
+    apiVersion: app.terraform.io/v1alpha2
+    kind: Module
+    metadata:
+      annotations:
+        app.mintel.com/altManifestFileSuffix: mntl-test-app-s3
+        app.mintel.com/placeholder: placeholder
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "-40"
+      labels:
+        app.kubernetes.io/name: mntl-test-app-s3
+        app.mintel.com/env: dev
+        app.mintel.com/owner: sre
+        app.mintel.com/region: eu-west-1
+        name: mntl-test-app-s3
+      name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3
+      namespace: test-namespace
+    spec:
+      destroyOnDeletion: true
+      module:
+        source: app.terraform.io/Mintel/private-s3-bucket/aws
+        version: 3.0.2
+      name: operator
+      organization: Mintel
+      restartedAt: 4f1634239ddc5806a82669ce8fda7532b70730f9845faa439d3093d03b2fa1ff
+      token:
+        secretKeyRef:
+          key: token
+          name: terraformrc
+      variables:
+        - name: aws_account_name
+        - name: aws_region
+        - name: eks_cluster_name
+        - name: enable_versioning
+        - name: name
+        - name: output_secret_name
+        - name: projectName
+        - name: secret_tags
+        - name: tags
+        - name: tfcloud_agent
+      workspace:
+        name: dev-eu-west-1-cluster1-test-namespace-mntl-test-app-s3

--- a/charts/terraform-cloud/tests/project_test.yaml
+++ b/charts/terraform-cloud/tests/project_test.yaml
@@ -1,0 +1,128 @@
+suite: Test Workspace project assignment
+templates:
+  - workspace.yaml
+  - irsa-workspace.yaml
+release:
+  namespace: test-namespace
+tests:
+  - it: No spec.project rendered when projectName is unset
+    template: workspace.yaml
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      s3.enabled: true
+    asserts:
+      - matchSnapshot: {}
+      - notExists:
+          path: spec.project
+        documentIndex: 0
+
+  - it: global.terraform.projectName sets spec.project.name on every workspace
+    template: workspace.yaml
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      global.terraform.projectName: my-tfc-project
+      s3.enabled: true
+    asserts:
+      - matchSnapshot: {}
+      - equal:
+          path: spec.project.name
+          value: my-tfc-project
+        documentIndex: 0
+
+  - it: resource-level defaultVars.projectName overrides global
+    template: workspace.yaml
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      global.terraform.projectName: global-project
+      s3:
+        enabled: true
+        terraform:
+          defaultVars:
+            projectName: s3-project
+    asserts:
+      - matchSnapshot: {}
+      - equal:
+          path: spec.project.name
+          value: s3-project
+        documentIndex: 0
+
+  - it: instance-level projectName overrides resource and global
+    template: workspace.yaml
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      global.terraform.projectName: global-project
+      s3:
+        enabled: true
+        terraform:
+          defaultVars:
+            projectName: s3-project
+          instances:
+            bucket-a: {}
+            bucket-b:
+              projectName: bucket-b-project
+    asserts:
+      - matchSnapshot: {}
+      - equal:
+          path: spec.project.name
+          value: s3-project
+        documentIndex: 0
+      - equal:
+          path: spec.project.name
+          value: bucket-b-project
+        documentIndex: 2
+
+  - it: projectName is not emitted as a Terraform variable
+    template: workspace.yaml
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      global.terraform.projectName: my-tfc-project
+      s3.enabled: true
+    asserts:
+      - notContains:
+          path: spec.terraformVariables
+          content:
+            name: projectName
+        documentIndex: 0
+
+  - it: IRSA workspace inherits the global projectName
+    template: irsa-workspace.yaml
+    set:
+      global.name: test-app
+      global.clusterEnv: dev
+      global.clusterName: cluster1
+      global.clusterRegion: eu-west-1
+      global.owner: sre
+      global.partOf: test-project
+      global.terraform.projectName: my-tfc-project
+      s3.enabled: true
+    asserts:
+      - matchSnapshot: {}
+      - equal:
+          path: spec.project.name
+          value: my-tfc-project
+        documentIndex: 0

--- a/charts/terraform-cloud/values.yaml
+++ b/charts/terraform-cloud/values.yaml
@@ -56,6 +56,12 @@ global:
     defaultApplyMethod: auto
     # -- teamAccess configuration for the workspace
     # teamAccess: []
+    # -- Optional. HCP Terraform Project name to assign every Workspace this chart renders.
+    # The project must already exist in the TFC organization. When empty, workspaces land in
+    # the org's Default Project. Can be overridden per-resource via
+    # `<resource>.terraform.defaultVars.projectName`, or per-instance via
+    # `<resource>.terraform.instances.<name>.projectName`.
+    projectName: ""
     tags:
       # -- Include the "backstage.io/component" tag in default tags
       addBackstageComponentTag: true


### PR DESCRIPTION
Add global.terraform.projectName (with per-resource defaultVars and per-instance overrides). When set, the rendered Workspace CR includes spec.project.name so the Terraform Cloud Operator places the workspace in the named HCP Terraform project. The project must already exist in the TFC organization. When unset, workspaces continue to land in the org's Default Project, so this is non-breaking.

Bumps chart to 1.22.0.