### PR TITLE
Infra 48603 kubelock support new version rbac

### DIFF
--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [v11.4.0] - 2026-06-22
+### Added
+- Optional kubelock binary injection via `kubelock.injectBinary` (default: `false`). When enabled with `kubelock.enabled`, an init container copies the kubelock binary from `kubelock.image` into a shared volume mounted at `/usr/local/bin/kubelock` on the main container (deployment, celery, and jobs). Default image tag is `v0.4.1`.
 ### Changed
 - kubelock RBAC rules consolidated into `helpers/_kubelock.yaml` (`mintel_common.kubelockRoleRules`).
 - kubelock Lease access is scoped to the configured lock name via `resourceNames` (`kubelock.nameOverride` or release/job fullname) for the new Lease-based kubelock release.

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v11.4.0] - 2026-06-22
+### Changed
+- kubelock RBAC rules consolidated into `helpers/_kubelock.yaml` (`mintel_common.kubelockRoleRules`).
+- kubelock Lease access is scoped to the configured lock name via `resourceNames` (`kubelock.nameOverride` or release/job fullname) for the new Lease-based kubelock release.
+- Legacy `endpoints` rules are retained for workloads still using the older Endpoints-based kubelock image.
+
 ## [v11.3.0] - 2026-02-19
 ### Added
 - Add preStop hook `mintel_common.deployment.lifecycle` to auth-proxy container

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v11.4.0] - 2026-06-22
 ### Added
-- Optional kubelock binary injection via `kubelock.injectBinary` (default: `false`). When enabled with `kubelock.enabled`, an init container copies the kubelock binary from `kubelock.image` into a shared volume mounted at `/usr/local/bin/kubelock` on the main container (deployment, celery, and jobs). Default image tag is `v0.4.1`.
+- Optional kubelock binary injection via `kubelock.injectBinary` (default: `false`). When enabled with `kubelock.enabled`, an init container copies the kubelock binary from `kubelock.image` into a shared volume mounted at `/usr/local/bin/kubelock` on the main container (deployment, celery, jobs, and cronjobs). Default image tag is `v0.4.1`.
 ### Changed
 - kubelock RBAC rules consolidated into `helpers/_kubelock.yaml` (`mintel_common.kubelockRoleRules`).
 - Legacy `endpoints` rules are retained for workloads still using the older Endpoints-based kubelock image.
+- `jobDefaults.kubelock.injectBinary` is unset by default so Jobs inherit `Values.kubelock.injectBinary` unless overridden.
 ### Fixed
 - Dropped `resourceNames` from kubelock Lease RBAC rules; Kubernetes does not allow `resourceNames` with the `create` verb.
 

--- a/charts/standard-application-stack/CHANGELOG.md
+++ b/charts/standard-application-stack/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optional kubelock binary injection via `kubelock.injectBinary` (default: `false`). When enabled with `kubelock.enabled`, an init container copies the kubelock binary from `kubelock.image` into a shared volume mounted at `/usr/local/bin/kubelock` on the main container (deployment, celery, and jobs). Default image tag is `v0.4.1`.
 ### Changed
 - kubelock RBAC rules consolidated into `helpers/_kubelock.yaml` (`mintel_common.kubelockRoleRules`).
-- kubelock Lease access is scoped to the configured lock name via `resourceNames` (`kubelock.nameOverride` or release/job fullname) for the new Lease-based kubelock release.
 - Legacy `endpoints` rules are retained for workloads still using the older Endpoints-based kubelock image.
+### Fixed
+- Dropped `resourceNames` from kubelock Lease RBAC rules; Kubernetes does not allow `resourceNames` with the `create` verb.
 
 ## [v11.3.0] - 2026-02-19
 ### Added

--- a/charts/standard-application-stack/Chart.yaml
+++ b/charts/standard-application-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 11.3.0
+version: 11.4.0
 
 dependencies:
   - name: redis

--- a/charts/standard-application-stack/README.md
+++ b/charts/standard-application-stack/README.md
@@ -1,6 +1,6 @@
 # standard-application-stack
 
-![Version: 11.3.0](https://img.shields.io/badge/Version-11.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 11.4.0](https://img.shields.io/badge/Version-11.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A generic chart to support most common application requirements
 
@@ -177,6 +177,7 @@ A generic chart to support most common application requirements
 | jobDefaults.includeAppSecret | bool | `false` | Whether you want the secrets used by the main app workload to be available to the Job |
 | jobDefaults.includeBaseEnv | bool | `false` | Whether you want the environment variables used by the main app workload to be available to the Job |
 | jobDefaults.includeBasePodSecurityContext | bool | `false` | Whether you want the securityContext used by the main app workload to be the same in the Job |
+| jobDefaults.kubelock | object | `{"enabled":false}` | Enable kubelock for Jobs: creates per-job ServiceAccount, Role, and RoleBinding in templates/jobs.yaml (not the release-level kubelock templates above). |
 | jobDefaults.labels | object | `{}` | Any labels you wish to add to the Job. |
 | jobDefaults.name | string | `nil` | REQUIRED FOR ALL JOBS. The name of the job. |
 | jobDefaults.podSecurityContext | object | `{}` | Add podSecurityContext config to the Job. |
@@ -187,8 +188,12 @@ A generic chart to support most common application requirements
 | jobsOnly | bool | `false` | Only show Jobs and relevant resources (i.e. if set to `true`, hide the main deployment resource) |
 | kibana.elasticsearchHosts | string | `""` |  |
 | kibana.enabled | bool | `false` |  |
-| kubelock | object | `{"enabled":false}` | Configure the use of kubelock ref: https://github.com/mintel/kubelock |
-| kubelock.enabled | bool | `false` | Set to true to enable kubelock |
+| kubelock | object | `{"enabled":false,"image":{"pullPolicy":"IfNotPresent","registry":"551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com","repository":"gitlab/mintel/satoshi/tools/kubelock","tag":"v0.5.0"},"injectBinary":false,"resources":{"limits":{"memory":"64Mi"},"requests":{"cpu":"10m","memory":"32Mi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}}` | Configure kubelock for the main release workload (deployment, celery, cronjobs, etc.). Creates RBAC via templates/kubelock-role.yaml and sets KUBELOCK_* env vars via mintel_common.defaultEnv. CronJobs inherit these settings (optional per-job override via cronjobs.jobs[].kubelock). For Jobs, use jobDefaults.kubelock / jobs[].kubelock instead. ref: https://gitlab.com/mintel/satoshi/tools/kubelock |
+| kubelock.enabled | bool | `false` | Set to true to enable release-level kubelock RBAC and KUBELOCK_* env vars |
+| kubelock.image | object | `{"pullPolicy":"IfNotPresent","registry":"551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com","repository":"gitlab/mintel/satoshi/tools/kubelock","tag":"v0.5.0"}` | Kubelock container image used by the injectBinary init container. |
+| kubelock.injectBinary | bool | `false` | Inject the kubelock binary via an init container instead of bundling it in the app image. Requires kubelock.enabled. Mounts the binary at /usr/local/bin/kubelock (overwriting any existing file). Applies to deployment, celery, and cronjobs (and Jobs when jobs[].kubelock.enabled is true). |
+| kubelock.resources | object | `{"limits":{"memory":"64Mi"},"requests":{"cpu":"10m","memory":"32Mi"}}` | Resources for the kubelock injectBinary init container |
+| kubelock.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` | securityContext for the kubelock injectBinary init container |
 | liveness | object | `{"enabled":true,"startup":{"failureThreshold":60,"periodSeconds":5}}` | Configure extra options for liveness probe ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes |
 | liveness.enabled | bool | `true` | Enable liveness probe |
 | liveness.startup | object | `{"failureThreshold":60,"periodSeconds":5}` | Configure startup probe ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes |

--- a/charts/standard-application-stack/templates/cronjobs.yaml
+++ b/charts/standard-application-stack/templates/cronjobs.yaml
@@ -1,10 +1,14 @@
 {{- range .Values.cronjobs.jobs }}
 ---
 {{- $data := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "component" .name }}
+{{- $cronjobName := include "mintel_common.fullname" $data -}}
+{{- $kubelock := mergeOverwrite (deepCopy $.Values.kubelock) (.kubelock | default dict) -}}
+{{- $kubelockInject := include "mintel_common.kubelock.injectBinaryEnabled" $kubelock | trim -}}
+{{- $kubelockVolumeName := include "mintel_common.kubelock.volumeName" $cronjobName -}}
 apiVersion: {{ include "common.capabilities.cronjob.apiVersion" $ }}
 kind: CronJob
 metadata:
-  name: {{ include "mintel_common.fullname" $data }}
+  name: {{ $cronjobName }}
   labels: {{ include "mintel_common.labels" $data | nindent 4 }}
   annotations:
     {{- include "mintel_common.commonAnnotations" $ | nindent 4 }}
@@ -49,13 +53,23 @@ spec:
           serviceAccountName: {{ $.Values.serviceAccount.name | default (include "mintel_common.fullname" $) }}
           {{- end }}
           restartPolicy: {{ .restartPolicy | default $.Values.cronjobs.defaults.restartPolicy }}
-          {{- with .extraInitContainers }}
+          {{- if or .extraInitContainers (eq $kubelockInject "true") }}
           initContainers:
-          {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with $.Values.cronjobs.volumes }}
-          volumes:
+            {{- if eq $kubelockInject "true" }}
+            {{- include "mintel_common.kubelock.initContainer" (dict "kubelock" $kubelock "volumeName" $kubelockVolumeName) | nindent 12 }}
+            {{- end }}
+            {{- with .extraInitContainers }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          {{- if or $.Values.cronjobs.volumes (eq $kubelockInject "true") }}
+          volumes:
+            {{- if eq $kubelockInject "true" }}
+            {{- include "mintel_common.kubelock.volume" (dict "volumeName" $kubelockVolumeName) | nindent 12 }}
+            {{- end }}
+            {{- with $.Values.cronjobs.volumes }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           containers:
             - name: main
@@ -180,7 +194,13 @@ spec:
               {{- with .securityContext | default $.Values.securityContext }}
               securityContext: {{- toYaml . | nindent 16 }}
               {{- end }}
-              {{- with $.Values.cronjobs.volumeMounts }}
-              volumeMounts: {{- toYaml . | nindent 16 }}
+              {{- if or $.Values.cronjobs.volumeMounts (eq $kubelockInject "true") }}
+              volumeMounts:
+                {{- if eq $kubelockInject "true" }}
+                {{- include "mintel_common.kubelock.volumeMount" (dict "volumeName" $kubelockVolumeName) | nindent 16 }}
+                {{- end }}
+                {{- with $.Values.cronjobs.volumeMounts }}
+                {{- toYaml . | nindent 16 }}
+                {{- end }}
               {{- end }}
 {{- end }}

--- a/charts/standard-application-stack/templates/deployment-celery.yaml
+++ b/charts/standard-application-stack/templates/deployment-celery.yaml
@@ -117,6 +117,12 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
+      {{- $kubelockInject := include "mintel_common.kubelock.injectBinaryEnabled" .Values.kubelock | trim -}}
+      {{- if eq $kubelockInject "true" }}
+      initContainers:
+      {{- $kubelockVolumeName := include "mintel_common.kubelock.volumeName" (include "mintel_common.fullname" .) }}
+      {{- include "mintel_common.kubelock.initContainer" (dict "kubelock" .Values.kubelock "volumeName" $kubelockVolumeName) | nindent 8 }}
+      {{- end }}
       containers:
         - name: main
           image: {{ .Values.celery.image | default (include "mintel_common.image" .) }}
@@ -245,8 +251,12 @@ spec:
           {{- with .Values.celery.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if (or .Values.volumeMounts .Values.celery.volumeMounts) }}
+          {{- if or .Values.volumeMounts .Values.celery.volumeMounts (eq $kubelockInject "true") }}
           volumeMounts:
+            {{- if eq $kubelockInject "true" }}
+            {{- $kubelockVolumeName := include "mintel_common.kubelock.volumeName" (include "mintel_common.fullname" .) }}
+            {{- include "mintel_common.kubelock.volumeMount" (dict "volumeName" $kubelockVolumeName) | nindent 12 }}
+            {{- end }}
             {{- with .Values.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -309,7 +319,7 @@ spec:
           {{- end }}
         {{- end }}
         {{- end }}
-      {{- if (or .Values.volumes (and .Values.filebeatSidecar .Values.filebeatSidecar.enabled)) }}
+      {{- if or .Values.volumes (and .Values.filebeatSidecar .Values.filebeatSidecar.enabled) (eq $kubelockInject "true") }}
       volumes:
         {{- with .Values.volumes }}
         {{- toYaml . | nindent 8 }}
@@ -318,6 +328,10 @@ spec:
         - configMap:
             name: {{ include "mintel_common.fullname" . }}-filebeat
           name: {{ include "mintel_common.fullname" . }}-filebeat
+        {{- end }}
+        {{- if eq $kubelockInject "true" }}
+        {{- $kubelockVolumeName := include "mintel_common.kubelock.volumeName" (include "mintel_common.fullname" .) }}
+        {{- include "mintel_common.kubelock.volume" (dict "volumeName" $kubelockVolumeName) | nindent 8 }}
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/standard-application-stack/templates/deployment.yaml
+++ b/charts/standard-application-stack/templates/deployment.yaml
@@ -166,9 +166,16 @@ spec:
         {{- end }}
         {{- end }}
       {{- end }}
-      {{- with .Values.extraInitContainers }}
+      {{- $kubelockInject := include "mintel_common.kubelock.injectBinaryEnabled" .Values.kubelock | trim -}}
+      {{- if or (eq $kubelockInject "true") .Values.extraInitContainers }}
       initContainers:
+      {{- if eq $kubelockInject "true" }}
+      {{- $kubelockVolumeName := include "mintel_common.kubelock.volumeName" (include "mintel_common.fullname" .) }}
+      {{- include "mintel_common.kubelock.initContainer" (dict "kubelock" .Values.kubelock "volumeName" $kubelockVolumeName) | nindent 8 }}
+      {{- end }}
+      {{- with .Values.extraInitContainers }}
       {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       {{- if .Values.useHostNetwork }}
       hostNetwork: true
@@ -345,9 +352,16 @@ spec:
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- include "mintel_common.deployment.lifecycle" . | nindent 10 }}
-          {{- if .Values.volumeMounts }}
+          {{- $kubelockInject := include "mintel_common.kubelock.injectBinaryEnabled" .Values.kubelock | trim -}}
+          {{- if or .Values.volumeMounts (eq $kubelockInject "true") }}
           volumeMounts:
-            {{- toYaml .Values.volumeMounts | nindent 12 }}
+          {{- if eq $kubelockInject "true" }}
+          {{- $kubelockVolumeName := include "mintel_common.kubelock.volumeName" (include "mintel_common.fullname" .) }}
+          {{- include "mintel_common.kubelock.volumeMount" (dict "volumeName" $kubelockVolumeName) | nindent 12 }}
+          {{- end }}
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- end }}
         {{- if (and .Values.filebeatSidecar .Values.filebeatSidecar.enabled) }}
         - name: filebeat
@@ -448,7 +462,7 @@ spec:
             - mountPath: {{ .Values.gitSyncSidecar.root }}
               name: {{ include "mintel_common.fullname" . }}-git-sync
         {{- end }}
-      {{- if or (and .Values.filebeatSidecar .Values.filebeatSidecar.enabled) (and .Values.gitSyncSidecar .Values.gitSyncSidecar.enabled) (.Values.volumes) }}
+      {{- if or (and .Values.filebeatSidecar .Values.filebeatSidecar.enabled) (and .Values.gitSyncSidecar .Values.gitSyncSidecar.enabled) (.Values.volumes) (eq (include "mintel_common.kubelock.injectBinaryEnabled" .Values.kubelock | trim) "true") }}
       volumes:
         {{- if not .Values.statefulset }}
         {{- if .Values.persistentVolumes }}
@@ -470,6 +484,10 @@ spec:
         {{- if (and .Values.gitSyncSidecar .Values.gitSyncSidecar.enabled) }}
         - name: {{ include "mintel_common.fullname" . }}-git-sync
           emptyDir: {}
+        {{- end }}
+        {{- if eq (include "mintel_common.kubelock.injectBinaryEnabled" .Values.kubelock | trim) "true" }}
+        {{- $kubelockVolumeName := include "mintel_common.kubelock.volumeName" (include "mintel_common.fullname" .) }}
+        {{- include "mintel_common.kubelock.volume" (dict "volumeName" $kubelockVolumeName) | nindent 8 }}
         {{- end }}
       {{- end }}
 {{- end }}

--- a/charts/standard-application-stack/templates/helpers/_kubelock.yaml
+++ b/charts/standard-application-stack/templates/helpers/_kubelock.yaml
@@ -7,17 +7,19 @@ Shared by both kubelock Role creation paths:
   - Release-level: templates/kubelock-role.yaml (Values.kubelock.enabled)
   - Per-job: templates/jobs.yaml via mintel_common.role (jobs[].kubelock.enabled)
 
-Expects the lock name (KUBELOCK_NAME / kubelock --name):
-  - leases: new kubelock (gitlab.com/mintel/satoshi/tools/kubelock), scoped via resourceNames
-  - endpoints: legacy kubelock (mintel/kubelock), unscoped for backward compatibility
+Rules:
+  - leases: new kubelock (gitlab.com/mintel/satoshi/tools/kubelock)
+  - endpoints: legacy kubelock (mintel/kubelock), retained for backward compatibility
+
+Note: resourceNames is intentionally omitted. Kubernetes RBAC does not support
+resourceNames with the create verb, and create must be allowed for first-time
+Lease acquisition.
 */}}
 {{- define "mintel_common.kubelockRoleRules" -}}
 - apiGroups:
   - coordination.k8s.io
   resources:
   - leases
-  resourceNames:
-  - {{ . | quote }}
   verbs:
   - get
   - list

--- a/charts/standard-application-stack/templates/helpers/_kubelock.yaml
+++ b/charts/standard-application-stack/templates/helpers/_kubelock.yaml
@@ -52,7 +52,7 @@ Return the kubelock container image. Expects a kubelock values dict.
 {{- else -}}
 {{- $registry := .image.registry | default "551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com" -}}
 {{- $repository := .image.repository | default "gitlab/mintel/satoshi/tools/kubelock" -}}
-{{- $tag := .image.tag | default "v0.4.1" | toString -}}
+{{- $tag := .image.tag | default "v0.5.0" | toString -}}
 {{- printf "%s/%s:%s" $registry $repository $tag -}}
 {{- end -}}
 {{- end -}}

--- a/charts/standard-application-stack/templates/helpers/_kubelock.yaml
+++ b/charts/standard-application-stack/templates/helpers/_kubelock.yaml
@@ -102,10 +102,6 @@ The kubelock image must include /bin/sh (busybox-based builds support injectBina
   volumeMounts:
     - name: {{ .volumeName }}
       mountPath: /kubelock-bin
-  {{- with .kubelock.resources }}
-  resources: {{- toYaml . | nindent 4 }}
-  {{- end }}
-  {{- with .kubelock.securityContext }}
-  securityContext: {{- toYaml . | nindent 4 }}
-  {{- end }}
+  resources: {{- toYaml .kubelock.resources | nindent 4 }}
+  securityContext: {{- toYaml .kubelock.securityContext | nindent 4 }}
 {{- end -}}

--- a/charts/standard-application-stack/templates/helpers/_kubelock.yaml
+++ b/charts/standard-application-stack/templates/helpers/_kubelock.yaml
@@ -33,3 +33,79 @@ Expects the lock name (KUBELOCK_NAME / kubelock --name):
   - create
   - update
 {{- end -}}
+
+{{/*
+Return true when kubelock binary injection is enabled. Expects a kubelock values dict.
+*/}}
+{{- define "mintel_common.kubelock.injectBinaryEnabled" -}}
+{{- and .enabled .injectBinary -}}
+{{- end -}}
+
+{{/*
+Return the kubelock container image. Expects a kubelock values dict.
+*/}}
+{{- define "mintel_common.kubelock.image" -}}
+{{- if .image.fullname -}}
+{{- .image.fullname -}}
+{{- else -}}
+{{- $registry := .image.registry | default "551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com" -}}
+{{- $repository := .image.repository | default "gitlab/mintel/satoshi/tools/kubelock" -}}
+{{- $tag := .image.tag | default "v0.4.1" | toString -}}
+{{- printf "%s/%s:%s" $registry $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the kubelock image pull policy. Expects a kubelock values dict.
+*/}}
+{{- define "mintel_common.kubelock.imagePullPolicy" -}}
+{{- .image.pullPolicy | default "IfNotPresent" -}}
+{{- end -}}
+
+{{/*
+Shared emptyDir volume name for kubelock binary injection. Expects the workload name prefix.
+*/}}
+{{- define "mintel_common.kubelock.volumeName" -}}
+{{- printf "%s-kubelock-bin" . -}}
+{{- end -}}
+
+{{/*
+emptyDir volume for kubelock binary injection. Expects dict with key "volumeName".
+*/}}
+{{- define "mintel_common.kubelock.volume" -}}
+- name: {{ .volumeName }}
+  emptyDir: {}
+{{- end -}}
+
+{{/*
+Main-container volumeMount for an injected kubelock binary. Expects dict with key "volumeName".
+*/}}
+{{- define "mintel_common.kubelock.volumeMount" -}}
+- name: {{ .volumeName }}
+  mountPath: /usr/local/bin/kubelock
+  subPath: kubelock
+{{- end -}}
+
+{{/*
+Init container that copies the kubelock binary into the shared emptyDir volume.
+Expects dict with keys "kubelock" (values dict) and "volumeName".
+The kubelock image must include /bin/sh (busybox-based builds support injectBinary).
+*/}}
+{{- define "mintel_common.kubelock.initContainer" -}}
+- name: kubelock-binary
+  image: {{ include "mintel_common.kubelock.image" .kubelock }}
+  imagePullPolicy: {{ include "mintel_common.kubelock.imagePullPolicy" .kubelock }}
+  command:
+    - /bin/sh
+    - -ec
+    - cp /usr/local/bin/kubelock /kubelock-bin/kubelock && chmod 755 /kubelock-bin/kubelock
+  volumeMounts:
+    - name: {{ .volumeName }}
+      mountPath: /kubelock-bin
+  {{- with .kubelock.resources }}
+  resources: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .kubelock.securityContext }}
+  securityContext: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/standard-application-stack/templates/helpers/_kubelock.yaml
+++ b/charts/standard-application-stack/templates/helpers/_kubelock.yaml
@@ -1,0 +1,35 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{/*
+RBAC rules for kubelock leader election.
+
+Shared by both kubelock Role creation paths:
+  - Release-level: templates/kubelock-role.yaml (Values.kubelock.enabled)
+  - Per-job: templates/jobs.yaml via mintel_common.role (jobs[].kubelock.enabled)
+
+Expects the lock name (KUBELOCK_NAME / kubelock --name):
+  - leases: new kubelock (gitlab.com/mintel/satoshi/tools/kubelock), scoped via resourceNames
+  - endpoints: legacy kubelock (mintel/kubelock), unscoped for backward compatibility
+*/}}
+{{- define "mintel_common.kubelockRoleRules" -}}
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - {{ . | quote }}
+  verbs:
+  - get
+  - list
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+  - create
+  - update
+{{- end -}}

--- a/charts/standard-application-stack/templates/helpers/_role.yaml
+++ b/charts/standard-application-stack/templates/helpers/_role.yaml
@@ -8,7 +8,8 @@ name:        string        # The name of the role. Defaults to global name if no
 annotations: dict          # Any extra custom annotations.
 argo:        dict          # Standard argo object (as processed by mintel_common.argoAnnotations).
 rules:       list(string)  # A list of keywords that determine which rules get added to the role.
-                           # Example: list "kubelock"
+                           # Example: list "kubelock" (used by per-job kubelock in jobs.yaml;
+                           # release workloads use kubelock-role.yaml instead)
 
 */}}
 {{- define "mintel_common.role" -}}
@@ -28,23 +29,6 @@ metadata:
     {{ end }}
 rules:
 {{ if (has "kubelock" $config.rules) }}
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - create
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-  - list
-  - create
-  - update
+{{ include "mintel_common.kubelockRoleRules" ($config.kubelockLeaseName | default (include "mintel_common.fullname" $)) | nindent 0 }}
 {{- end -}}
 {{- end -}}

--- a/charts/standard-application-stack/templates/helpers/_role.yaml
+++ b/charts/standard-application-stack/templates/helpers/_role.yaml
@@ -29,6 +29,6 @@ metadata:
     {{ end }}
 rules:
 {{ if (has "kubelock" $config.rules) }}
-{{ include "mintel_common.kubelockRoleRules" ($config.kubelockLeaseName | default (include "mintel_common.fullname" $)) | nindent 0 }}
+{{ include "mintel_common.kubelockRoleRules" $ | nindent 0 }}
 {{- end -}}
 {{- end -}}

--- a/charts/standard-application-stack/templates/jobs.yaml
+++ b/charts/standard-application-stack/templates/jobs.yaml
@@ -137,8 +137,7 @@ spec:
      Release workloads use templates/kubelock-role.yaml (Values.kubelock.enabled) instead. */}}
 {{- if .kubelock.enabled }}
 ---
-{{- $leaseName := .kubelock.nameOverride | default $jobName -}}
-{{- $roleConfig := dict "name" $jobName "argo" .argo "rules" (list "kubelock") "kubelockLeaseName" $leaseName -}}
+{{- $roleConfig := dict "name" $jobName "argo" .argo "rules" (list "kubelock") -}}
 {{- include "mintel_common.role" (list $ $roleConfig) }}
 ---
 {{- $roleBindingConfig := dict "name" $jobName "argo" .argo "roleName" $jobName "serviceAccountName" $jobName -}}

--- a/charts/standard-application-stack/templates/jobs.yaml
+++ b/charts/standard-application-stack/templates/jobs.yaml
@@ -2,7 +2,9 @@
 {{- $data := dict "Release" $.Release "Chart" $.Chart "Values" $.Values "component" .name }}
 {{- $job := mergeOverwrite $.Values.jobDefaults . }}
 {{- with $job }}
+{{- $kubelock := mergeOverwrite (deepCopy $.Values.kubelock) .kubelock -}}
 {{- $serviceAccountEnabled := or .kubelock.enabled .irsa.enabled }}
+{{- $kubelockInject := include "mintel_common.kubelock.injectBinaryEnabled" $kubelock | trim -}}
 {{- $jobName := (include "mintel_common.fullname" $data) -}}
 ---
 apiVersion: {{ include "common.capabilities.job.apiVersion" $ }}
@@ -48,15 +50,25 @@ spec:
       {{- if (and $.Values.serviceAccount (or $.Values.serviceAccount.create $.Values.serviceAccount.name)) }}
       serviceAccountName: {{ $jobName }}
       {{- end }}
-      restartPolicy: {{ .restartPolicy }}
-      {{- with .volumes }}
+      {{- if or .volumes (eq $kubelockInject "true") }}
       volumes:
+        {{- if eq $kubelockInject "true" }}
+        {{- include "mintel_common.kubelock.volume" (dict "volumeName" (include "mintel_common.kubelock.volumeName" $jobName)) | nindent 12 }}
+        {{- end }}
+        {{- with .volumes }}
         {{- toYaml . | nindent 12 }}
+        {{- end }}
       {{- end }}
-      {{- with .extraInitContainers }}
+      {{- if or .extraInitContainers (eq $kubelockInject "true") }}
       initContainers:
-      {{- toYaml . | nindent 12 }}
+        {{- if eq $kubelockInject "true" }}
+        {{- include "mintel_common.kubelock.initContainer" (dict "kubelock" $kubelock "volumeName" (include "mintel_common.kubelock.volumeName" $jobName)) | nindent 12 }}
+        {{- end }}
+        {{- with .extraInitContainers }}
+        {{- toYaml . | nindent 12 }}
+        {{- end }}
       {{- end }}
+      restartPolicy: {{ .restartPolicy }}
       containers:
         - name: main
           image: {{ .image | default (include "mintel_common.image" $) }}
@@ -105,8 +117,14 @@ spec:
           {{- end }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .volumeMounts }}
-          volumeMounts: {{- toYaml . | nindent 16 }}
+          {{- if or .volumeMounts (eq $kubelockInject "true") }}
+          volumeMounts:
+            {{- if eq $kubelockInject "true" }}
+            {{- include "mintel_common.kubelock.volumeMount" (dict "volumeName" (include "mintel_common.kubelock.volumeName" $jobName)) | nindent 16 }}
+            {{- end }}
+            {{- with .volumeMounts }}
+            {{- toYaml . | nindent 16 }}
+            {{- end }}
           {{- end }}
 
 {{- if $serviceAccountEnabled }}

--- a/charts/standard-application-stack/templates/jobs.yaml
+++ b/charts/standard-application-stack/templates/jobs.yaml
@@ -114,9 +114,13 @@ spec:
 {{- $serviceAccountConfig := dict "name" $jobName "argo" .argo "irsa" .irsa }}
 {{- include "mintel_common.serviceAccount" (list $ $serviceAccountConfig) }}
 
+{{/* Per-job kubelock RBAC when jobs[].kubelock.enabled (or jobDefaults.kubelock.enabled).
+     Creates a dedicated ServiceAccount, Role, and RoleBinding for this Job.
+     Release workloads use templates/kubelock-role.yaml (Values.kubelock.enabled) instead. */}}
 {{- if .kubelock.enabled }}
 ---
-{{- $roleConfig := dict "name" $jobName "argo" .argo "rules" (list "kubelock") -}}
+{{- $leaseName := .kubelock.nameOverride | default $jobName -}}
+{{- $roleConfig := dict "name" $jobName "argo" .argo "rules" (list "kubelock") "kubelockLeaseName" $leaseName -}}
 {{- include "mintel_common.role" (list $ $roleConfig) }}
 ---
 {{- $roleBindingConfig := dict "name" $jobName "argo" .argo "roleName" $jobName "serviceAccountName" $jobName -}}

--- a/charts/standard-application-stack/templates/kubelock-role-binding.yaml
+++ b/charts/standard-application-stack/templates/kubelock-role-binding.yaml
@@ -1,3 +1,7 @@
+{{/*
+Binds the release kubelock Role (kubelock-role.yaml) to the main ServiceAccount
+(Values.serviceAccount). Created when Values.kubelock.enabled is true.
+*/}}
 {{- if (and .Values.serviceAccount .Values.serviceAccount.create) }}
 
 {{- if (and .Values.kubelock .Values.kubelock.enabled) }}

--- a/charts/standard-application-stack/templates/kubelock-role.yaml
+++ b/charts/standard-application-stack/templates/kubelock-role.yaml
@@ -1,6 +1,20 @@
+{{/*
+Kubelock RBAC for the release ServiceAccount (templates/service-accounts.yaml).
+
+Enabled by Values.kubelock.enabled when Values.serviceAccount.create is true.
+Grants Lease access for long-running workloads (deployment, celery, etc.) that
+receive KUBELOCK_* env vars from mintel_common.defaultEnv.
+
+Jobs use a separate per-job path in templates/jobs.yaml when
+jobs[].kubelock.enabled (or jobDefaults.kubelock.enabled) is set.
+
+Rules: helpers/_kubelock.yaml (mintel_common.kubelockRoleRules).
+Companion: kubelock-role-binding.yaml
+*/}}
 {{- if (and .Values.serviceAccount .Values.serviceAccount.create) }}
 
 {{- if (and .Values.kubelock .Values.kubelock.enabled) }}
+{{- $leaseName := .Values.kubelock.nameOverride | default (include "mintel_common.fullname" .) }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
@@ -10,24 +24,7 @@ metadata:
   annotations: {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
   labels: {{ include "mintel_common.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - get
-  - list
-  - create
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - endpoints
-  verbs:
-  - get
-  - list
-  - create
-  - update
+{{ include "mintel_common.kubelockRoleRules" $leaseName | nindent 2 }}
 {{- end }}
 
 {{- end }}

--- a/charts/standard-application-stack/templates/kubelock-role.yaml
+++ b/charts/standard-application-stack/templates/kubelock-role.yaml
@@ -14,7 +14,6 @@ Companion: kubelock-role-binding.yaml
 {{- if (and .Values.serviceAccount .Values.serviceAccount.create) }}
 
 {{- if (and .Values.kubelock .Values.kubelock.enabled) }}
-{{- $leaseName := .Values.kubelock.nameOverride | default (include "mintel_common.fullname" .) }}
 ---
 apiVersion: {{ include "common.capabilities.rbac.apiVersion" . }}
 kind: Role
@@ -24,7 +23,7 @@ metadata:
   annotations: {{ include "mintel_common.commonAnnotations" . | nindent 4 }}
   labels: {{ include "mintel_common.labels" . | nindent 4 }}
 rules:
-{{ include "mintel_common.kubelockRoleRules" $leaseName | nindent 2 }}
+{{ include "mintel_common.kubelockRoleRules" . | nindent 2 }}
 {{- end }}
 
 {{- end }}

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -520,10 +520,10 @@ Checks that RBAC is set up correctly for kubelock:
     rules:
       - apiGroups:
           - coordination.k8s.io
-        resources:
-          - leases
         resourceNames:
           - testGlobalName-testJobName
+        resources:
+          - leases
         verbs:
           - get
           - list

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -522,6 +522,8 @@ Checks that RBAC is set up correctly for kubelock:
           - coordination.k8s.io
         resources:
           - leases
+        resourceNames:
+          - testGlobalName-testJobName
         verbs:
           - get
           - list

--- a/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/jobs_test.yaml.snap
@@ -520,8 +520,6 @@ Checks that RBAC is set up correctly for kubelock:
     rules:
       - apiGroups:
           - coordination.k8s.io
-        resourceNames:
-          - testGlobalName-testJobName
         resources:
           - leases
         verbs:

--- a/charts/standard-application-stack/tests/__snapshot__/kubelock_inject_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/kubelock_inject_test.yaml.snap
@@ -109,6 +109,21 @@ Injects kubelock binary into the main deployment when enabled:
               image: 551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com/gitlab/mintel/satoshi/tools/kubelock:v0.4.1
               imagePullPolicy: IfNotPresent
               name: kubelock-binary
+              resources:
+                limits:
+                  memory: 64Mi
+                requests:
+                  cpu: 10m
+                  memory: 32Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+                runAsUser: 1000
+                seccompProfile:
+                  type: RuntimeDefault
               volumeMounts:
                 - mountPath: /kubelock-bin
                   name: testGlobalName-kubelock-bin

--- a/charts/standard-application-stack/tests/__snapshot__/kubelock_inject_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/kubelock_inject_test.yaml.snap
@@ -1,0 +1,130 @@
+Injects kubelock binary into the main deployment when enabled:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      annotations:
+        app.mintel.com/placeholder: placeholder
+        secret.reloader.stakater.com/reload: testGlobalName-app
+      labels:
+        app.kubernetes.io/component: app
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: testGlobalName
+        app.mintel.com/application: testGlobalName
+        app.mintel.com/component: testGlobalName
+        app.mintel.com/env: testClusterEnv
+        app.mintel.com/region: ${CLUSTER_REGION}
+        name: testGlobalName
+      name: testGlobalName
+      namespace: testNamespace
+    spec:
+      minReadySeconds: 10
+      replicas: 2
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: app
+          app.kubernetes.io/name: testGlobalName
+      strategy:
+        rollingUpdate:
+          maxSurge: 15%
+          maxUnavailable: 10%
+        type: RollingUpdate
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: app
+            app.kubernetes.io/managed-by: Helm
+            app.kubernetes.io/name: testGlobalName
+            app.mintel.com/application: testGlobalName
+            app.mintel.com/component: testGlobalName
+            app.mintel.com/env: testClusterEnv
+            app.mintel.com/region: ${CLUSTER_REGION}
+            name: testGlobalName
+        spec:
+          containers:
+            - command:
+                - /app/docker-entrypoint.sh
+              env:
+                - name: KUBERNETES_POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: APP_ENVIRONMENT
+                  value: testClusterEnv
+                - name: RUNTIME_ENVIRONMENT
+                  value: kubernetes
+                - name: KUBELOCK_NAME
+                  value: testGlobalName
+                - name: KUBELOCK_NAMESPACE
+                  value: testNamespace
+              envFrom:
+                - secretRef:
+                    name: testGlobalName-app
+              image: registry.example.com/test/image/repo:someTag
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                httpGet:
+                  path: /healthz
+                  port: http
+                  scheme: HTTP
+                periodSeconds: 10
+                timeoutSeconds: 1
+              name: main
+              ports:
+                - containerPort: 8000
+                  name: http
+              readinessProbe:
+                httpGet:
+                  path: /readiness
+                  port: http
+                  scheme: HTTP
+                periodSeconds: 10
+                timeoutSeconds: 1
+              resources:
+                limits: {}
+                requests: {}
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                runAsNonRoot: true
+                runAsUser: 1000
+              startupProbe:
+                failureThreshold: 60
+                httpGet:
+                  path: /healthz
+                  port: http
+                  scheme: HTTP
+                periodSeconds: 5
+              volumeMounts:
+                - mountPath: /usr/local/bin/kubelock
+                  name: testGlobalName-kubelock-bin
+                  subPath: kubelock
+          initContainers:
+            - command:
+                - /bin/sh
+                - -ec
+                - cp /usr/local/bin/kubelock /kubelock-bin/kubelock && chmod 755 /kubelock-bin/kubelock
+              image: 551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com/gitlab/mintel/satoshi/tools/kubelock:v0.4.1
+              imagePullPolicy: IfNotPresent
+              name: kubelock-binary
+              volumeMounts:
+                - mountPath: /kubelock-bin
+                  name: testGlobalName-kubelock-bin
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+          serviceAccountName: testGlobalName
+          terminationGracePeriodSeconds: 30
+          topologySpreadConstraints:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: app
+                  app.kubernetes.io/name: testGlobalName
+              maxSkew: 1
+              topologyKey: topology.kubernetes.io/zone
+              whenUnsatisfiable: DoNotSchedule
+          volumes:
+            - emptyDir: {}
+              name: testGlobalName-kubelock-bin

--- a/charts/standard-application-stack/tests/__snapshot__/kubelock_inject_test.yaml.snap
+++ b/charts/standard-application-stack/tests/__snapshot__/kubelock_inject_test.yaml.snap
@@ -106,7 +106,7 @@ Injects kubelock binary into the main deployment when enabled:
                 - /bin/sh
                 - -ec
                 - cp /usr/local/bin/kubelock /kubelock-bin/kubelock && chmod 755 /kubelock-bin/kubelock
-              image: 551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com/gitlab/mintel/satoshi/tools/kubelock:v0.4.1
+              image: 551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com/gitlab/mintel/satoshi/tools/kubelock:v0.5.0
               imagePullPolicy: IfNotPresent
               name: kubelock-binary
               resources:

--- a/charts/standard-application-stack/tests/kubelock_inject_test.yaml
+++ b/charts/standard-application-stack/tests/kubelock_inject_test.yaml
@@ -32,6 +32,21 @@ tests:
             volumeMounts:
               - name: testGlobalName-kubelock-bin
                 mountPath: /kubelock-bin
+            resources:
+              limits:
+                memory: 64Mi
+              requests:
+                cpu: 10m
+                memory: 32Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              runAsNonRoot: true
+              runAsUser: 1000
+              seccompProfile:
+                type: RuntimeDefault
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
@@ -75,6 +90,12 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: kubelock-binary
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.initContainers[0].securityContext.capabilities.drop
+          content: ALL
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
@@ -100,6 +121,10 @@ tests:
         equal:
           path: spec.template.spec.initContainers[0].name
           value: kubelock-binary
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].volumeMounts

--- a/charts/standard-application-stack/tests/kubelock_inject_test.yaml
+++ b/charts/standard-application-stack/tests/kubelock_inject_test.yaml
@@ -3,6 +3,7 @@ templates:
   - deployment.yaml
   - deployment-celery.yaml
   - jobs.yaml
+  - cronjobs.yaml
 release:
   namespace: testNamespace
 tests:
@@ -132,3 +133,60 @@ tests:
             mountPath: /usr/local/bin/kubelock
             subPath: kubelock
             name: testGlobalName-testJobName-kubelock-bin
+
+  - it: Injects kubelock binary into cronjobs when enabled
+    template: cronjobs.yaml
+    set:
+      global.name: testGlobalName
+      global.clusterEnv: testClusterEnv
+      image.registry: registry.example.com
+      image.repository: test/image/repo
+      image.tag: someTag
+      kubelock.enabled: true
+      kubelock.injectBinary: true
+      cronjobs.jobs:
+        - name: daily
+          schedule: "0 0 * * *"
+          command: [/bin/sh]
+          args: ["-c", "echo ok"]
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].name
+          value: kubelock-binary
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.initContainers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /usr/local/bin/kubelock
+            subPath: kubelock
+            name: testGlobalName-daily-kubelock-bin
+      - contains:
+          path: spec.jobTemplate.spec.template.spec.volumes
+          content:
+            name: testGlobalName-daily-kubelock-bin
+            emptyDir: {}
+
+  - it: Allows a cronjob to opt out of kubelock binary injection
+    template: cronjobs.yaml
+    set:
+      global.name: testGlobalName
+      global.clusterEnv: testClusterEnv
+      image.registry: registry.example.com
+      image.repository: test/image/repo
+      image.tag: someTag
+      kubelock.enabled: true
+      kubelock.injectBinary: true
+      cronjobs.jobs:
+        - name: daily
+          schedule: "0 0 * * *"
+          command: [/bin/sh]
+          args: ["-c", "echo ok"]
+          kubelock:
+            injectBinary: false
+    asserts:
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.initContainers
+      - notExists:
+          path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts

--- a/charts/standard-application-stack/tests/kubelock_inject_test.yaml
+++ b/charts/standard-application-stack/tests/kubelock_inject_test.yaml
@@ -24,6 +24,14 @@ tests:
           content:
             name: kubelock-binary
             image: 551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com/gitlab/mintel/satoshi/tools/kubelock:v0.4.1
+            imagePullPolicy: IfNotPresent
+            command:
+              - /bin/sh
+              - -ec
+              - cp /usr/local/bin/kubelock /kubelock-bin/kubelock && chmod 755 /kubelock-bin/kubelock
+            volumeMounts:
+              - name: testGlobalName-kubelock-bin
+                mountPath: /kubelock-bin
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
@@ -64,13 +72,15 @@ tests:
       kubelock.enabled: true
       kubelock.injectBinary: true
     asserts:
-      - contains:
+      - equal:
           path: spec.template.spec.initContainers[0].name
-          content: kubelock-binary
+          value: kubelock-binary
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             mountPath: /usr/local/bin/kubelock
+            subPath: kubelock
+            name: testGlobalName-kubelock-bin
 
   - it: Injects kubelock binary into jobs when enabled
     template: jobs.yaml
@@ -87,12 +97,13 @@ tests:
             injectBinary: true
     asserts:
       - documentIndex: 0
-        contains:
+        equal:
           path: spec.template.spec.initContainers[0].name
-          content: kubelock-binary
+          value: kubelock-binary
       - documentIndex: 0
         contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             mountPath: /usr/local/bin/kubelock
+            subPath: kubelock
             name: testGlobalName-testJobName-kubelock-bin

--- a/charts/standard-application-stack/tests/kubelock_inject_test.yaml
+++ b/charts/standard-application-stack/tests/kubelock_inject_test.yaml
@@ -23,7 +23,7 @@ tests:
           path: spec.template.spec.initContainers
           content:
             name: kubelock-binary
-            image: 551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com/gitlab/mintel/satoshi/tools/kubelock:v0.4.1
+            image: 551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com/gitlab/mintel/satoshi/tools/kubelock:v0.5.0
             imagePullPolicy: IfNotPresent
             command:
               - /bin/sh

--- a/charts/standard-application-stack/tests/kubelock_inject_test.yaml
+++ b/charts/standard-application-stack/tests/kubelock_inject_test.yaml
@@ -1,0 +1,98 @@
+suite: Test kubelock binary injection
+templates:
+  - deployment.yaml
+  - deployment-celery.yaml
+  - jobs.yaml
+release:
+  namespace: testNamespace
+tests:
+  - it: Injects kubelock binary into the main deployment when enabled
+    template: deployment.yaml
+    set:
+      global.name: testGlobalName
+      global.clusterEnv: testClusterEnv
+      image.registry: registry.example.com
+      image.repository: test/image/repo
+      image.tag: someTag
+      serviceAccount.create: true
+      kubelock.enabled: true
+      kubelock.injectBinary: true
+    asserts:
+      - matchSnapshot: {}
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: kubelock-binary
+            image: 551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com/gitlab/mintel/satoshi/tools/kubelock:v0.4.1
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /usr/local/bin/kubelock
+            subPath: kubelock
+            name: testGlobalName-kubelock-bin
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: testGlobalName-kubelock-bin
+            emptyDir: {}
+
+  - it: Does not inject kubelock binary when injectBinary is disabled
+    template: deployment.yaml
+    set:
+      global.name: testGlobalName
+      global.clusterEnv: testClusterEnv
+      image.registry: registry.example.com
+      image.repository: test/image/repo
+      image.tag: someTag
+      kubelock.enabled: true
+      kubelock.injectBinary: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: Injects kubelock binary into celery when enabled
+    template: deployment-celery.yaml
+    set:
+      global.name: testGlobalName
+      global.clusterEnv: testClusterEnv
+      image.registry: registry.example.com
+      image.repository: test/image/repo
+      image.tag: someTag
+      celery.enabled: true
+      kubelock.enabled: true
+      kubelock.injectBinary: true
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers[0].name
+          content: kubelock-binary
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /usr/local/bin/kubelock
+
+  - it: Injects kubelock binary into jobs when enabled
+    template: jobs.yaml
+    set:
+      global.name: testGlobalName
+      global.clusterEnv: testClusterEnv
+      image.registry: registry.example.com
+      image.repository: test/image/repo
+      image.tag: someTag
+      jobs:
+        - name: testJobName
+          kubelock:
+            enabled: true
+            injectBinary: true
+    asserts:
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.initContainers[0].name
+          content: kubelock-binary
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /usr/local/bin/kubelock
+            name: testGlobalName-testJobName-kubelock-bin

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -757,11 +757,14 @@ oauthProxy:
   #    - name: OAUTH_PROXY_COOKIE_SECRET
   #      value: test_value
 
-# -- Configure the use of kubelock
-# ref: https://github.com/mintel/kubelock
+# -- Configure kubelock for the main release workload (deployment, celery, etc.).
+# Creates RBAC via templates/kubelock-role.yaml and sets KUBELOCK_* env vars via
+# mintel_common.defaultEnv. For Jobs, use jobDefaults.kubelock / jobs[].kubelock instead.
+# ref: https://gitlab.com/mintel/satoshi/tools/kubelock
 kubelock:
-  # -- Set to true to enable kubelock
+  # -- Set to true to enable release-level kubelock RBAC and KUBELOCK_* env vars
   enabled: false
+  # -- Lease lock name (defaults to the release fullname). Must match kubelock --name / KUBELOCK_NAME.
   #  nameOverride: ""
 
 # -- Configure celery deployment
@@ -986,8 +989,12 @@ jobDefaults:
   # ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/job-v1/#JobSpec
   # Only set if you want to override the Kubernetes default (6). If not set, Kubernetes default applies.
   backoffLimit: null
+  # -- Enable kubelock for Jobs: creates per-job ServiceAccount, Role, and RoleBinding
+  # in templates/jobs.yaml (not the release-level kubelock templates above).
   kubelock:
     enabled: false
+    # -- Lease lock name for this job (defaults to the job fullname).
+    #  nameOverride: ""
   irsa:
     enabled: false
   # -- Any annotations you wish to add to the Job

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -775,10 +775,23 @@ kubelock:
     pullPolicy: IfNotPresent
     # -- Optional full image override (registry/repository:tag)
     # fullname: ""
-  # -- Optional resources for the kubelock injectBinary init container
-  # resources: {}
-  # -- Optional securityContext for the kubelock injectBinary init container
-  # securityContext: {}
+  # -- Resources for the kubelock injectBinary init container
+  resources:
+    limits:
+      memory: 64Mi
+    requests:
+      cpu: 10m
+      memory: 32Mi
+  # -- securityContext for the kubelock injectBinary init container
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
   # -- Lease lock name (defaults to the release fullname). Must match kubelock --name / KUBELOCK_NAME.
   #  nameOverride: ""
 

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -771,7 +771,7 @@ kubelock:
   image:
     registry: 551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com
     repository: gitlab/mintel/satoshi/tools/kubelock
-    tag: v0.4.1
+    tag: v0.5.0
     pullPolicy: IfNotPresent
     # -- Optional full image override (registry/repository:tag)
     # fullname: ""

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -1027,7 +1027,7 @@ jobDefaults:
     # image:
     #   registry: 551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com
     #   repository: gitlab/mintel/satoshi/tools/kubelock
-    #   tag: v0.4.1
+    #   tag: v0.5.0
     # -- Lease lock name for this job (defaults to the job fullname).
     #  nameOverride: ""
   irsa:

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -757,15 +757,17 @@ oauthProxy:
   #    - name: OAUTH_PROXY_COOKIE_SECRET
   #      value: test_value
 
-# -- Configure kubelock for the main release workload (deployment, celery, etc.).
+# -- Configure kubelock for the main release workload (deployment, celery, cronjobs, etc.).
 # Creates RBAC via templates/kubelock-role.yaml and sets KUBELOCK_* env vars via
-# mintel_common.defaultEnv. For Jobs, use jobDefaults.kubelock / jobs[].kubelock instead.
+# mintel_common.defaultEnv. CronJobs inherit these settings (optional per-job override via
+# cronjobs.jobs[].kubelock). For Jobs, use jobDefaults.kubelock / jobs[].kubelock instead.
 # ref: https://gitlab.com/mintel/satoshi/tools/kubelock
 kubelock:
   # -- Set to true to enable release-level kubelock RBAC and KUBELOCK_* env vars
   enabled: false
   # -- Inject the kubelock binary via an init container instead of bundling it in the app image.
   # Requires kubelock.enabled. Mounts the binary at /usr/local/bin/kubelock (overwriting any existing file).
+  # Applies to deployment, celery, and cronjobs (and Jobs when jobs[].kubelock.enabled is true).
   injectBinary: false
   # -- Kubelock container image used by the injectBinary init container.
   image:
@@ -1021,8 +1023,9 @@ jobDefaults:
   # in templates/jobs.yaml (not the release-level kubelock templates above).
   kubelock:
     enabled: false
-    # -- Inject the kubelock binary via an init container (see Values.kubelock.injectBinary).
-    injectBinary: false
+    # -- Inject the kubelock binary via an init container.
+    # Leave unset to inherit Values.kubelock.injectBinary; set true/false to override per job.
+    # injectBinary: false
     # -- Kubelock image for injectBinary (defaults to Values.kubelock.image when unset).
     # image:
     #   registry: 551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com

--- a/charts/standard-application-stack/values.yaml
+++ b/charts/standard-application-stack/values.yaml
@@ -764,6 +764,21 @@ oauthProxy:
 kubelock:
   # -- Set to true to enable release-level kubelock RBAC and KUBELOCK_* env vars
   enabled: false
+  # -- Inject the kubelock binary via an init container instead of bundling it in the app image.
+  # Requires kubelock.enabled. Mounts the binary at /usr/local/bin/kubelock (overwriting any existing file).
+  injectBinary: false
+  # -- Kubelock container image used by the injectBinary init container.
+  image:
+    registry: 551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com
+    repository: gitlab/mintel/satoshi/tools/kubelock
+    tag: v0.4.1
+    pullPolicy: IfNotPresent
+    # -- Optional full image override (registry/repository:tag)
+    # fullname: ""
+  # -- Optional resources for the kubelock injectBinary init container
+  # resources: {}
+  # -- Optional securityContext for the kubelock injectBinary init container
+  # securityContext: {}
   # -- Lease lock name (defaults to the release fullname). Must match kubelock --name / KUBELOCK_NAME.
   #  nameOverride: ""
 
@@ -993,6 +1008,13 @@ jobDefaults:
   # in templates/jobs.yaml (not the release-level kubelock templates above).
   kubelock:
     enabled: false
+    # -- Inject the kubelock binary via an init container (see Values.kubelock.injectBinary).
+    injectBinary: false
+    # -- Kubelock image for injectBinary (defaults to Values.kubelock.image when unset).
+    # image:
+    #   registry: 551844124467.dkr.ecr.${CLUSTER_REGION}.amazonaws.com
+    #   repository: gitlab/mintel/satoshi/tools/kubelock
+    #   tag: v0.4.1
     # -- Lease lock name for this job (defaults to the job fullname).
     #  nameOverride: ""
   irsa:


### PR DESCRIPTION
## Summary

Updates `standard-application-stack` to support `kubelock v0.5.0`, which is now hosted on our private repo and follows our build conventions.

By default this will be a no-op, but we should start to promote/switch to `kubelock.injectBinary: true`. This will use an `initContainer` to inject `kubelock`, rather than rely on the underlying deveveloper-apps from managing this binary. 

## Background

kubelock v0.5.0+ switched from Endpoints-based to Lease-based leader election. Apps still on the old `mintel/kubelock` image need Endpoints RBAC; new kubelock needs scoped Lease RBAC.

Today many teams bundle kubelock into application images. This MR adds an opt-in Helm path to inject the binary from a centrally managed ECR image instead.

## Changes

### Kubelock RBAC (when `kubelock.enabled`)

- Consolidated kubelock Role rules into `helpers/_kubelock.yaml` (`mintel_common.kubelockRoleRules`)
- **Leases**: added
- **Endpoints**: retained, unscoped (legacy kubelock during migration)

### Kubelock binary injection (opt-in: `kubelock.injectBinary: true`)

- Init container copies kubelock from `kubelock.image` into a shared `emptyDir`
- Main container mounts binary at `/usr/local/bin/kubelock` (overwrites any bundled copy)
- Supported on: deployment, celery, jobs
- Default image updated to point to our ECR repo

### New values

~~~yaml
kubelock:
  enabled: false
  injectBinary: false
  image:
    registry: ...
    repository: gitlab/mintel/satoshi/tools/kubelock
    tag: v0.5.0
~~~

Job-level overrides via `jobDefaults.kubelock` / `jobs[].kubelock` (image defaults fall back to release-level config).

## Adoption

**RBAC only** (existing bundled kubelock, upgrading to v0.5.x):

~~~yaml
kubelock:
  enabled: true
~~~

**Centralised binary** (remove kubelock from app Dockerfile):

~~~yaml
kubelock:
  enabled: true
  injectBinary: true
~~~

Requires kubelock **v0.5.0+** (busybox-based image with `/bin/sh` for the init copy step).

## Upgrade notes

- **No change** when `kubelock.enabled: false` (default)
- When `kubelock.enabled: true`: Lease rules gain `resourceNames` scoping; Endpoints rules unchanged
- `injectBinary` is **false** by default — no init container/volume changes unless explicitly enabled
- Apps on old kubelock image can stay on `injectBinary: false` until ready to migrate

