### PR TITLE
terraform-cloud: cleanup and json schema

### DIFF
--- a/charts/terraform-cloud/CHANGELOG.md
+++ b/charts/terraform-cloud/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.21.4] - 2026-05-22
+### Added
+- `values.schema.json` providing permissive type validation for declared
+  values. Unknown keys are still allowed so consumers and the dynamic
+  `defaultVars` / `instances` / IRSA `vars` pass-throughs aren't constrained.
+- Documented previously-undeclared values in `values.yaml`: `nameOverride`,
+  `jobs`, `global.application`, `global.component`, `global.additionalLabels`,
+  and `irsa.nameOverride`. All are optional with safe defaults; no behavior
+  change for existing consumers.
+
+### Fixed
+- `postgresql.terraform.defaultVars.enable_deletion_protection` example comment
+  in `values.yaml` was missing its `: bool` type hint; aligned with the
+  matching comment in the other database modules.
+- Moved the `irsa.nameOverride` documentation out from under
+  `irsa.terraform`, where it was misleading — the template reads
+  `.Values.irsa.nameOverride` (top-level on the `irsa` block).
+
 ## [v1.21.3] - 2026-05-12
 ### Changed
 - Updated app-iam module version to 3.4.0

--- a/charts/terraform-cloud/Chart.yaml
+++ b/charts/terraform-cloud/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.21.3
+version: 1.21.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/terraform-cloud/README.md
+++ b/charts/terraform-cloud/README.md
@@ -1,6 +1,6 @@
 # terraform-cloud
 
-![Version: 1.21.3](https://img.shields.io/badge/Version-1.21.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
+![Version: 1.21.4](https://img.shields.io/badge/Version-1.21.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.0.0](https://img.shields.io/badge/AppVersion-2.0.0-informational?style=flat-square)
 
 A Helm chart for provisioning resources using Terraform Cloud
 
@@ -69,11 +69,14 @@ A Helm chart for provisioning resources using Terraform Cloud
 | extraIAM.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | extraIAM.terraform.module.source | string | `"app.terraform.io/Mintel/app-iam/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/app-iam/aws) |
 | extraIAM.terraform.module.version | string | `"3.4.0"` | Module version |
+| global.additionalLabels | object | `{}` | Extra labels merged into the common label set rendered on every resource. |
+| global.application | string | `""` | Override for the deprecated `Application` AWS tag. Defaults to `global.name` when unset. |
 | global.backstage | object | `{"component":""}` | Backstage Component |
 | global.clusterDomain | string | `"127.0.0.1.nip.io"` | Additional labels to apply to all resources |
 | global.clusterEnv | string | `"local"` | Environment (local, dev, qa, prod) |
 | global.clusterName | string | `""` | Kubernetes cluster name |
 | global.clusterRegion | string | `""` | Kubernetes cluster region |
+| global.component | string | `""` | Override for the deprecated `Component` AWS tag. Defaults to `global.name` when unset. |
 | global.name | string | `"example-app"` | Name of the application |
 | global.owner | string | `""` | Team which "owns" the application |
 | global.partOf | string | `""` | Top level application each deployment is a part of |
@@ -97,11 +100,13 @@ A Helm chart for provisioning resources using Terraform Cloud
 | glue.terraform.module.source | string | `"app.terraform.io/Mintel/glue/aws//modules/entrypoint"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/glue/aws) |
 | glue.terraform.module.version | string | `"1.3.1"` | Module version |
 | irsa.enabled | bool | `false` | Set to true to explicitly instantiate this module if there's need to access resources created elsewhere |
+| irsa.nameOverride | string | `""` | Override the generated IRSA workspace name (skips the default which is `global.name`). |
 | irsa.terraform | object | `{"module":{"source":"app.terraform.io/Mintel/app-iam/aws","version":"3.4.0"},"notifications":[{"enabled":true,"name":"tfcloud-auto-approver","token":"${TFCLOUD_AUTO_APPROVER_SIGNATURE_KEY}","triggers":["run:needs_attention"],"type":"generic","url":"${TFCLOUD_AUTO_APPROVER_URL}"}],"vars":{}}` | Set ArgoCD syncWave for this resource (default -20) syncWave: -20 |
 | irsa.terraform.module.source | string | `"app.terraform.io/Mintel/app-iam/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/app-iam/aws) |
 | irsa.terraform.module.version | string | `"3.4.0"` | Module version |
 | irsa.terraform.notifications | list | `[{"enabled":true,"name":"tfcloud-auto-approver","token":"${TFCLOUD_AUTO_APPROVER_SIGNATURE_KEY}","triggers":["run:needs_attention"],"type":"generic","url":"${TFCLOUD_AUTO_APPROVER_URL}"}]` | Configure Terraform Cloud notifications. This should not be changed unless you really know what you're doing. |
 | irsa.terraform.vars | object | See below | Vars to be applied to all instances defined below |
+| jobs | list | `[]` | List of auxiliary job/worker definitions consumed by the IRSA workspace to build `k8s_extra_service_accounts`. Each entry needs a `name`; the chart constructs the service account as `<global.name>-<name>`. Example:   jobs:     - name: worker     - name: scheduler |
 | kinesis-firehose.enabled | bool | `false` | Set to true to create a Kinesis Firehose delivery stream |
 | kinesis-firehose.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
 | kinesis-firehose.terraform | object | `{"defaultVars":null,"instances":{},"module":{"source":"app.terraform.io/Mintel/kinesis-firehose/aws//modules/entrypoint","version":"0.0.1"},"terraformVersion":"1.4.3"}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |
@@ -134,6 +139,7 @@ A Helm chart for provisioning resources using Terraform Cloud
 | memcached.terraform.instances | object | `{}` | A map of instance names => variable key/value pairs to be sent to the terraform module. The values in `defaultVars` will be applied to every instance if not explicitly defined here. |
 | memcached.terraform.module.source | string | `"app.terraform.io/Mintel/memcached/aws"` | Registry path of the Terraform module used to create the resource (https://app.terraform.io/app/Mintel/registry/modules/private/Mintel/memcached/aws) |
 | memcached.terraform.module.version | string | `"1.0.3"` | Module version |
+| nameOverride | string | `""` | Override the chart's generated `fullname`. When unset, `global.name` is used. |
 | opensearch.enabled | bool | `false` | Set to true to create an Opensearch cluster |
 | opensearch.outputSecret | bool | `true` | Set to true to create an AWS secret manager external secret with outputs |
 | opensearch.terraform | object | `{"defaultVars":null,"instances":{},"module":{"source":"app.terraform.io/Mintel/opensearch/aws","version":"1.6.0"}}` | Set ArgoCD syncWave for this resource (default -40) syncWave: -40 |

--- a/charts/terraform-cloud/values.schema.json
+++ b/charts/terraform-cloud/values.schema.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "terraform-cloud Helm chart values",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["global"],
+  "properties": {
+    "nameOverride": {
+      "type": "string",
+      "description": "Override the chart's generated fullname. Defaults to global.name."
+    },
+    "jobs": {
+      "type": "array",
+      "description": "Auxiliary jobs/workers. Each entry's `name` is used to build a `<global.name>-<name>` IRSA service account.",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" }
+        }
+      }
+    },
+    "global": { "$ref": "#/$defs/global" },
+    "irsa": { "$ref": "#/$defs/irsaResource" },
+    "activeMQ": { "$ref": "#/$defs/resource" },
+    "apiGatewayHttp": { "$ref": "#/$defs/resource" },
+    "auroraMySql": { "$ref": "#/$defs/resource" },
+    "auroraPostgresql": { "$ref": "#/$defs/resource" },
+    "cmsBackup": { "$ref": "#/$defs/resource" },
+    "datasync": { "$ref": "#/$defs/resource" },
+    "dynamodb": { "$ref": "#/$defs/resource" },
+    "extraIAM": { "$ref": "#/$defs/resource" },
+    "glue": { "$ref": "#/$defs/resource" },
+    "kinesis-firehose": { "$ref": "#/$defs/resource" },
+    "lambda": { "$ref": "#/$defs/resource" },
+    "mariadb": { "$ref": "#/$defs/resource" },
+    "memcached": { "$ref": "#/$defs/resource" },
+    "opensearch": { "$ref": "#/$defs/resource" },
+    "postgresql": { "$ref": "#/$defs/resource" },
+    "redis": { "$ref": "#/$defs/resource" },
+    "s3": { "$ref": "#/$defs/resource" },
+    "s3ReplicationRules": { "$ref": "#/$defs/resource" },
+    "s3MultiRegionAccessPoint": { "$ref": "#/$defs/resource" },
+    "sns": { "$ref": "#/$defs/resourceWithEventBus" },
+    "sqs": { "$ref": "#/$defs/resourceWithEventBus" },
+    "sshKeyPairSecret": { "$ref": "#/$defs/resource" },
+    "staticWebsite": { "$ref": "#/$defs/resource" },
+    "stepFunctionEks": { "$ref": "#/$defs/resource" }
+  },
+  "$defs": {
+    "global": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "name",
+        "owner",
+        "partOf",
+        "clusterDomain",
+        "clusterEnv",
+        "clusterRegion",
+        "terraform"
+      ],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "owner": { "type": "string" },
+        "partOf": { "type": "string" },
+        "clusterDomain": { "type": "string" },
+        "clusterEnv": { "type": "string" },
+        "clusterName": { "type": "string" },
+        "clusterRegion": { "type": "string" },
+        "application": { "type": "string" },
+        "component": { "type": "string" },
+        "additionalLabels": {
+          "type": "object",
+          "additionalProperties": { "type": "string" }
+        },
+        "backstage": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "component": { "type": "string" }
+          }
+        },
+        "terraform": { "$ref": "#/$defs/globalTerraform" }
+      }
+    },
+    "globalTerraform": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "organization": { "type": "string" },
+        "secretsMountPath": { "type": "string" },
+        "terraformVersion": { "type": "string" },
+        "externalSecrets": { "type": "boolean" },
+        "irsa": { "type": "boolean" },
+        "agentPoolID": { "type": "string" },
+        "executionMode": {
+          "type": "string",
+          "enum": ["agent", "remote", "local"]
+        },
+        "restartedAt": { "type": "string" },
+        "enableRestartedAt": { "type": "boolean" },
+        "defaultWorkspaceAllowDestroy": { "type": "boolean" },
+        "defaultApplyMethod": {
+          "type": "string",
+          "enum": ["auto", "manual"]
+        },
+        "teamAccess": {
+          "type": "array",
+          "items": { "type": "object" }
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "addBackstageComponentTag": { "type": "boolean" },
+            "addDeprecatedTags": { "type": "boolean" }
+          }
+        }
+      }
+    },
+    "resource": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "outputSecret": { "type": "boolean" },
+        "syncWave": { "type": ["integer", "string"] },
+        "terraform": { "$ref": "#/$defs/resourceTerraform" }
+      }
+    },
+    "resourceWithEventBus": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "outputSecret": { "type": "boolean" },
+        "syncWave": { "type": ["integer", "string"] },
+        "eventBus": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "terraform": { "$ref": "#/$defs/resourceTerraform" }
+      }
+    },
+    "resourceTerraform": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "terraformVersion": { "type": "string" },
+        "module": { "$ref": "#/$defs/module" },
+        "defaultVars": {
+          "description": "Free-form variables passed through to the Terraform module. Keys are module-defined.",
+          "type": ["object", "null"]
+        },
+        "instances": {
+          "description": "Map of instance name -> variable overrides. Keys are user-defined; values are free-form.",
+          "type": ["object", "null"],
+          "additionalProperties": { "type": ["object", "null"] }
+        }
+      }
+    },
+    "module": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["source", "version"],
+      "properties": {
+        "source": { "type": "string" },
+        "version": { "type": "string" }
+      }
+    },
+    "irsaResource": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "nameOverride": { "type": "string" },
+        "syncWave": { "type": ["integer", "string"] },
+        "terraform": {
+          "type": "object",
+          "additionalProperties": true,
+          "properties": {
+            "terraformVersion": { "type": "string" },
+            "module": { "$ref": "#/$defs/module" },
+            "vars": {
+              "description": "Free-form variables passed through to the app-iam module. IRSA uses `vars` rather than `defaultVars` for historical reasons.",
+              "type": ["object", "null"]
+            },
+            "notifications": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true,
+                "required": ["name", "enabled", "type"],
+                "properties": {
+                  "name": { "type": "string" },
+                  "enabled": { "type": "boolean" },
+                  "type": { "type": "string" },
+                  "url": { "type": "string" },
+                  "token": { "type": "string" },
+                  "triggers": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/terraform-cloud/values.yaml
+++ b/charts/terraform-cloud/values.yaml
@@ -2,6 +2,18 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# -- Override the chart's generated `fullname`. When unset, `global.name` is used.
+nameOverride: ""
+
+# -- List of auxiliary job/worker definitions consumed by the IRSA workspace to
+# build `k8s_extra_service_accounts`. Each entry needs a `name`; the chart
+# constructs the service account as `<global.name>-<name>`.
+# Example:
+#   jobs:
+#     - name: worker
+#     - name: scheduler
+jobs: []
+
 ###
 ## Global
 ###
@@ -21,6 +33,12 @@ global:
   clusterName: ""
   # -- Kubernetes cluster region
   clusterRegion: ""
+  # -- Override for the deprecated `Application` AWS tag. Defaults to `global.name` when unset.
+  application: ""
+  # -- Override for the deprecated `Component` AWS tag. Defaults to `global.name` when unset.
+  component: ""
+  # -- Extra labels merged into the common label set rendered on every resource.
+  additionalLabels: {}
   # -- Backstage Component
   backstage:
     component: ""
@@ -430,13 +448,13 @@ glue:
 irsa:
   # -- Set to true to explicitly instantiate this module if there's need to access resources created elsewhere
   enabled: false
+  # -- Override the generated IRSA workspace name (skips the default which is `global.name`).
+  nameOverride: ""
   # -- Set ArgoCD syncWave for this resource (default -20)
   # syncWave: -20
   terraform:
     ### Set Terraform version for this module to overwrite global.TerraformVersion
     # terraformVersion:
-    ### Set override to stop IRSA from ending in global.name
-    # nameOverride:
     # @default -- -
     module:
       # -- Registry path of the Terraform module used to create the resource
@@ -738,7 +756,7 @@ postgresql:
       ### Automatically set to 14 in prod, 7 in qa and 0 in dev. Override this only if you know what you're doing.
       # backup_retention_period: number
       ### Automatically set to true in prod and qa but false in dev. Override this only if you know what you're doing.
-      # enable_deletion_protection
+      # enable_deletion_protection: bool
     # -- A map of instance names => variable key/value pairs to be sent to the terraform module. The values in
     # `defaultVars` will be applied to every instance if not explicitly defined here.
     instances: {}


### PR DESCRIPTION
Document five values that the templates already consume but were never declared in values.yaml: top-level `nameOverride` and `jobs`; `global.application`, `global.component`, `global.additionalLabels`; and `irsa.nameOverride`. All are optional with safe defaults, so there is no behavior change for existing consumers.

Add a permissive `values.schema.json` that provides type validation for declared values while leaving room for unknown keys, so the dynamic `defaultVars` / `instances` / IRSA `vars` pass-throughs to Terraform modules remain unconstrained.

Also fix two small inconsistencies:

- The `postgresql.terraform.defaultVars.enable_deletion_protection` comment was missing its `: bool` type hint; aligned with the matching comment in the other database modules.
- `irsa.nameOverride` was commented under `irsa.terraform`, but the template reads `.Values.irsa.nameOverride` (top-level on the `irsa` block). Moved the documentation to the correct level.
